### PR TITLE
Hotfix for Virtual WAN peering index error

### DIFF
--- a/networking_virtual_wan.tf
+++ b/networking_virtual_wan.tf
@@ -30,7 +30,7 @@ resource "azurerm_virtual_hub_connection" "vhub_connection" {
 
   name                      = each.value.name
   virtual_hub_id            = try(module.virtual_wans[each.value.vhub.virtual_wan_key].virtual_hubs[each.value.vhub.virtual_hub_key].id, null)
-  remote_virtual_network_id = lookup(each.value.vnet, "lz_key", null) == null ? local.combined_objects_networking[each.value.vnet.vnet_key].id : local.combined_objects_networking[each.value.vnet.output_key].vnets[each.value.vnet.vnet_key].id
+  remote_virtual_network_id = lookup(each.value.vnet, "lz_key", null) == null ? local.combined_objects_networking[local.client_config.landingzone_key][each.value.vnet.vnet_key].id : local.combined_objects_networking[each.value.lz_key].vnets[each.value.vnet.vnet_key].id
   internet_security_enabled = try(each.value.internet_security_enabled, null)
 }
 


### PR DESCRIPTION
Fixes a bug when deploying Virtual WAN landing zone where the index is not defined correctly for local and remote landing zone state. 

```
Error: Invalid index

  on /home/vscode/.terraform.cache/modules/networking/networking_virtual_wan.tf line 33, in resource "azurerm_virtual_hub_connection" "vhub_connection":
  33:   remote_virtual_network_id = lookup(each.value.vnet, "lz_key", null) == null ? local.combined_objects_networking[each.value.vnet.vnet_key].id : local.combined_objects_networking[each.value.vnet.output_key].vnets[each.value.vnet.vnet_key].id
    |----------------
    | each.value.vnet.vnet_key is "vnet_re1"
    | local.combined_objects_networking is object with 3 attributes

The given key does not identify an element in this collection value.
```