### PR TITLE
Remove sensitive outputs in AKS for Terraform 0.15

### DIFF
--- a/examples/compute/kubernetes_services/101-single-cluster/aks.tfvars
+++ b/examples/compute/kubernetes_services/101-single-cluster/aks.tfvars
@@ -22,7 +22,6 @@ aks_clusters = {
       type = "SystemAssigned"
     }
 
-    # kubernetes_version = "1.19.6"
     vnet_key           = "spoke_aks_re1"
 
     network_profile = {
@@ -54,8 +53,6 @@ aks_clusters = {
     load_balancer_profile = {
       # Only one option can be set
       managed_outbound_ip_count = 1
-      # outbound_ip_prefix_ids = []
-      # outbound_ip_address_ids = []
     }
 
     default_node_pool = {
@@ -67,7 +64,6 @@ aks_clusters = {
       max_pods              = 30
       node_count            = 1
       os_disk_size_gb       = 512
-      orchestrator_version  = "1.19.6"
       tags = {
         "project" = "system services"
       }

--- a/examples/compute/kubernetes_services/101-single-cluster/aks.tfvars
+++ b/examples/compute/kubernetes_services/101-single-cluster/aks.tfvars
@@ -22,7 +22,7 @@ aks_clusters = {
       type = "SystemAssigned"
     }
 
-    kubernetes_version = "1.19.6"
+    # kubernetes_version = "1.19.6"
     vnet_key           = "spoke_aks_re1"
 
     network_profile = {

--- a/examples/compute/kubernetes_services/102-multi-nodepools/aks.tfvars
+++ b/examples/compute/kubernetes_services/102-multi-nodepools/aks.tfvars
@@ -8,7 +8,7 @@ aks_clusters = {
       type = "SystemAssigned"
     }
 
-    kubernetes_version = "1.19.6"
+    # kubernetes_version = "1.19.6"
 
     #lz_key   = "networking_spoke_aks"
     vnet_key = "spoke_aks_re1"
@@ -41,7 +41,7 @@ aks_clusters = {
       max_pods              = 30
       node_count            = 1
       os_disk_size_gb       = 512
-      orchestrator_version  = "1.19.6"
+      # orchestrator_version  = "1.19.6"
       tags = {
         "project" = "system services"
       }
@@ -59,7 +59,7 @@ aks_clusters = {
         node_count           = 1
         enable_auto_scaling  = false
         os_disk_size_gb      = 512
-        orchestrator_version = "1.19.6"
+        # orchestrator_version = "1.19.6"
         tags = {
           "project" = "user services"
         }

--- a/examples/compute/kubernetes_services/102-multi-nodepools/aks.tfvars
+++ b/examples/compute/kubernetes_services/102-multi-nodepools/aks.tfvars
@@ -8,9 +8,6 @@ aks_clusters = {
       type = "SystemAssigned"
     }
 
-    # kubernetes_version = "1.19.6"
-
-    #lz_key   = "networking_spoke_aks"
     vnet_key = "spoke_aks_re1"
 
     network_policy = {
@@ -41,7 +38,6 @@ aks_clusters = {
       max_pods              = 30
       node_count            = 1
       os_disk_size_gb       = 512
-      # orchestrator_version  = "1.19.6"
       tags = {
         "project" = "system services"
       }
@@ -59,7 +55,6 @@ aks_clusters = {
         node_count           = 1
         enable_auto_scaling  = false
         os_disk_size_gb      = 512
-        # orchestrator_version = "1.19.6"
         tags = {
           "project" = "user services"
         }

--- a/examples/compute/kubernetes_services/103-multi-clusters/aks.tfvars
+++ b/examples/compute/kubernetes_services/103-multi-clusters/aks.tfvars
@@ -8,7 +8,7 @@ aks_clusters = {
       type = "SystemAssigned"
     }
 
-    kubernetes_version = "1.19.6"
+    # kubernetes_version = "1.19.6"
 
     lz_key   = "networking_spoke_aks"
     vnet_key = "spoke_aks_re1"
@@ -43,7 +43,7 @@ aks_clusters = {
       max_pods              = 30
       node_count            = 3
       os_disk_size_gb       = 512
-      orchestrator_version  = "1.19.6"
+      # orchestrator_version  = "1.19.6"
       tags = {
         "project" = "system services"
       }
@@ -69,7 +69,7 @@ aks_clusters = {
       type = "SystemAssigned"
     }
 
-    kubernetes_version = "1.19.6"
+    # kubernetes_version = "1.19.6"
 
     lz_key   = "networking_spoke_aks"
     vnet_key = "spoke_aks_re2"

--- a/examples/compute/kubernetes_services/103-multi-clusters/aks.tfvars
+++ b/examples/compute/kubernetes_services/103-multi-clusters/aks.tfvars
@@ -43,7 +43,6 @@ aks_clusters = {
       max_pods              = 30
       node_count            = 3
       os_disk_size_gb       = 512
-      # orchestrator_version  = "1.19.6"
       tags = {
         "project" = "system services"
       }
@@ -68,8 +67,6 @@ aks_clusters = {
     identity = {
       type = "SystemAssigned"
     }
-
-    # kubernetes_version = "1.19.6"
 
     lz_key   = "networking_spoke_aks"
     vnet_key = "spoke_aks_re2"
@@ -102,7 +99,6 @@ aks_clusters = {
       max_pods              = 30
       node_count            = 3
       os_disk_size_gb       = 512
-      orchestrator_version  = "1.19.6"
       tags = {
         "project" = "system services"
       }

--- a/examples/compute/kubernetes_services/104-private-cluster/aks.tfvars
+++ b/examples/compute/kubernetes_services/104-private-cluster/aks.tfvars
@@ -16,8 +16,6 @@ aks_clusters = {
       type = "SystemAssigned"
     }
 
-    # kubernetes_version = "1.19.6"
-
     lz_key   = "networking_spoke_aks"
     vnet_key = "spoke_aks_re1"
 
@@ -38,8 +36,6 @@ aks_clusters = {
     load_balancer_profile = {
       # Only one option can be set
       managed_outbound_ip_count = 1
-      # outbound_ip_prefix_ids = []
-      # outbound_ip_address_ids = []
     }
 
     default_node_pool = {
@@ -51,7 +47,6 @@ aks_clusters = {
       max_pods              = 30
       node_count            = 2
       os_disk_size_gb       = 512
-      # orchestrator_version  = "1.19.6"
       tags = {
         "project" = "system services"
       }
@@ -69,7 +64,6 @@ aks_clusters = {
         node_count           = 2
         enable_auto_scaling  = false
         os_disk_size_gb      = 512
-        # orchestrator_version = "1.19.6"
         tags = {
           "project" = "user services"
         }

--- a/examples/compute/kubernetes_services/104-private-cluster/aks.tfvars
+++ b/examples/compute/kubernetes_services/104-private-cluster/aks.tfvars
@@ -16,7 +16,7 @@ aks_clusters = {
       type = "SystemAssigned"
     }
 
-    kubernetes_version = "1.19.6"
+    # kubernetes_version = "1.19.6"
 
     lz_key   = "networking_spoke_aks"
     vnet_key = "spoke_aks_re1"
@@ -51,7 +51,7 @@ aks_clusters = {
       max_pods              = 30
       node_count            = 2
       os_disk_size_gb       = 512
-      orchestrator_version  = "1.19.6"
+      # orchestrator_version  = "1.19.6"
       tags = {
         "project" = "system services"
       }
@@ -69,7 +69,7 @@ aks_clusters = {
         node_count           = 2
         enable_auto_scaling  = false
         os_disk_size_gb      = 512
-        orchestrator_version = "1.19.6"
+        # orchestrator_version = "1.19.6"
         tags = {
           "project" = "user services"
         }

--- a/modules/azuread/applications/module.tf
+++ b/modules/azuread/applications/module.tf
@@ -1,6 +1,6 @@
 resource "azuread_application" "app" {
 
-  display_name = var.global_settings.passthrough ? format("%s", var.settings.application_name) : format("%v-%s", try(var.global_settings.prefixes[0], ""), var.settings.application_name)
+  name = var.global_settings.passthrough ? format("%s", var.settings.application_name) : format("%v-%s", try(var.global_settings.prefixes[0], ""), var.settings.application_name)
 
   owners = [
     var.client_config.object_id

--- a/modules/azuread/groups/group.tf
+++ b/modules/azuread/groups/group.tf
@@ -1,6 +1,6 @@
 resource "azuread_group" "group" {
 
-  display_name            = var.global_settings.passthrough ? format("%s", var.azuread_groups.name) : format("%s%s", try(format("%s-", var.global_settings.prefixes.0), ""), var.azuread_groups.name)
+  name            = var.global_settings.passthrough ? format("%s", var.azuread_groups.name) : format("%s%s", try(format("%s-", var.global_settings.prefixes.0), ""), var.azuread_groups.name)
   description             = lookup(var.azuread_groups, "description", null)
   prevent_duplicate_names = lookup(var.azuread_groups, "prevent_duplicate_names", null)
 

--- a/modules/azuread/groups_members/members.tf
+++ b/modules/azuread/groups_members/members.tf
@@ -33,7 +33,7 @@ module "object_id" {
 data "azuread_group" "name" {
   for_each = toset(try(var.settings.members.group_names, []))
 
-  display_name = each.value
+  name = each.value
 }
 
 module "group_name" {

--- a/modules/compute/aks/aks.tf
+++ b/modules/compute/aks/aks.tf
@@ -58,7 +58,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
     node_labels                  = try(var.settings.default_node_pool.node_labels, null)
     node_taints                  = try(var.settings.default_node_pool.node_taints, null)
     vnet_subnet_id               = var.subnets[var.settings.default_node_pool.subnet_key].id
-    orchestrator_version         = try(var.settings.default_node_pool.orchestrator_version, var.settings.kubernetes_version)
+    orchestrator_version         = try(var.settings.default_node_pool.orchestrator_version, try(var.settings.kubernetes_version, null))
     tags                         = merge(try(var.settings.default_node_pool.tags, {}), local.tags)
   }
 
@@ -245,7 +245,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "nodepools" {
   max_pods              = try(each.value.max_pods, 30)
   node_labels           = try(each.value.node_labels, null)
   node_taints           = try(each.value.node_taints, null)
-  orchestrator_version  = try(each.value.orchestrator_version, var.settings.kubernetes_version)
+  orchestrator_version  = try(each.value.orchestrator_version, try(var.settings.kubernetes_version, null))
   tags                  = merge(try(each.value.tags, {}), try(var.settings.default_node_pool.tags, {}))
 
 }

--- a/modules/compute/aks/output.tf
+++ b/modules/compute/aks/output.tf
@@ -32,14 +32,6 @@ output "enable_rbac" {
   value = lookup(var.settings, "enable_rbac", true)
 }
 
-output "kube_admin_config" {
-  value = azurerm_kubernetes_cluster.aks.kube_admin_config
-}
-
-output "kube_admin_config_raw" {
-  value = azurerm_kubernetes_cluster.aks.kube_admin_config_raw
-}
-
 output "kube_config" {
   value = azurerm_kubernetes_cluster.aks.kube_config
 }


### PR DESCRIPTION
Remove Sensitive outputs

Fixed Terraform v 0.15 error with sensitive value
```output
│ Error: Output refers to sensitive values
│
│   on .terraform/modules/caf/modules/compute/aks/output.tf line 39:
│   39: output kube_admin_config_raw {
│
│ Expressions used in outputs can only refer to sensitive values if the sensitive attribute is true.
```

https://github.com/Azure/caf-terraform-landingzones-starter/issues/51
