### PR TITLE
Updated Key Access Policy configuration name for  diagnostic storage account

### DIFF
--- a/examples/storage_accounts/100-simple-storage-account-blob-container/keyvaults.tfvars
+++ b/examples/storage_accounts/100-simple-storage-account-blob-container/keyvaults.tfvars
@@ -17,7 +17,7 @@ keyvault_access_policies = {
       secret_permissions  = ["Set", "Get", "List", "Delete", "Purge", "Recover"]
     }
     diastg = {
-      dia_storage_account_key = "dsa1"
+      diagnostic_storage_account_key = "dsa1"
       key_permissions     = ["get", "create", "list", "restore", "recover", "unwrapkey", "wrapkey", "purge", "encrypt", "decrypt", "sign", "verify"]
       secret_permissions  = ["Set", "Get", "List", "Delete", "Purge", "Recover"]
     }

--- a/examples/storage_accounts/100-simple-storage-account-blob-container/standalone/readme.md
+++ b/examples/storage_accounts/100-simple-storage-account-blob-container/standalone/readme.md
@@ -18,7 +18,7 @@ To test this deployment in the example landingzone. Make sure the launchpad has 
 
 rover \
   -lz /tf/caf/landingzones/caf_example \
-  -var-folder  /tf/caf/aztfmod/examples/storage_accounts/100-simple-storage-account-blob-container \
+  -var-folder  /tf/caf/examples/storage_accounts/100-simple-storage-account-blob-container/ \
   -level level1 \
   -a plan
 

--- a/modules/security/keyvault_access_policies/policies.tf
+++ b/modules/security/keyvault_access_policies/policies.tf
@@ -122,11 +122,11 @@ module "diagnostic_storage_accounts" {
   source = "./access_policy"
   for_each = {
     for key, access_policy in var.access_policies : key => access_policy
-    if try(access_policy.dia_storage_account_key, null) != null
+    if try(access_policy.diagnostic_storage_account_key, null) != null
   }
 
   keyvault_id   = var.keyvault_id == null ? try(var.keyvaults[var.client_config.landingzone_key][var.keyvault_key].id, var.keyvaults[each.value.lz_key][var.keyvault_key].id) : var.keyvault_id
   access_policy = each.value
-  tenant_id     = var.resources.diagnostic_storage_accounts[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.dia_storage_account_key].identity.0.tenant_id
-  object_id     = var.resources.diagnostic_storage_accounts[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.dia_storage_account_key].identity.0.principal_id
+  tenant_id     = var.resources.diagnostic_storage_accounts[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.diagnostic_storage_account_key].identity.0.tenant_id
+  object_id     = var.resources.diagnostic_storage_accounts[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.diagnostic_storage_account_key].identity.0.principal_id
 }


### PR DESCRIPTION
- Updated the Key Vault access policies configuration. dia_storage_account_key  changed to diagnostic_storage_account_key for standardization.
- Updated the readme file with the correct path