### PR TITLE
Quick fix for Event Hub namespaces diagnostics

### DIFF
--- a/modules/diagnostics/module.tf
+++ b/modules/diagnostics/module.tf
@@ -9,7 +9,7 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostics" {
   target_resource_id = var.resource_id
 
   eventhub_name                  = each.value.destination_type == "event_hub" ? try(var.diagnostics.event_hub_namespaces[var.diagnostics.diagnostics_destinations.event_hub_namespaces[each.value.destination_key].event_hub_namespace_key].name, null) : null
-  eventhub_authorization_rule_id = each.value.destination_type == "event_hub" ? try(format("%s/authorizationrules/RootManageSharedAccessKey", var.diagnostics.event_hub_namespaces[var.diagnostics.diagnostics_destinations.event_hub_namespaces[each.value.destination_key].event_hub_namespace_key].id), null) : null
+  eventhub_authorization_rule_id = each.value.destination_type == "event_hub" ? format("%s/authorizationrules/RootManageSharedAccessKey", var.diagnostics.event_hub_namespaces[var.diagnostics.diagnostics_destinations.event_hub_namespaces[each.value.destination_key].event_hub_namespace_key].id) : null
 
   log_analytics_workspace_id     = each.value.destination_type == "log_analytics" ? var.diagnostics.log_analytics[var.diagnostics.diagnostics_destinations.log_analytics[each.value.destination_key].log_analytics_key].id : null
   log_analytics_destination_type = each.value.destination_type == "log_analytics" ? lookup(var.diagnostics.diagnostics_definition[each.value.definition_key], "log_analytics_destination_type", null) : null


### PR DESCRIPTION
Removing the try() gives better visibility in the mapping errors that can occur between the structures.