### PR TITLE
Added 'plan' block for Linux VMs

### DIFF
--- a/.github/workflows/master-standalone-tf13.yaml
+++ b/.github/workflows/master-standalone-tf13.yaml
@@ -45,6 +45,7 @@ jobs:
             "compute/virtual_machine/101-single-windows-vm",
             "compute/virtual_machine/102-single-vm-data-disks",
             "compute/virtual_machine/104-single-windows-backup",
+            "compute/virtual_machine/106-marketplace-image-with-plan",
             "compute/virtual_machine/210-vm-bastion-winrm",
             "compute/virtual_machine/211-vm-bastion-winrm-agents",
             "cosmos_db/100-simple-cosmos-db-cassandra",

--- a/.github/workflows/master-standalone-tf14.yaml
+++ b/.github/workflows/master-standalone-tf14.yaml
@@ -46,6 +46,7 @@ jobs:
             "compute/virtual_machine/101-single-windows-vm",
             "compute/virtual_machine/102-single-vm-data-disks",
             "compute/virtual_machine/104-single-windows-backup",
+            "compute/virtual_machine/106-marketplace-image-with-plan",
             "compute/virtual_machine/210-vm-bastion-winrm",
             "compute/virtual_machine/211-vm-bastion-winrm-agents",
             "cosmos_db/100-simple-cosmos-db-cassandra",

--- a/.github/workflows/master-standalone-tf15.yaml
+++ b/.github/workflows/master-standalone-tf15.yaml
@@ -53,6 +53,7 @@ jobs:
             "compute/virtual_machine/101-single-windows-vm",
             "compute/virtual_machine/102-single-vm-data-disks",
             "compute/virtual_machine/104-single-windows-backup",
+            "compute/virtual_machine/106-marketplace-image-with-plan",
             "compute/virtual_machine/210-vm-bastion-winrm",
             "compute/virtual_machine/211-vm-bastion-winrm-agents",
             "cosmos_db/100-simple-cosmos-db-cassandra",

--- a/examples/compute/virtual_machine/106-marketplace-image-with-plan/configuration.tfvars
+++ b/examples/compute/virtual_machine/106-marketplace-image-with-plan/configuration.tfvars
@@ -72,7 +72,6 @@ virtual_machines = {
           name                    = "example_vm1-os"
           caching                 = "ReadWrite"
           storage_account_type    = "Standard_LRS"
-          disk_encryption_set_key = "set1"
         }
 
         source_image_reference = {
@@ -110,23 +109,10 @@ keyvaults = {
     creation_policies = {
       logged_in_user = {
         secret_permissions = ["Set", "Get", "List", "Delete", "Purge", "Recover"]
-        key_permissions    = ["Get", "List", "Update", "Create", "Import", "Delete", "Recover", "Backup", "Restore", "Decrypt", "Encrypt", "UnwrapKey", "WrapKey", "Verify", "Sign", "Purge"]
       }
     }
   }
 }
-
-keyvault_keys = {
-  key1 = {
-    keyvault_key       = "example_vm_rg1"
-    resource_group_key = "vm_region1"
-    name               = "disk-key"
-    key_type           = "RSA"
-    key_size           = "2048"
-    key_opts           = ["encrypt", "decrypt", "sign", "verify", "wrapKey", "unwrapKey"]
-  }
-}
-
 
 vnets = {
   vnet_region1 = {

--- a/examples/compute/virtual_machine/106-marketplace-image-with-plan/configuration.tfvars
+++ b/examples/compute/virtual_machine/106-marketplace-image-with-plan/configuration.tfvars
@@ -1,3 +1,5 @@
+# As a prerequisite for market place images, user needs to accept the license agreements once per subscription for the image.
+# For more information - https://docs.microsoft.com/en-us/azure/virtual-machines/windows/cli-ps-findimage#accept-purchase-plan-terms
 
 global_settings = {
   default_region = "region1"

--- a/examples/compute/virtual_machine/106-marketplace-image-with-plan/configuration.tfvars
+++ b/examples/compute/virtual_machine/106-marketplace-image-with-plan/configuration.tfvars
@@ -1,0 +1,157 @@
+
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "southeastasia"
+  }
+  resource_defaults = {
+    virtual_machines = {
+        # set the below to enable az managed boot diagostics for vms
+        # this will be override if a user managed storage account is defined for the vm
+        # use_azmanaged_storage_for_boot_diagnostics = true
+    }
+  }
+
+  prefix = "test"
+}
+
+resource_groups = {
+  vm_region1 = {
+    name = "example-virtual-machine-rg1"
+  }
+}
+
+# Virtual machines
+virtual_machines = {
+
+  # Configuration to deploy a bastion host linux virtual machine
+  example_vm1 = {
+    resource_group_key                   = "vm_region1"
+    provision_vm_agent                   = true
+    # when boot_diagnostics_storage_account_key is empty string "", boot diagnostics will be put on azure managed storage
+    # when boot_diagnostics_storage_account_key is a non-empty string, it needs to point to the key of a user managed storage defined in diagnostic_storage_accounts
+    # if boot_diagnostics_storage_account_key is not defined, but global_settings.resource_defaults.virtual_machines.use_azmanaged_storage_for_boot_diagnostics is true, boot diagnostics will be put on azure managed storage
+    #boot_diagnostics_storage_account_key = "bootdiag_region1"
+
+    os_type = "linux"
+
+    # the auto-generated ssh key in keyvault secret. Secret name being {VM name}-ssh-public and {VM name}-ssh-private
+    keyvault_key = "example_vm_rg1"
+
+    # Define the number of networking cards to attach the virtual machine
+    networking_interfaces = {
+      nic0 = {
+        # Value of the keys from networking.tfvars
+        vnet_key                = "vnet_region1"
+        subnet_key              = "example"
+        name                    = "0"
+        enable_ip_forwarding    = false
+        internal_dns_name_label = "nic0"
+        public_ip_address_key   = "example_vm_pip1_rg1"
+        # example with external network objects
+        # subnet_id = "/subscriptions/sub-id/resourceGroups/test-manual/providers/Microsoft.Network/virtualNetworks/vnet/subnets/default"
+        # public_address_id = "/subscriptions/sub-id/resourceGroups/test-manual/providers/Microsoft.Network/publicIPAddresses/arnaudip"
+        # nsg_id = "/subscriptions/sub-id/resourceGroups/test-manual/providers/Microsoft.Network/networkSecurityGroups/nsgtest"
+
+      }
+    }
+
+    virtual_machine_settings = {
+      linux = {
+        name                            = "example_vm1"
+        size                            = "Standard_F2"
+        admin_username                  = "adminuser"
+        disable_password_authentication = true
+
+        # Value of the nic keys to attach the VM. The first one in the list is the default nic
+        network_interface_keys = ["nic0"]
+
+        os_disk = {
+          name                    = "example_vm1-os"
+          caching                 = "ReadWrite"
+          storage_account_type    = "Standard_LRS"
+          disk_encryption_set_key = "set1"
+        }
+
+        source_image_reference = {
+          publisher = "citrix"
+          offer     = "netscaler-130-ma-service-agent"
+          sku       = "netscaler-ma-service-agent"
+          version   = "latest"
+        }
+
+        plan = {
+          name = "netscaler-ma-service-agent"
+          publisher = "citrix"
+          product = "netscaler-130-ma-service-agent"
+        }
+        
+      }
+    }
+  }
+}
+
+
+
+
+keyvaults = {
+  example_vm_rg1 = {
+    name                        = "vmlinuxakv1"
+    resource_group_key          = "vm_region1"
+    sku_name                    = "standard"
+    soft_delete_enabled         = true
+    purge_protection_enabled    = true
+    enabled_for_disk_encryption = true
+    tags = {
+      env = "Standalone"
+    }
+    creation_policies = {
+      logged_in_user = {
+        secret_permissions = ["Set", "Get", "List", "Delete", "Purge", "Recover"]
+        key_permissions    = ["Get", "List", "Update", "Create", "Import", "Delete", "Recover", "Backup", "Restore", "Decrypt", "Encrypt", "UnwrapKey", "WrapKey", "Verify", "Sign", "Purge"]
+      }
+    }
+  }
+}
+
+keyvault_keys = {
+  key1 = {
+    keyvault_key       = "example_vm_rg1"
+    resource_group_key = "vm_region1"
+    name               = "disk-key"
+    key_type           = "RSA"
+    key_size           = "2048"
+    key_opts           = ["encrypt", "decrypt", "sign", "verify", "wrapKey", "unwrapKey"]
+  }
+}
+
+
+vnets = {
+  vnet_region1 = {
+    resource_group_key = "vm_region1"
+    vnet = {
+      name          = "virtual_machines"
+      address_space = ["10.100.100.0/24"]
+    }
+    specialsubnets = {}
+    subnets = {
+      example = {
+        name = "examples"
+        cidr = ["10.100.100.0/29"]
+      }
+    }
+
+  }
+}
+
+public_ip_addresses = {
+  example_vm_pip1_rg1 = {
+    name                    = "example_vm_pip1"
+    resource_group_key      = "vm_region1"
+    sku                     = "Standard"
+    allocation_method       = "Static"
+    ip_version              = "IPv4"
+    idle_timeout_in_minutes = "4"
+
+  }
+}

--- a/examples/compute/virtual_machine/106-marketplace-image-with-plan/configuration.tfvars
+++ b/examples/compute/virtual_machine/106-marketplace-image-with-plan/configuration.tfvars
@@ -8,9 +8,9 @@ global_settings = {
   }
   resource_defaults = {
     virtual_machines = {
-        # set the below to enable az managed boot diagostics for vms
-        # this will be override if a user managed storage account is defined for the vm
-        # use_azmanaged_storage_for_boot_diagnostics = true
+      # set the below to enable az managed boot diagostics for vms
+      # this will be override if a user managed storage account is defined for the vm
+      # use_azmanaged_storage_for_boot_diagnostics = true
     }
   }
 
@@ -28,8 +28,8 @@ virtual_machines = {
 
   # Configuration to deploy a bastion host linux virtual machine
   example_vm1 = {
-    resource_group_key                   = "vm_region1"
-    provision_vm_agent                   = true
+    resource_group_key = "vm_region1"
+    provision_vm_agent = true
     # when boot_diagnostics_storage_account_key is empty string "", boot diagnostics will be put on azure managed storage
     # when boot_diagnostics_storage_account_key is a non-empty string, it needs to point to the key of a user managed storage defined in diagnostic_storage_accounts
     # if boot_diagnostics_storage_account_key is not defined, but global_settings.resource_defaults.virtual_machines.use_azmanaged_storage_for_boot_diagnostics is true, boot diagnostics will be put on azure managed storage
@@ -83,11 +83,11 @@ virtual_machines = {
         }
 
         plan = {
-          name = "netscaler-ma-service-agent"
+          name      = "netscaler-ma-service-agent"
           publisher = "citrix"
-          product = "netscaler-130-ma-service-agent"
+          product   = "netscaler-130-ma-service-agent"
         }
-        
+
       }
     }
   }

--- a/modules/compute/virtual_machine/vm_linux.tf
+++ b/modules/compute/virtual_machine/vm_linux.tf
@@ -117,6 +117,16 @@ resource "azurerm_linux_virtual_machine" "vm" {
     }
   }
 
+  dynamic "plan" {
+    for_each = try(each.value.plan, false) == false ? [] : [1]
+
+    content {
+      name      = each.value.plan.name
+      product   = each.value.plan.product
+      publisher = each.value.plan.publisher
+    }
+  }
+
 }
 
 #


### PR DESCRIPTION
- Added 'plan' block for Linux Virtual Machines
- As a prerequisite user needs to accept the license agreements once per subscription for the image. 
  For more information - https://docs.microsoft.com/en-us/azure/virtual-machines/windows/cli-ps-findimage#accept-purchase-plan-terms

For this example: 

```
$agreementTerms=Get-AzMarketplaceterms -Publisher "citrix" -Product "netscaler-130-ma-service-agent" -Name "netscaler-ma-service-agent"

Set-AzMarketplaceTerms -Publisher "citrix" -Product "netscaler-130-ma-service-agent" -Name "netscaler-ma-service-agent" -Terms $agreementTerms -Accept
```