### PR TITLE
Cosmos DB Cassandra API

### DIFF
--- a/.github/workflows/master-100.yaml
+++ b/.github/workflows/master-100.yaml
@@ -94,6 +94,7 @@ jobs:
             "compute/virtual_machine/211-vm-bastion-winrm-agents",
             "cosmos_db/100-simple-cosmos-db-mongo",
             "cosmos_db/100-simple-cosmos-db-sql",
+            "cosmos_db/100-simple-cosmos-db-cassandra",
             "databricks/100-simple-databricks",
             "datalake/101-datalake-storage",
             "eventhub_namespace/100-simple-evh",

--- a/.github/workflows/master-standalone.yaml
+++ b/.github/workflows/master-standalone.yaml
@@ -36,6 +36,7 @@ jobs:
           config_files: [
             "compute/virtual_machine/105-single-windows-vm-kv-admin-secrets",
             "compute/virtual_machine/211-vm-bastion-winrm-agents",
+            "cosmos_db/100-simple-cosmos-db-cassandra",
             "networking/private_links/endpoints/centralized"
           ]
 

--- a/examples/cosmos_db/100-simple-cosmos-db-cassandra/cassandra.tfvars
+++ b/examples/cosmos_db/100-simple-cosmos-db-cassandra/cassandra.tfvars
@@ -1,0 +1,70 @@
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "northeurope"
+    region2 = "westeurope"
+  }
+}
+
+resource_groups = {
+  cosmosdb_region1 = {
+    name   = "cosmosdb"
+    region = "region1"
+  }
+}
+
+cosmos_dbs = {
+  cosmosdb_account_re1 = {
+    name                      = "cosmosdbcassandra-ex102"
+    resource_group_key        = "cosmosdb_region1"
+    offer_type                = "Standard"
+    kind                      = "GlobalDocumentDB"
+    enable_automatic_failover = "true"
+
+    consistency_policy = {
+      consistency_level       = "BoundedStaleness"
+      max_interval_in_seconds = "300"
+      max_staleness_prefix    = "100000"
+    }
+    # Primary location (Write Region)
+    geo_locations = {
+      primary_geo_location = {
+        prefix            = "customid-101"
+        region            = "region1"
+        zone_redundant    = false
+        failover_priority = 0
+      }
+
+      # failover location
+      failover_geo_location = {
+        region            = "region2"
+        zone_redundant    = false
+        failover_priority = 1
+      }
+    }
+
+    # optional
+    enable_free_tier                = false
+    ip_range_filter                 = ""
+    enable_multiple_write_locations = false
+    tags = {
+      "project" = "EDH"
+    }
+
+    capabilities = [
+      "EnableCassandra",
+      #"EnableServerless",
+      #"DisableRateLimitingResponses"
+    ]
+
+    cassandra_keyspaces = {
+      keyspace_re1 = {
+        name       = "cosmos-cassandra-exks"
+        throughput = 400
+        # autoscale_settings = {
+        #   max_throughput = 4000
+        # }
+      }
+    }
+  }
+}

--- a/examples/cosmos_db/100-simple-cosmos-db-cassandra/standalone/ci.sh
+++ b/examples/cosmos_db/100-simple-cosmos-db-cassandra/standalone/ci.sh
@@ -8,7 +8,7 @@ cd standalone
 terraform init
 
 terraform apply \
-  -var-file ../configuration.tfvars \
+  -var-file ../cassandra.tfvars \
   -var tags='{testing_job_id="${1}"}' \
   -var var_folder_path=${current_folder} \
   -input=false \
@@ -16,7 +16,7 @@ terraform apply \
 
 
 terraform destroy \
-  -var-file ../configuration.tfvars \
+  -var-file ../cassandra.tfvars \
   -var tags='{testing_job_id="${1}"}' \
   -var var_folder_path=${current_folder} \
   -input=false \

--- a/examples/cosmos_db/100-simple-cosmos-db-cassandra/standalone/ci.sh
+++ b/examples/cosmos_db/100-simple-cosmos-db-cassandra/standalone/ci.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+current_folder=$(pwd)
+cd standalone
+
+terraform init
+
+terraform apply \
+  -var-file ../configuration.tfvars \
+  -var tags='{testing_job_id="${1}"}' \
+  -var var_folder_path=${current_folder} \
+  -input=false \
+  -auto-approve
+
+
+terraform destroy \
+  -var-file ../configuration.tfvars \
+  -var tags='{testing_job_id="${1}"}' \
+  -var var_folder_path=${current_folder} \
+  -input=false \
+  -auto-approve
+

--- a/examples/cosmos_db/100-simple-cosmos-db-cassandra/standalone/main.tf
+++ b/examples/cosmos_db/100-simple-cosmos-db-cassandra/standalone/main.tf
@@ -1,0 +1,43 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 2.40.0"
+    }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 1.0.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 2.2.1"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 2.1.0"
+    }
+    external = {
+      source  = "hashicorp/external"
+      version = "~> 1.2.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 2.2.0"
+    }
+    azurecaf = {
+      source  = "aztfmod/azurecaf"
+      version = "~> 1.1.0"
+    }
+  }
+  required_version = ">= 0.13"
+}
+
+
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = true
+    }
+  }
+}
+

--- a/examples/cosmos_db/100-simple-cosmos-db-cassandra/standalone/module.tf
+++ b/examples/cosmos_db/100-simple-cosmos-db-cassandra/standalone/module.tf
@@ -1,0 +1,15 @@
+module "caf" {
+  source = "../../../../"
+
+  global_settings             = var.global_settings
+  diagnostic_storage_accounts = var.diagnostic_storage_accounts
+  resource_groups             = var.resource_groups
+  storage_accounts            = var.storage_accounts
+  keyvaults                   = var.keyvaults
+  managed_identities          = var.managed_identities
+  role_mapping                = var.role_mapping
+
+  database = {
+    cosmos_dbs = var.cosmos_dbs
+  }
+}

--- a/examples/cosmos_db/100-simple-cosmos-db-cassandra/standalone/readme.md
+++ b/examples/cosmos_db/100-simple-cosmos-db-cassandra/standalone/readme.md
@@ -1,0 +1,15 @@
+You can test this module outside of a landingzone using
+
+```bash
+terraform init
+
+terraform [plan|apply|destroy] \ 
+  -var-file ../configuration.tfvars \
+  -var-file ../keyvaults.tfvars \
+  -var-file ../nsg_definitions.tfvars \
+  -var-file ../virtual_networks.tfvars \
+  -var-file ../public_ip_addresses.tfvars \
+  -var-file ../virtual_machines.tfvars
+
+
+```

--- a/examples/cosmos_db/100-simple-cosmos-db-cassandra/standalone/readme.md
+++ b/examples/cosmos_db/100-simple-cosmos-db-cassandra/standalone/readme.md
@@ -3,13 +3,7 @@ You can test this module outside of a landingzone using
 ```bash
 terraform init
 
-terraform [plan|apply|destroy] \ 
-  -var-file ../configuration.tfvars \
-  -var-file ../keyvaults.tfvars \
-  -var-file ../nsg_definitions.tfvars \
-  -var-file ../virtual_networks.tfvars \
-  -var-file ../public_ip_addresses.tfvars \
-  -var-file ../virtual_machines.tfvars
-
+terraform [plan|apply|destroy] \
+  -var-file ../cassandra.tfvars
 
 ```

--- a/examples/cosmos_db/100-simple-cosmos-db-cassandra/standalone/variables.tf
+++ b/examples/cosmos_db/100-simple-cosmos-db-cassandra/standalone/variables.tf
@@ -2,7 +2,9 @@
 variable global_settings {
   default = {}
 }
-
+variable var_folder_path {
+  default = {}
+}
 variable tags {
   default = null
   type    = map

--- a/examples/cosmos_db/100-simple-cosmos-db-cassandra/standalone/variables.tf
+++ b/examples/cosmos_db/100-simple-cosmos-db-cassandra/standalone/variables.tf
@@ -1,0 +1,109 @@
+
+variable global_settings {
+  default = {}
+}
+
+variable tags {
+  default = null
+  type    = map
+}
+variable app_service_environments {
+  default = {}
+}
+variable app_service_plans {
+  default = {}
+}
+variable app_services {
+  default = {}
+}
+variable diagnostics_definition {
+  default = null
+}
+variable resource_groups {
+  default = null
+}
+variable network_security_group_definition {
+  default = null
+}
+variable vnets {
+  default = {}
+}
+variable azurerm_redis_caches {
+  default = {}
+}
+variable mssql_servers {
+  default = {}
+}
+variable mssql_databases {
+  default = {}
+}
+variable mssql_elastic_pools {
+  default = {}
+}
+variable storage_accounts {
+  default = {}
+}
+variable azuread_groups {
+  default = {}
+}
+variable keyvaults {
+  default = {}
+}
+variable keyvault_access_policies {
+  default = {}
+}
+variable virtual_machines {
+  default = {}
+}
+variable bastion_hosts {
+  default = {}
+}
+variable public_ip_addresses {
+  default = {}
+}
+variable diagnostic_storage_accounts {
+  default = {}
+}
+variable managed_identities {
+  default = {}
+}
+variable private_dns {
+  default = {}
+}
+variable synapse_workspaces {
+  default = {}
+}
+variable azurerm_application_insights {
+  default = {}
+}
+variable role_mapping {
+  default = {}
+}
+variable aks_clusters {
+  default = {}
+}
+variable databricks_workspaces {
+  default = {}
+}
+variable machine_learning_workspaces {
+  default = {}
+}
+variable monitoring {
+  default = {}
+}
+variable virtual_wans {
+  default = {}
+}
+variable event_hub_namespaces {
+  default = {}
+}
+variable application_gateways {
+  default = {}
+}
+variable application_gateway_applications {
+  default = {}
+}
+
+variable cosmos_dbs {
+  default = {}
+}

--- a/modules/databases/cosmos_db/cassandra_keyspace.tf
+++ b/modules/databases/cosmos_db/cassandra_keyspace.tf
@@ -1,0 +1,15 @@
+module cassandra_keyspaces {
+  source   = "./cassandra_keyspace"
+  for_each = try(var.settings.cassandra_keyspaces, {})
+
+  global_settings       = var.global_settings
+  settings              = each.value
+  resource_group_name   = azurerm_cosmosdb_account.cosmos_account.resource_group_name
+  location              = azurerm_cosmosdb_account.cosmos_account.location
+  cosmosdb_account_name = azurerm_cosmosdb_account.cosmos_account.name
+}
+
+output cassandra_keyspaces {
+  value     = module.cassandra_keyspaces
+  sensitive = true
+}

--- a/modules/databases/cosmos_db/cassandra_keyspace/cassandra_keyspace.tf
+++ b/modules/databases/cosmos_db/cassandra_keyspace/cassandra_keyspace.tf
@@ -1,0 +1,18 @@
+## Cosmos DB Cassandra API
+
+# Create database
+resource "azurerm_cosmosdb_cassandra_keyspace" "keyspace" {
+  name                = var.settings.name
+  resource_group_name = var.resource_group_name
+  account_name        = var.cosmosdb_account_name
+  throughput          = try(var.settings.throughput, null)
+
+  # Note : throughput & autoscaling are conflicting properties
+  dynamic "autoscale_settings" {
+    for_each = try(var.settings.autoscale_settings, {})
+
+    content {
+      max_throughput = autoscale_settings.value.max_throughput
+    }
+  }
+}

--- a/modules/databases/cosmos_db/cassandra_keyspace/main.tf
+++ b/modules/databases/cosmos_db/cassandra_keyspace/main.tf
@@ -1,0 +1,14 @@
+locals {
+  module_tag = {
+    "module" = basename(abspath(path.module))
+  }
+  #tags = merge(local.module_tag, try(var.settings.tags, null), var.base_tags)
+}
+
+terraform {
+  required_providers {
+    azurecaf = {
+      source = "aztfmod/azurecaf"
+    }
+  }
+}

--- a/modules/databases/cosmos_db/cassandra_keyspace/output.tf
+++ b/modules/databases/cosmos_db/cassandra_keyspace/output.tf
@@ -1,0 +1,5 @@
+output id {
+  description = "The ID of the CosmosDB Cassandra KeySpace."
+  value       = azurerm_cosmosdb_cassandra_keyspace.keyspace.id
+  sensitive   = true
+}

--- a/modules/databases/cosmos_db/cassandra_keyspace/variables.tf
+++ b/modules/databases/cosmos_db/cassandra_keyspace/variables.tf
@@ -1,0 +1,5 @@
+variable settings {}
+variable global_settings {}
+variable resource_group_name {}
+variable location {}
+variable cosmosdb_account_name {}


### PR DESCRIPTION
First draft of Cosmos DB Cassandra API. Terraform only supports creating a Cassandra Keyspace at the moment rather than the sub-resource of a Table; the Go SDK supports this, but Terraform support is not yet available.