### PR TITLE
Add SQL Server and DB to Dynamic App Settings

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -80,6 +80,8 @@ locals {
     keyvaults                   = local.combined_objects_keyvaults
     machine_learning_workspaces = local.combined_objects_machine_learning
     managed_identities          = local.combined_objects_managed_identities
+    mssql_databases             = local.combined_objects_mssql_databases
+    mssql_servers               = local.combined_objects_mssql_servers
     storage_accounts            = local.combined_objects_storage_accounts
   }
 


### PR DESCRIPTION
Allow for dynamic app settings of SQL Server and DB outputs. 

Example: 
	
    dynamic_app_settings = {
      "SQL_SERVER_FQDN" = {
        mssql_servers = {
          sql_server = {
            attribute_key = "fully_qualified_domain_name"
          }
        }
      }
    }