### PR TITLE
Update event_hub destination type

### DIFF
--- a/modules/diagnostics/module.tf
+++ b/modules/diagnostics/module.tf
@@ -8,8 +8,8 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostics" {
   name               = try(format("%s%s", try(var.global_settings.prefix_with_hyphen, ""), each.value.name), format("%s%s", try(var.global_settings.prefix_with_hyphen, ""), var.diagnostics.diagnostics_definition[each.value.definition_key].name))
   target_resource_id = var.resource_id
 
-  eventhub_name                  = each.value.destination_type == "event_hub_namespace" ? try(var.diagnostics.event_hub_namespaces[var.diagnostics.diagnostics_destinations.event_hub_namespaces[each.value.destination_key].event_hub_namespace_key].name, null) : null
-  eventhub_authorization_rule_id = each.value.destination_type == "event_hub_namespace" ? try(format("%s/authorizationrules/RootManageSharedAccessKey", var.diagnostics.event_hub_namespaces[var.diagnostics.diagnostics_destinations.event_hub_namespaces[each.value.destination_key].event_hub_namespace_key].id), null) : null
+  eventhub_name                  = each.value.destination_type == "event_hub" ? try(var.diagnostics.event_hub_namespaces[var.diagnostics.diagnostics_destinations.event_hub_namespaces[each.value.destination_key].event_hub_namespace_key].name, null) : null
+  eventhub_authorization_rule_id = each.value.destination_type == "event_hub" ? try(format("%s/authorizationrules/RootManageSharedAccessKey", var.diagnostics.event_hub_namespaces[var.diagnostics.diagnostics_destinations.event_hub_namespaces[each.value.destination_key].event_hub_namespace_key].id), null) : null
 
   log_analytics_workspace_id     = each.value.destination_type == "log_analytics" ? var.diagnostics.log_analytics[var.diagnostics.diagnostics_destinations.log_analytics[each.value.destination_key].log_analytics_key].id : null
   log_analytics_destination_type = each.value.destination_type == "log_analytics" ? lookup(var.diagnostics.diagnostics_definition[each.value.definition_key], "log_analytics_destination_type", null) : null


### PR DESCRIPTION
Update destination type to event_hub

```hcl
   diagnostic_profiles = {
      vnet = {
        definition_key   = "networking_all"
        destination_type = "storage"
        destination_key  = "all_regions"
      }
      operations = {
        name             = "operations"
        definition_key   = "networking_all"
        destination_type = "log_analytics"
        destination_key  = "east_logs"
      }
      operationsevh = {
        name             = "operationsevh"
        definition_key   = "network_security_group"
        destination_type = "event_hub"
        destination_key  = "central_logs"
      }
    }
```