### PR TITLE
Removed redundant space in terraform-azurerm-caf/modules/networking/application_gateway/variable.tf

### DIFF
--- a/modules/networking/application_gateway/variable.tf
+++ b/modules/networking/application_gateway/variable.tf
@@ -32,7 +32,7 @@ variable sku_tier {
   description = "(Optional) (Default = Standard_v2) (Required) The Tier of the SKU to use for this Application Gateway. Possible values are Standard, Standard_v2, WAF and WAF_v2."
 
   validation {
-    condition     = contains(["Standard", "Standard_v2", "WAF ", "WAF_v2"], var.sku_tier)
+    condition     = contains(["Standard", "Standard_v2", "WAF", "WAF_v2"], var.sku_tier)
     error_message = "Provide an allowed value as defined in https://www.terraform.io/docs/providers/azurerm/r/application_gateway.html#sku."
   }
 }


### PR DESCRIPTION
Choosing "WAF" as sku_tier results in an error. Removed redundant space in variable validation condition.