### PR TITLE
Refactor aks subnets to take in a dictionary of key(s) and resource id 

### DIFF
--- a/modules/compute/aks/aks.tf
+++ b/modules/compute/aks/aks.tf
@@ -57,13 +57,13 @@ resource "azurerm_kubernetes_cluster" "aks" {
     max_pods                     = try(var.settings.default_node_pool.max_pods, 30)
     node_labels                  = try(var.settings.default_node_pool.node_labels, null)
     node_taints                  = try(var.settings.default_node_pool.node_taints, null)
-    vnet_subnet_id               = coalesce(
+    orchestrator_version         = try(var.settings.default_node_pool.orchestrator_version, try(var.settings.kubernetes_version, null))
+    tags                         = merge(try(var.settings.default_node_pool.tags, {}), local.tags)
+    vnet_subnet_id = coalesce(
       try(var.subnets[var.settings.default_node_pool.subnet_key].id, ""),
       try(var.subnets[var.settings.default_node_pool.subnet.key].id, ""),
       try(var.settings.default_node_pool.subnet.resource_id, "")
-      )
-    orchestrator_version         = try(var.settings.default_node_pool.orchestrator_version, try(var.settings.kubernetes_version, null))
-    tags                         = merge(try(var.settings.default_node_pool.tags, {}), local.tags)
+    )
   }
 
   dns_prefix = try(var.settings.dns_prefix, random_string.prefix.result)
@@ -238,11 +238,6 @@ resource "azurerm_kubernetes_cluster_node_pool" "nodepools" {
   name                  = each.value.name
   mode                  = try(each.value.mode, "User")
   kubernetes_cluster_id = azurerm_kubernetes_cluster.aks.id
-  vnet_subnet_id        = coalesce(
-    try(var.subnets[each.value.subnet_key].id, ""),
-    try(var.subnets[each.value.subnet.key].id, ""),
-    try(each.value.subnet.resource_id, "")
-  )
   vm_size               = each.value.vm_size
   os_disk_size_gb       = try(each.value.os_disk_size_gb, null)
   os_disk_type          = try(each.value.os_disk_type, null)
@@ -255,5 +250,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "nodepools" {
   node_taints           = try(each.value.node_taints, null)
   orchestrator_version  = try(each.value.orchestrator_version, try(var.settings.kubernetes_version, null))
   tags                  = merge(try(var.settings.default_node_pool.tags, {}), try(each.value.tags, {}))
-
+  vnet_subnet_id = coalesce(
+    try(var.subnets[each.value.subnet_key].id, ""),
+    try(var.subnets[each.value.subnet.key].id, ""),
+    try(each.value.subnet.resource_id, "")
+  )
 }

--- a/modules/compute/aks/aks.tf
+++ b/modules/compute/aks/aks.tf
@@ -57,7 +57,11 @@ resource "azurerm_kubernetes_cluster" "aks" {
     max_pods                     = try(var.settings.default_node_pool.max_pods, 30)
     node_labels                  = try(var.settings.default_node_pool.node_labels, null)
     node_taints                  = try(var.settings.default_node_pool.node_taints, null)
-    vnet_subnet_id               = var.subnets[var.settings.default_node_pool.subnet_key].id
+    vnet_subnet_id               = coalesce(
+      try(var.subnets[var.settings.default_node_pool.subnet_key].id, ""),
+      try(var.subnets[var.settings.default_node_pool.subnet.key].id, ""),
+      try(var.settings.default_node_pool.subnet.resource_id, "")
+      )
     orchestrator_version         = try(var.settings.default_node_pool.orchestrator_version, try(var.settings.kubernetes_version, null))
     tags                         = merge(try(var.settings.default_node_pool.tags, {}), local.tags)
   }
@@ -234,7 +238,11 @@ resource "azurerm_kubernetes_cluster_node_pool" "nodepools" {
   name                  = each.value.name
   mode                  = try(each.value.mode, "User")
   kubernetes_cluster_id = azurerm_kubernetes_cluster.aks.id
-  vnet_subnet_id        = var.subnets[each.value.subnet_key].id
+  vnet_subnet_id        = coalesce(
+    try(var.subnets[each.value.subnet_key].id, ""),
+    try(var.subnets[each.value.subnet.key].id, ""),
+    try(each.value.subnet.resource_id, "")
+  )
   vm_size               = each.value.vm_size
   os_disk_size_gb       = try(each.value.os_disk_size_gb, null)
   os_disk_type          = try(each.value.os_disk_type, null)


### PR DESCRIPTION
### Summary

- Convert subnet to accept a dictionary of key/values (landing zone key and subnet key) 
- Also Allow subnets to accept a resource id 
- This refactoring helps decouple the VNET/Subnet creation from the AKS construction set.

Example Usage in your aks config:
```bash

aks_clusters = {
  cluster_re1 = {
    name               = "aks-sample-cluster"
    resource_group_key = "aks_rg"
    .......
    vnet_key = "vnet"
    lz_key   = "swetha_resources" #example landing zone key

   # Example Usage - Using Resource ID in the dict
    default_node_pool = {
      name    = "..."
      vm_size = "Standard_DS2_v2"
      subnet = {
        resource_id = "/subscriptions/<subscription-id>/resourceGroups/<resource-group-name>/providers/Microsoft.Network/virtualNetworks/<vnet-id>/subnets/<subnet-id>       
      }
      ....
    }

    # Example Usage - Using a subnet key and lzkey in the dict
    node_pools = {
      pool = {
        name = "..."
        mode = "User"
        subnet = {         
          lz_key = "swetha_resources" 
          key    = "aks_node_pool"
        }
       ....
      }
    }

  }
}

```

Issue: https://github.com/aztfmod/terraform-azurerm-caf/issues/512
