### PR TITLE
Add support for Redis Cache VNET integration

### DIFF
--- a/modules/redis_cache/module.tf
+++ b/modules/redis_cache/module.tf
@@ -20,12 +20,13 @@ resource "azurerm_redis_cache" "redis" {
   sku_name            = var.redis.sku_name
   tags                = local.tags
 
-  enable_non_ssl_port       = lookup(var.redis, "enable_non_ssl_port", null)
-  minimum_tls_version       = lookup(var.redis, "minimum_tls_version", "1.2")
-  private_static_ip_address = lookup(var.redis, "private_static_ip_address", null)
-  shard_count               = lookup(var.redis, "shard_count", null)
-  subnet_id                 = lookup(var.redis, "subnet_id", null)
-  zones                     = lookup(var.redis, "zones", null)
+  enable_non_ssl_port           = lookup(var.redis, "enable_non_ssl_port", null)
+  minimum_tls_version           = lookup(var.redis, "minimum_tls_version", "1.2")
+  private_static_ip_address     = lookup(var.redis, "private_static_ip_address", null)
+  public_network_access_enabled = lookup(var.redis, "public_network_access_enabled", null)
+  shard_count                   = lookup(var.redis, "shard_count", null)
+  zones                         = lookup(var.redis, "zones", null)
+  subnet_id                     = try(var.subnet_id, null)
 
   dynamic "redis_configuration" {
     for_each = lookup(var.redis, "redis_configuration", {}) != {} ? [var.redis.redis_configuration] : []

--- a/modules/redis_cache/variables.tf
+++ b/modules/redis_cache/variables.tf
@@ -15,6 +15,12 @@ variable "tags" {
 
 variable "redis" {}
 
+variable "subnet_id" {
+  description = "The ID of the Subnet within which the Redis Cache should be deployed"
+  type        = string
+  default     = null
+}
+
 variable "global_settings" {
   description = "Global settings object (see module README.md)"
 }

--- a/redis_caches.tf
+++ b/redis_caches.tf
@@ -1,7 +1,8 @@
 
 module "redis_caches" {
-  source   = "./modules/redis_cache"
-  for_each = local.database.azurerm_redis_caches
+  source     = "./modules/redis_cache"
+  depends_on = [module.networking]
+  for_each   = local.database.azurerm_redis_caches
 
   tags                = try(each.value.tags, null)
   location            = lookup(each.value, "region", null) == null ? module.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
@@ -9,6 +10,7 @@ module "redis_caches" {
   redis               = each.value.redis
   global_settings     = local.global_settings
   base_tags           = try(local.global_settings.inherit_tags, false) ? module.resource_groups[each.value.resource_group_key].tags : {}
+  subnet_id           = try(each.value.subnet_key, null) == null ? null : try(local.combined_objects_networking[local.client_config.landingzone_key][each.value.vnet_key].subnets[each.value.subnet_key].id, local.combined_objects_networking[each.value.lz_key][each.value.vnet_key].subnets[each.value.subnet_key].id)
 
 }
 


### PR DESCRIPTION
This PR solves #402, adds support to create a fully private Redis Cache:
* Adds `public_network_access_enabled` parameter to module's interface
* Sets new module variable to pass the `subnet.id` directly, instead of part of `redis` map, to be able to obtain it dynamically from a landing zone
* Add `subnet_id` parameter from top module and construct the lookup from `combined_objects`
* Depend on networking module for ordering purposes

This code has been tested and I'm able to successfully deploy a Premium instance within vnet.

