### PR TITLE
Generate DNS from VM name

### DIFF
--- a/modules/networking/public_ip_addresses/module.tf
+++ b/modules/networking/public_ip_addresses/module.tf
@@ -6,7 +6,7 @@ resource "azurerm_public_ip" "pip" {
   sku                     = var.sku
   ip_version              = var.ip_version
   idle_timeout_in_minutes = var.idle_timeout_in_minutes
-  domain_name_label       = var.domain_name_label
+  domain_name_label       = var.generate_domain_name_label ? var.name : var.domain_name_label
   reverse_fqdn            = var.reverse_fqdn
   zones                   = var.zones
   tags                    = local.tags

--- a/modules/networking/public_ip_addresses/variables.tf
+++ b/modules/networking/public_ip_addresses/variables.tf
@@ -22,6 +22,10 @@ variable idle_timeout_in_minutes {
 variable domain_name_label {
   default = null
 }
+# if set to true, automatically generate a domain name label with the name
+variable generate_domain_name_label {
+  default = false
+}
 variable reverse_fqdn {
   default = null
 }

--- a/networking.tf
+++ b/networking.tf
@@ -56,20 +56,21 @@ module public_ip_addresses {
   source   = "./modules/networking/public_ip_addresses"
   for_each = local.networking.public_ip_addresses
 
-  name                    = azurecaf_name.public_ip_addresses[each.key].result
-  resource_group_name     = module.resource_groups[each.value.resource_group_key].name
-  location                = lookup(each.value, "region", null) == null ? module.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
-  sku                     = try(each.value.sku, "Basic")
-  allocation_method       = try(each.value.allocation_method, "Dynamic")
-  ip_version              = try(each.value.ip_version, "IPv4")
-  idle_timeout_in_minutes = try(each.value.idle_timeout_in_minutes, null)
-  domain_name_label       = try(each.value.domain_name_label, null)
-  reverse_fqdn            = try(each.value.reverse_fqdn, null)
-  tags                    = try(each.value.tags, null)
-  zones                   = try(each.value.zones, null)
-  diagnostic_profiles     = try(each.value.diagnostic_profiles, {})
-  diagnostics             = local.combined_diagnostics
-  base_tags               = try(local.global_settings.inherit_tags, false) ? module.resource_groups[each.value.resource_group_key].tags : {}
+  name                       = azurecaf_name.public_ip_addresses[each.key].result
+  resource_group_name        = module.resource_groups[each.value.resource_group_key].name
+  location                   = lookup(each.value, "region", null) == null ? module.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  sku                        = try(each.value.sku, "Basic")
+  allocation_method          = try(each.value.allocation_method, "Dynamic")
+  ip_version                 = try(each.value.ip_version, "IPv4")
+  idle_timeout_in_minutes    = try(each.value.idle_timeout_in_minutes, null)
+  domain_name_label          = try(each.value.domain_name_label, null)
+  reverse_fqdn               = try(each.value.reverse_fqdn, null)
+  generate_domain_name_label = try(each.value.generate_domain_name_label, false)
+  tags                       = try(each.value.tags, null)
+  zones                      = try(each.value.zones, null)
+  diagnostic_profiles        = try(each.value.diagnostic_profiles, {})
+  diagnostics                = local.combined_diagnostics
+  base_tags                  = try(local.global_settings.inherit_tags, false) ? module.resource_groups[each.value.resource_group_key].tags : {}
 }
 
 #

--- a/networking.tf
+++ b/networking.tf
@@ -73,6 +73,7 @@ module public_ip_addresses {
   base_tags                  = try(local.global_settings.inherit_tags, false) ? module.resource_groups[each.value.resource_group_key].tags : {}
 }
 
+
 #
 #
 # Vnet peering


### PR DESCRIPTION
This is to set the domain name with the name of the VM automatically. As this name can be dynamically created it can't be set upfront from the TFVARS input file