### PR TITLE
DNS proxy_enabled not processed in Azure firewall policy

### DIFF
--- a/modules/networking/firewall_policies/firewall_policy.tf
+++ b/modules/networking/firewall_policies/firewall_policy.tf
@@ -23,7 +23,7 @@ resource "azurerm_firewall_policy" "fwpol" {
 
     content {
       servers       = try(dns.value.servers, null)
-      proxy_enabled = try(dns.values.proxy_enabled, false)
+      proxy_enabled = try(dns.value.proxy_enabled, false)
     }
   }
 


### PR DESCRIPTION
This PR closes the issue #414 