### PR TITLE
Updated local.combined_objects_azurerm_firewalls each.value iterator

### DIFF
--- a/networking.tf
+++ b/networking.tf
@@ -163,7 +163,7 @@ module "routes" {
   address_prefix            = each.value.address_prefix
   next_hop_type             = each.value.next_hop_type
   next_hop_in_ip_address    = try(lower(each.value.next_hop_type), null) == "virtualappliance" ? try(each.value.next_hop_in_ip_address, null) : null
-  next_hop_in_ip_address_fw = try(lower(each.value.next_hop_type), null) == "virtualappliance" ? try(try(local.combined_objects_azurerm_firewalls[local.client_config.landingzone_key][each.value.private_ip_keys.azurerm_firewall.key].ip_configuration[each.value.private_ip_keys.azurerm_firewall.interface_index].private_ip_address, local.combined_objects_azurerm_firewalls[each.value.lz_key][each.value.private_ip_keys.azurerm_firewall.key].ip_configuration[each.value.private_ip_keys.azurerm_firewall.interface_index].private_ip_address), null) : null
+  next_hop_in_ip_address_fw = try(lower(each.value.next_hop_type), null) == "virtualappliance" ? try(try(local.combined_objects_azurerm_firewalls[local.client_config.landingzone_key][each.value.private_ip_keys.azurerm_firewall.key].ip_configuration[each.value.private_ip_keys.azurerm_firewall.interface_index].private_ip_address, local.combined_objects_azurerm_firewalls[each.value.private_ip_keys.azurerm_firewall.lz_key][each.value.private_ip_keys.azurerm_firewall.key].ip_configuration[each.value.private_ip_keys.azurerm_firewall.interface_index].private_ip_address), null) : null
 }
 
 #


### PR DESCRIPTION
Added additional elements to iterator to allow `lz_key` to be specified inside the `private_ip_keys` structure

before:
```
azurerm_routes = {
  name  = {
    name = "name"
     ...
    lz_key = "lz_key_name"
    private_ip_keys = {
      ...
```
after:
```
azurerm_routes = {
  name  = {
    name = "name"
     ...
    private_ip_keys = {
      lz_key = "lz_key_name"
      ...          
```

