### PR TITLE
adding azure devops project creation capabilities to CAF

### DIFF
--- a/azure_devops_projects.tf
+++ b/azure_devops_projects.tf
@@ -1,0 +1,11 @@
+module "azure_devops_projects" {
+  source          = "./modules/devops/providers/azure-devops"
+  for_each        = var.azure_devops_projects
+  project         = each.value
+  global_settings = local.global_settings
+  client_config   = local.client_config
+}
+
+output azure_devops_projects {
+  value = module.azure_devops_projects
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -122,6 +122,7 @@ You can customize the examples execution by modifying the variables as follow:
 | azuread\_groups | n/a | `map` | `{}` | no |
 | azuread\_roles | n/a | `map` | `{}` | no |
 | azuread\_users | n/a | `map` | `{}` | no |
+| azure\_devops\_projects | n/a | `map` | `{}` | no |
 | azurerm\_application\_insights | n/a | `map` | `{}` | no |
 | azurerm\_firewall\_application\_rule\_collection\_definition | n/a | `map` | `{}` | no |
 | azurerm\_firewall\_nat\_rule\_collection\_definition | n/a | `map` | `{}` | no |

--- a/examples/devops/providers/azure-devops/new_project/ado_project.tfvars
+++ b/examples/devops/providers/azure-devops/new_project/ado_project.tfvars
@@ -1,0 +1,5 @@
+azure_devops_projects = {
+  test_project = {
+    name = "Test Project"
+  }
+}

--- a/examples/devops/providers/azure-devops/new_project/configuration.tfvars
+++ b/examples/devops/providers/azure-devops/new_project/configuration.tfvars
@@ -1,0 +1,18 @@
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "southeastasia"
+  }
+}
+
+resource_groups = {
+  ado_test = {
+    name = "ado_test"
+  }
+}
+
+azure_devops_projects = {
+  test = {
+    name = "Test Project"
+  }
+}

--- a/examples/devops/providers/azure-devops/new_project/configuration.tfvars
+++ b/examples/devops/providers/azure-devops/new_project/configuration.tfvars
@@ -10,9 +10,3 @@ resource_groups = {
     name = "ado_test"
   }
 }
-
-azure_devops_projects = {
-  test = {
-    name = "Test Project"
-  }
-}

--- a/examples/module.tf
+++ b/examples/module.tf
@@ -13,6 +13,7 @@ module "caf" {
   azuread_apps                 = var.azuread_apps
   azuread_users                = var.azuread_users
   azuread_roles                = var.azuread_roles
+  azure_devops_projects        = var.azure_devops_projects
   tags                         = local.tags
   keyvaults                    = var.keyvaults
   keyvault_access_policies     = var.keyvault_access_policies

--- a/examples/variables.tf
+++ b/examples/variables.tf
@@ -313,3 +313,6 @@ variable netapp_accounts {
 variable automations {
   default = {}
 }
+variable azure_devops_projects {
+  default = {}
+}

--- a/modules/devops/providers/azure-devops/README.md
+++ b/modules/devops/providers/azure-devops/README.md
@@ -1,0 +1,43 @@
+# Azure DevOps
+
+This submodule is part of Cloud Adoption Framework landing zones for Azure on Terraform.
+
+You can instantiate this submodule directly using the following parameters:
+
+```
+module "azure_devops_projects" {
+  source  = "aztfmod/caf/azurerm//modules/devops/providers/azure-devops"
+  version = "5.1.3"
+  # insert the 5 required variables here
+}
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.13 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| microsoft/azuredevops | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| client\_config | Client configuration object (see module README.md). | `any` | n/a | yes |
+| global\_settings | Global settings object (see module README.md) | `any` | n/a | yes |
+| project | The project configuration map | `map` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| id | The Project ID. |
+| name | The Project name. |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/devops/providers/azure-devops/main.tf
+++ b/modules/devops/providers/azure-devops/main.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    azuredevops = {
+      source = "microsoft/azuredevops"
+      version = ">=0.1.0"
+    }
+  }
+}

--- a/modules/devops/providers/azure-devops/output.tf
+++ b/modules/devops/providers/azure-devops/output.tf
@@ -1,0 +1,7 @@
+output project_id {
+  value = azuredevops_project.project.id
+}
+
+output project_name {
+  value     = azuredevops_project.project.name 
+}

--- a/modules/devops/providers/azure-devops/project.tf
+++ b/modules/devops/providers/azure-devops/project.tf
@@ -1,0 +1,7 @@
+resource "azuredevops_project" "project" {
+  name               = var.project.name
+  description        = lookup(var.project, "description", "")
+  visibility         = lookup(var.project, "visibility", "private")
+  version_control    = lookup(var.project, "version_control", "Git")
+  work_item_template = lookup(var.project, "work_item_template", "Agile")
+}

--- a/modules/devops/providers/azure-devops/variables.tf
+++ b/modules/devops/providers/azure-devops/variables.tf
@@ -1,0 +1,10 @@
+variable project {
+  description = "(REQUIRED) The Project model."
+  type        = map
+}
+variable global_settings {
+  description = "Global settings object (see module README.md)"
+}
+variable client_config {
+  description = "Client configuration object (see module README.md)."
+}

--- a/modules/devops/providers/azure-devops/variables.tf
+++ b/modules/devops/providers/azure-devops/variables.tf
@@ -1,5 +1,5 @@
 variable project {
-  description = "(REQUIRED) The Project model."
+  description = "The object representative of the ado project entity to update."
   type        = map
 }
 variable global_settings {

--- a/variables.tf
+++ b/variables.tf
@@ -234,3 +234,7 @@ variable "local_network_gateways" {
 variable "ip_groups" {
   default = {}
 }
+
+variable azure_devops_projects {
+  default = {}
+}


### PR DESCRIPTION
Adding ADO terraform provider project creation [resource](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/project) extension to CAF. 

Verified that I was able to utilize this new feature to create a new project in Azure DevOps by following the below steps. 

```shell
export AZDO_PERSONAL_ACCESS_TOKEN=redacted
export AZDO_ORG_SERVICE_URL=redacted

rover -lz /tf/caf/public/landingzones/landingzones/caf_launchpad -launchpad -var-folder /tf/caf/public/landingzones/landingzones/caf_launchpad/scenario/100 -a apply

rover -lz /tf/caf/public/modules/examples/ -var-folder /tf/caf/public/modules/examples/devops/providers/azure-devops/new_project/ -a apply -level level1
```

![image](https://user-images.githubusercontent.com/7635865/108646238-d008c580-747a-11eb-8c33-3d311e964715.png)