### PR TITLE
Missing module output

### DIFF
--- a/container_registry.tf
+++ b/container_registry.tf
@@ -20,3 +20,8 @@ module container_registry {
   base_tags                = try(local.global_settings.inherit_tags, false) ? module.resource_groups[each.value.resource_group_key].tags : {}
 }
 
+output azure_container_registries {
+  value     = module.container_registry
+  sensitive = true
+}
+  


### PR DESCRIPTION
For the deployment of azure container groups it is useful to be able to fetch the login_server and possibly the admin_username and admin_password of a container registry