### PR TITLE
Add SQL Firewall rule

### DIFF
--- a/modules/databases/mssql_server/firewall_rule.tf
+++ b/modules/databases/mssql_server/firewall_rule.tf
@@ -1,0 +1,14 @@
+#
+# Firewall Rule
+#
+
+resource "azurerm_sql_firewall_rule" "mssql_firewall_rules" {
+
+  for_each = try(var.settings.mssql_firewall_rules, {})
+
+  name                = each.value.name
+  resource_group_name = var.resource_group_name
+  server_name         = azurerm_mssql_server.mssql.name
+  start_ip_address    = each.value.start_ip_address
+  end_ip_address      = each.value.end_ip_address
+}


### PR DESCRIPTION
Related Issue: [505](https://github.com/aztfmod/terraform-azurerm-caf/issues/505)

Add support toggling "Allow Azure Services" to a SQL DB Server

Add azurerm_sql_firewall_rule to SQL Server

![Screen Shot 2021-06-08 at 9 01 29 AM](https://user-images.githubusercontent.com/54150331/121238377-0b7ea280-c866-11eb-8e5b-481c01409bf9.png)
