### PR TITLE
Updated MSI tags, added example

### DIFF
--- a/.github/workflows/master-100-tf13.yaml
+++ b/.github/workflows/master-100-tf13.yaml
@@ -103,6 +103,7 @@ jobs:
             "keyvault/102-keyvault-cert-issuer",
             "machine_learning/100-aml",
             "machine_learning/101-aml-vnet",
+            "managed_service_identity/100-msi-levels",
             "mariadb_server/100-simple-mariadb",
             "mariadb_server/101-vnet-rule-mariadb",
             "mariadb_server/102-private-endpoint-mariadb",

--- a/.github/workflows/master-100-tf14.yaml
+++ b/.github/workflows/master-100-tf14.yaml
@@ -116,6 +116,7 @@ jobs:
             "keyvault/102-keyvault-cert-issuer",
             "machine_learning/100-aml",
             "machine_learning/101-aml-vnet",
+            "managed_service_identity/100-msi-levels",
             "mariadb_server/100-simple-mariadb",
             "mariadb_server/101-vnet-rule-mariadb",
             "mariadb_server/102-private-endpoint-mariadb",

--- a/.github/workflows/master-100-tf15.yaml
+++ b/.github/workflows/master-100-tf15.yaml
@@ -100,6 +100,7 @@ jobs:
             "keyvault/102-keyvault-cert-issuer",
             "machine_learning/100-aml",
             "machine_learning/101-aml-vnet",
+            "managed_service_identity/100-msi-levels",
             "mariadb_server/100-simple-mariadb",
             "mariadb_server/101-vnet-rule-mariadb",
             "mariadb_server/102-private-endpoint-mariadb",

--- a/.github/workflows/master-standalone-tf13.yaml
+++ b/.github/workflows/master-standalone-tf13.yaml
@@ -63,6 +63,7 @@ jobs:
             "eventhub/103-eventhub-consumer-groups",
             "keyvault/101-keyvault-policies",
             "machine_learning/100-aml",
+            "managed_service_identity/100-msi-levels",
             "mariadb_server/100-simple-mariadb",
             "mariadb_server/101-vnet-rule-mariadb",
             "mariadb_server/102-private-endpoint-mariadb",

--- a/.github/workflows/master-standalone-tf14.yaml
+++ b/.github/workflows/master-standalone-tf14.yaml
@@ -72,6 +72,7 @@ jobs:
             "eventhub/103-eventhub-consumer-groups",
             "keyvault/101-keyvault-policies",
             "machine_learning/100-aml",
+            "managed_service_identity/100-msi-levels",
             "mariadb_server/100-simple-mariadb",
             "mariadb_server/101-vnet-rule-mariadb",
             "mariadb_server/102-private-endpoint-mariadb",

--- a/.github/workflows/master-standalone-tf15.yaml
+++ b/.github/workflows/master-standalone-tf15.yaml
@@ -54,6 +54,7 @@ jobs:
             "eventhub_namespace/101-evh-with-private-endpoint",
             "keyvault/101-keyvault-policies",
             "machine_learning/100-aml",
+            "managed_service_identity/100-msi-levels",
             "mariadb_server/100-simple-mariadb",
             "mariadb_server/101-vnet-rule-mariadb",
             "mariadb_server/102-private-endpoint-mariadb",

--- a/examples/managed_service_identity/100-msi-levels/configuration.tfvars
+++ b/examples/managed_service_identity/100-msi-levels/configuration.tfvars
@@ -1,0 +1,62 @@
+
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "southeastasia"
+  }
+}
+
+resource_groups = {
+  msi_region1 = {
+    name   = "security-rg1"
+    region = "region1"
+  }
+}
+
+managed_identities = {
+  level0 = {
+    # Used by the release agent to access the level0 keyvault and storage account with the tfstates in read / write
+    # Assign read access to level0
+    name               = "msi-level0"
+    resource_group_key = "msi_region1"
+    tags = {
+      level = "level0"
+    }
+  }
+  level1 = {
+    # Used by the release agent to access the level1 keyvault and storage account with the tfstates in read / write
+    # Assign read access to level0
+    name               = "msi-level1"
+    resource_group_key = "msi_region1"
+    tags = {
+      level = "level1"
+    }
+  }
+  level2 = {
+    # Used by the release agent to access the level2 keyvault and storage account with the tfstates in read / write
+    # Assign read access to level1
+    name               = "msi-level2"
+    resource_group_key = "msi_region1"
+    tags = {
+      level = "level2"
+    }
+  }
+  level3 = {
+    # Used by the release agent to access the level3 keyvault and storage account with the tfstates in read / write
+    # Assign read access to level2
+    name               = "msi-level3"
+    resource_group_key = "msi_region1"
+    tags = {
+      level = "level3"
+    }
+  }
+  level4 = {
+    # Used by the release agent to access the level4 keyvault and storage account with the tfstates in read / write
+    # Assign read access to level3
+    name               = "msi-level4"
+    resource_group_key = "msi_region1"
+    tags = {
+      level = "level4"
+    }
+  }
+}

--- a/examples/managed_service_identity/100-msi-levels/standalone/ci.sh
+++ b/examples/managed_service_identity/100-msi-levels/standalone/ci.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+current_folder=$(pwd)
+cd standalone
+
+terraform init
+
+terraform apply \
+  -var-file ../configuration.tfvars \
+  -var tags='{testing_job_id='"${1}"'}' \
+  -var var_folder_path=${current_folder} \
+  -input=false \
+  -auto-approve
+
+
+terraform destroy \
+  -var-file ../configuration.tfvars \
+  -var tags='{testing_job_id='"${1}"'}' \
+  -var var_folder_path=${current_folder} \
+  -input=false \
+  -auto-approve
+

--- a/examples/managed_service_identity/100-msi-levels/standalone/main.tf
+++ b/examples/managed_service_identity/100-msi-levels/standalone/main.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 2.52"
+    }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 1.4.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 2.2.1"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 2.1.0"
+    }
+    external = {
+      source  = "hashicorp/external"
+      version = "~> 1.2.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 2.2.0"
+    }
+    azurecaf = {
+      source  = "aztfmod/azurecaf"
+      version = "~> 1.2.0"
+    }
+  }
+  required_version = ">= 0.14"
+}
+
+provider "azurerm" {
+  features {}
+}
+

--- a/examples/managed_service_identity/100-msi-levels/standalone/module.tf
+++ b/examples/managed_service_identity/100-msi-levels/standalone/module.tf
@@ -1,0 +1,7 @@
+module "caf" {
+  source = "../../../../"
+
+  global_settings    = var.global_settings
+  resource_groups    = var.resource_groups
+  managed_identities = var.managed_identities
+}

--- a/examples/managed_service_identity/100-msi-levels/standalone/readme.md
+++ b/examples/managed_service_identity/100-msi-levels/standalone/readme.md
@@ -1,0 +1,25 @@
+You can test this module outside of a landingzone using
+
+```bash
+cd /tf/caf/aztfmod/examples/managed_service_identity/101-msi-levels/standalone
+
+terraform init
+
+terraform [plan|apply|delete] \
+  -var-file ../configuration.tfvars
+
+
+```
+
+To test this deployment in the example landingzone. Make sure the launchpad has been deployed first
+
+```bash
+
+rover \
+  -lz /tf/caf/landingzones/caf_example \
+  -tfstate example-101-msi-levels.tfstate \
+  -var-folder /tf/caf/aztfmod/examples/managed_service_identity/101-msi-levels \
+  -level level1 \
+  -a [plan|apply|delete]
+
+```

--- a/examples/managed_service_identity/100-msi-levels/standalone/variables.tf
+++ b/examples/managed_service_identity/100-msi-levels/standalone/variables.tf
@@ -1,0 +1,19 @@
+
+variable "global_settings" {
+  default = {}
+}
+variable "resource_groups" {
+  default = null
+}
+variable "managed_identities" {
+  default = {}
+}
+
+variable "var_folder_path" {
+  default = {}
+}
+
+variable "tags" {
+  default = null
+  type    = map(any)
+}

--- a/managed_identities.tf
+++ b/managed_identities.tf
@@ -7,6 +7,7 @@ module "managed_identities" {
   resource_group_name = module.resource_groups[each.value.resource_group_key].name
   location            = module.resource_groups[each.value.resource_group_key].location
   global_settings     = local.global_settings
+  settings            = each.value
   base_tags           = try(local.global_settings.inherit_tags, false) ? module.resource_groups[each.value.resource_group_key].tags : {}
 }
 

--- a/modules/security/managed_identity/main.tf
+++ b/modules/security/managed_identity/main.tf
@@ -6,11 +6,3 @@ terraform {
   }
   required_version = ">= 0.13"
 }
-
-
-locals {
-  module_tag = {
-    "module" = basename(abspath(path.module))
-  }
-  tags = merge(var.base_tags, local.module_tag, var.tags)
-}

--- a/modules/security/managed_identity/managed_identity.tf
+++ b/modules/security/managed_identity/managed_identity.tf
@@ -1,4 +1,6 @@
-
+locals {
+  tags = try(var.settings.tags, null) == null ? null : try(var.settings.tags.environment, null) == null ? var.settings.tags : merge(lookup(var.settings, "tags", {}), { "environment" : var.global_settings.environment })
+}
 resource "azurecaf_name" "msi" {
   name          = var.name
   resource_type = "azurerm_user_assigned_identity"
@@ -13,6 +15,6 @@ resource "azurerm_user_assigned_identity" "msi" {
   name                = azurecaf_name.msi.result
   resource_group_name = var.resource_group_name
   location            = var.location
-  tags                = local.tags
+  tags                = try(merge(var.base_tags, local.tags), {})
 }
 

--- a/modules/security/managed_identity/variables.tf
+++ b/modules/security/managed_identity/variables.tf
@@ -10,6 +10,7 @@ variable "name" {}
 variable "global_settings" {
   description = "Global settings object (see module README.md)"
 }
+variable "settings" {}
 variable "base_tags" {
   description = "Base tags for the resource to be inherited from the resource group."
   type        = map(any)


### PR DESCRIPTION
Currently the MSI adds a module tag but does not allow configuration tags to be added to the resource. 

Updated MSI tags module to use and merge local setting tags.

Closes #376 