### PR TITLE
Updated remaining hardcoded Azure urls

### DIFF
--- a/modules/azuread/applications/scripts/grant_consent.sh
+++ b/modules/azuread/applications/scripts/grant_consent.sh
@@ -14,7 +14,9 @@ else
     resourceId=$(az ad sp show --id "${resourceAppId}" --query "objectId" -o tsv)
     echo " -resourceId: ${resourceId}"
 
-    URI=$(echo  "https://graph.microsoft.com/beta/servicePrincipals/${resourceId}/appRoleAssignments") && echo " - uri: $URI"
+    microsoft_graph_endpoint=$(az cloud show | jq -r ".endpoints.microsoftGraphResourceId")
+
+    URI=$(echo  "${microsoft_graph_endpoint}beta/servicePrincipals${resourceId}/appRoleAssignments") && echo " - uri: $URI"
 
     # grant consent (Application.ReadWrite.OwnedBy)
     JSON=$( jq -n \

--- a/modules/azuread/roles/scripts/set_ad_role.sh
+++ b/modules/azuread/roles/scripts/set_ad_role.sh
@@ -2,14 +2,16 @@
 
 set -e
 
+microsoft_graph_endpoint=$(az cloud show | jq -r ".endpoints.microsoftGraphResourceId")
+
 function enable_directory_role {
     # Verify the AD_ROLE_NAME has been activated in the directory
     # Permissions required - https://docs.microsoft.com/en-us/graph/api/directoryrole-post-directoryroles?view=graph-rest-1.0&tabs=http#permissions
 
     echo "Enabling directory role: ${AD_ROLE_NAME}"
-    ROLE_ID=$(az rest --method Get --uri https://graph.microsoft.com/v1.0/directoryRoleTemplates -o json | jq -r '.value[] | select(.displayName == "'"$(echo ${AD_ROLE_NAME})"'") | .id')
+    ROLE_ID=$(az rest --method Get --uri ${microsoft_graph_endpoint}v1.0/directoryRoleTemplates -o json | jq -r '.value[] | select(.displayName == "'"$(echo ${AD_ROLE_NAME})"'") | .id')
 
-    URI="https://graph.microsoft.com/v1.0/directoryRoles"
+    URI="${microsoft_graph_endpoint}v1.0/directoryRoles"
 
     JSON=$( jq -n \
                 --arg role_id ${ROLE_ID} \
@@ -25,21 +27,21 @@ echo "Directory role '${AD_ROLE_NAME}'"
 
 # Add service principal to AD Role
 
-export ROLE_AAD=$(az rest --method Get --uri https://graph.microsoft.com/v1.0/directoryRoles -o json | jq -r '.value[] | select(.displayName == "'"$(echo ${AD_ROLE_NAME})"'") | .id')
+export ROLE_AAD=$(az rest --method Get --uri ${microsoft_graph_endpoint}v1.0/directoryRoles -o json | jq -r '.value[] | select(.displayName == "'"$(echo ${AD_ROLE_NAME})"'") | .id')
 
 if [ "${ROLE_AAD}" == '' ]; then
     enable_directory_role
-    export ROLE_AAD=$(az rest --method Get --uri https://graph.microsoft.com/v1.0/directoryRoles -o json | jq -r '.value[] | select(.displayName == "'"$(echo ${AD_ROLE_NAME})"'") | .id')
+    export ROLE_AAD=$(az rest --method Get --uri ${microsoft_graph_endpoint}v1.0/directoryRoles -o json | jq -r '.value[] | select(.displayName == "'"$(echo ${AD_ROLE_NAME})"'") | .id')
 fi
 
 
 case "${METHOD}" in
     POST)
-        URI=$(echo  "https://graph.microsoft.com/v1.0/directoryRoles/${ROLE_AAD}/members/\$ref") && echo " - uri: $URI"
+        URI=$(echo  "${microsoft_graph_endpoint}v1.0/directoryRoles/${ROLE_AAD}/members/\$ref") && echo " - uri: $URI"
 
         # grant AAD role to the AAD APP
         JSON=$( jq -n \
-            --arg uri_role "https://graph.microsoft.com/v1.0/directoryObjects/${SERVICE_PRINCIPAL_OBJECT_ID}" \
+            --arg uri_role "${microsoft_graph_endpoint}v1.0/directoryObjects/${SERVICE_PRINCIPAL_OBJECT_ID}" \
             '{"@odata.id": $uri_role}' ) && echo " - body: $JSON"
 
         az rest --method ${METHOD} --uri $URI --header Content-Type=application/json --body "$JSON"
@@ -47,7 +49,7 @@ case "${METHOD}" in
         echo "Role '${AD_ROLE_NAME}' assigned to azure ad application"
         ;;
     DELETE)
-        URI=$(echo  "https://graph.microsoft.com/v1.0/directoryRoles/${ROLE_AAD}/members/${SERVICE_PRINCIPAL_OBJECT_ID}/\$ref") && echo " - uri: $URI"
+        URI=$(echo  "${microsoft_graph_endpoint}v1.0/directoryRoles/${ROLE_AAD}/members/${SERVICE_PRINCIPAL_OBJECT_ID}/\$ref") && echo " - uri: $URI"
         az rest --method ${METHOD} --uri ${URI}
         echo "Role '${AD_ROLE_NAME}' unassigned to azure ad application ${SERVICE_PRINCIPAL_OBJECT_ID}"
         ;;

--- a/modules/subscription_billing_role_assignment/billing_role_assignment.tf
+++ b/modules/subscription_billing_role_assignment/billing_role_assignment.tf
@@ -29,6 +29,7 @@ module "role_assignment_azuread_users" {
   principal_id       = var.principals.azuread_users[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.key].rbac_id
   role_definition_id = data.external.role_definition.result.id
   settings           = each.value
+  cloud              = var.cloud
 }
 
 
@@ -43,5 +44,6 @@ module "role_assignment_msi" {
   principal_id         = var.principals.managed_identities[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.key].principal_id
   role_definition_id   = data.external.role_definition.result.id
   settings             = each.value
+  cloud                = var.cloud
 }
 

--- a/modules/subscription_billing_role_assignment/billing_role_assignment.tf
+++ b/modules/subscription_billing_role_assignment/billing_role_assignment.tf
@@ -6,7 +6,7 @@ data "azurerm_billing_enrollment_account_scope" "sub" {
 data "external" "role_definition" {
   program = [
     "bash", "-c",
-    "az rest --method GET --url https://management.azure.com${local.billing_scope_id}/billingRoleDefinitions?api-version=2019-10-01-preview --query \"value[?properties.roleName=='${var.billing_role_definition_name}'].{id:id}[0]\" -o json"
+    "az rest --method GET --url ${var.cloud.resourceManager}${local.billing_scope_id}/billingRoleDefinitions?api-version=2019-10-01-preview --query \"value[?properties.roleName=='${var.billing_role_definition_name}'].{id:id}[0]\" -o json"
   ]
 
   #

--- a/modules/subscription_billing_role_assignment/role_assignment/billing_role_assignment.tf
+++ b/modules/subscription_billing_role_assignment/role_assignment/billing_role_assignment.tf
@@ -1,10 +1,11 @@
 locals {
-  api_version = "2019-10-01-preview"
+  api_version                 = "2019-10-01-preview"
+  microsoft_resource_endpoint = var.cloud.resourceManager
 }
 
 resource "null_resource" "subscription_creation_role" {
   triggers = {
-    url = format("https://management.azure.com%s/billingRoleAssignments/%s?api-version=%s&useCosmos=true", var.billing_scope_id, var.principal_id, local.api_version)
+    url = format("%s%s/billingRoleAssignments/%s?api-version=%s&useCosmos=true", local.microsoft_resource_endpoint, var.billing_scope_id, var.principal_id, local.api_version)
     properties = jsonencode(
       {
         properties = {

--- a/modules/subscription_billing_role_assignment/role_assignment/variables.tf
+++ b/modules/subscription_billing_role_assignment/role_assignment/variables.tf
@@ -3,6 +3,7 @@ variable "principal_id" {}
 variable "role_definition_id" {}
 variable "tenant_id" {}
 variable "settings" {}
+variable "cloud" {}
 variable "aad_user_impersonate" {
   default = null
 }

--- a/modules/subscription_billing_role_assignment/variables.tf
+++ b/modules/subscription_billing_role_assignment/variables.tf
@@ -1,6 +1,7 @@
 variable "client_config" {}
 variable "principals" {}
 variable "settings" {}
+variable "cloud" {}
 variable "keyvaults" {}
 variable "billing_role_definition_name" {
   default = "Enrollment account subscription creator"

--- a/modules/subscriptions/scripts/assign_subscription_to_mg.sh
+++ b/modules/subscriptions/scripts/assign_subscription_to_mg.sh
@@ -6,7 +6,10 @@ function MG_Subscription {
     # https://docs.microsoft.com/en-us/rest/api/resources/tags/createorupdateatscope
 
     echo "${METHOD} Management Group ${MG_ID} - subscription: ${SUBSCRIPTION_ID}"
-    URI="https://management.azure.com/providers/Microsoft.Management/managementGroups/${MG_ID}/subscriptions/${SUBSCRIPTION_ID}?api-version=2020-02-01"
+
+    microsoft_resource_endpoint=$(az cloud show | jq -r ".endpoints.resourceManager")
+
+    URI="${microsoft_resource_endpoint}providers/Microsoft.Management/managementGroups/${MG_ID}/subscriptions/${SUBSCRIPTION_ID}?api-version=2020-02-01"
 
     az rest --method ${METHOD} --uri $URI
 

--- a/modules/subscriptions/scripts/tags.sh
+++ b/modules/subscriptions/scripts/tags.sh
@@ -8,7 +8,10 @@ function subscription_tags {
     echo "Set tags to subscription: ${SUBSCRIPTION_ID}"
     echo " - tags:"
     echo "${TAGS}" | jq -r
-    URI="https://management.azure.com/subscriptions/${SUBSCRIPTION_ID}/providers/Microsoft.Resources/tags/default?api-version=2020-06-01"
+
+    microsoft_resource_endpoint=$(az cloud show | jq -r ".endpoints.resourceManager")
+
+    URI="${microsoft_resource_endpoint}subscriptions/${SUBSCRIPTION_ID}/providers/Microsoft.Resources/tags/default?api-version=2020-06-01"
     echo " - uri: ${URI}"
 
     az rest --method PUT --uri $URI --header Content-Type=application/json --body "${TAGS}"

--- a/subscriptions.tf
+++ b/subscriptions.tf
@@ -18,6 +18,7 @@ module "subscription_billing_role_assignments" {
 
   billing_role_definition_name = each.value.billing_role_definition_name
   client_config                = local.client_config
+  cloud                        = local.cloud
   keyvaults                    = local.combined_objects_keyvaults
   settings                     = each.value
   principals = {


### PR DESCRIPTION
Update removes hard coded Azure endpoints and replaces them with dynamically retrieved values from 'az cloud show'. 

This is required for working on different clouds such as AzureUSGovernment where these endpoints are different.