### PR TITLE
Add support for remote rg in all resources

### DIFF
--- a/aks_clusters.tf
+++ b/aks_clusters.tf
@@ -11,10 +11,10 @@ module "aks_clusters" {
   client_config       = local.client_config
   diagnostics         = local.combined_diagnostics
   diagnostic_profiles = try(each.value.diagnostic_profiles, {})
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   settings            = each.value
   subnets             = lookup(each.value, "lz_key", null) == null ? local.combined_objects_networking[local.client_config.landingzone_key][each.value.vnet_key].subnets : local.combined_objects_networking[each.value.lz_key][each.value.vnet_key].subnets
-  resource_group      = local.resource_groups[each.value.resource_group_key]
+  resource_group      = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key]
   admin_group_object_ids = try(each.value.admin_groups.azuread_group_keys, null) == null ? null : try(each.value.admin_groups.ids, [
     for group_key in try(each.value.admin_groups.azuread_groups.keys, {}) : local.combined_objects_azuread_groups[local.client_config.landingzone_key][group_key].id
   ])

--- a/app_config.tf
+++ b/app_config.tf
@@ -4,11 +4,11 @@ module "app_config" {
   name     = each.value.name
 
   client_config       = local.client_config
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   combined_objects    = local.dynamic_app_config_combined_objects
   global_settings     = local.global_settings
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   settings            = each.value
   tags                = try(each.value.tags, {})
 }

--- a/app_config.tf
+++ b/app_config.tf
@@ -5,7 +5,7 @@ module "app_config" {
 
   client_config       = local.client_config
   location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   combined_objects    = local.dynamic_app_config_combined_objects
   global_settings     = local.global_settings
   base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}

--- a/app_service_environments.tf
+++ b/app_service_environments.tf
@@ -5,10 +5,10 @@ module "app_service_environments" {
   for_each = local.webapp.app_service_environments
 
   settings                  = each.value
-  resource_group_name       = local.resource_groups[each.value.resource_group_key].name
-  location                  = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name       = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location                  = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   tags                      = try(each.value.tags, null)
-  base_tags                 = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags                 = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   name                      = each.value.name
   kind                      = try(each.value.kind, "ASEV2")
   zone                      = try(each.value.zone, null)

--- a/app_service_plans.tf
+++ b/app_service_plans.tf
@@ -4,9 +4,9 @@ module "app_service_plans" {
 
   for_each = local.webapp.app_service_plans
 
-  resource_group_name        = local.resource_groups[each.value.resource_group_key].name
-  location                   = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
-  base_tags                  = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  resource_group_name        = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location                   = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  base_tags                  = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   app_service_environment_id = try(each.value.app_service_environment_key, null) == null ? null : try(local.combined_objects_app_service_environments[local.client_config.landingzone_key][each.value.app_service_environment_key].id, local.combined_objects_app_service_environments[each.value.lz_key][each.value.app_service_environment_key].id)
   tags                       = try(each.value.tags, null)
   kind                       = try(each.value.kind, null)

--- a/app_services.tf
+++ b/app_services.tf
@@ -8,8 +8,8 @@ module "app_services" {
 
   name                 = each.value.name
   client_config        = local.client_config
-  resource_group_name  = local.resource_groups[each.value.resource_group_key].name
-  location             = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name  = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location             = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   app_service_plan_id  = try(each.value.lz_key, null) == null ? local.combined_objects_app_service_plans[local.client_config.landingzone_key][each.value.app_service_plan_key].id : local.combined_objects_app_service_plans[each.value.lz_key][each.value.app_service_plan_key].id
   settings             = each.value.settings
   identity             = try(each.value.identity, null)
@@ -19,7 +19,7 @@ module "app_services" {
   global_settings      = local.global_settings
   dynamic_app_settings = try(each.value.dynamic_app_settings, {})
   combined_objects     = local.dynamic_app_settings_combined_objects
-  base_tags            = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags            = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   application_insight  = try(each.value.application_insight_key, null) == null ? null : module.azurerm_application_insights[each.value.application_insight_key]
   diagnostic_profiles  = try(each.value.diagnostic_profiles, null)
   diagnostics          = local.combined_diagnostics

--- a/application_gateways.tf
+++ b/application_gateways.tf
@@ -6,7 +6,7 @@ module "application_gateways" {
   global_settings               = local.global_settings
   client_config                 = local.client_config
   diagnostics                   = local.combined_diagnostics
-  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  resource_group_name           = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   location                      = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   settings                      = each.value
   sku_name                      = each.value.sku_name

--- a/application_gateways.tf
+++ b/application_gateways.tf
@@ -6,7 +6,7 @@ module "application_gateways" {
   global_settings               = local.global_settings
   client_config                 = local.client_config
   diagnostics                   = local.combined_diagnostics
-  resource_group_name           = local.resource_groups[each.value.resource_group_key].name
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   location                      = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   settings                      = each.value
   sku_name                      = each.value.sku_name

--- a/application_gateways.tf
+++ b/application_gateways.tf
@@ -7,12 +7,12 @@ module "application_gateways" {
   client_config                 = local.client_config
   diagnostics                   = local.combined_diagnostics
   resource_group_name           = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
-  location                      = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  location                      = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   settings                      = each.value
   sku_name                      = each.value.sku_name
   sku_tier                      = each.value.sku_tier
   vnets                         = local.combined_objects_networking
-  base_tags                     = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags                     = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   private_dns                   = lookup(each.value, "private_dns_records", null) == null ? {} : local.combined_objects_private_dns
   public_ip_addresses           = local.combined_objects_public_ip_addresses
   app_services                  = local.combined_objects_app_services

--- a/application_security_groups.tf
+++ b/application_security_groups.tf
@@ -5,9 +5,9 @@ module "application_security_groups" {
 
   settings            = each.value
   global_settings     = local.global_settings
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
 
 }
 

--- a/automations.tf
+++ b/automations.tf
@@ -6,9 +6,9 @@ module "automations" {
   global_settings     = local.global_settings
   settings            = each.value
   diagnostics         = local.combined_diagnostics
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
 }
 
 output "automations" {

--- a/availability_sets.tf
+++ b/availability_sets.tf
@@ -6,9 +6,9 @@ module "availability_sets" {
   client_config              = local.client_config
   settings                   = each.value
   name                       = each.value.name
-  resource_group_name        = local.resource_groups[each.value.resource_group_key].name
-  location                   = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
-  base_tags                  = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  resource_group_name        = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location                   = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  base_tags                  = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   availability_sets          = local.compute.availability_sets
   proximity_placement_groups = local.combined_objects_proximity_placement_groups
   ppg_id                     = try(module.proximity_placement_groups[each.value.proximity_placement_group_key].id, null)

--- a/azurerm_application_insights.tf
+++ b/azurerm_application_insights.tf
@@ -4,8 +4,8 @@ module "azurerm_application_insights" {
 
   prefix                                = local.global_settings.prefix
   tags                                  = lookup(each.value, "tags", null)
-  resource_group_name                   = local.resource_groups[each.value.resource_group_key].name
-  location                              = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name                   = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location                              = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   name                                  = lookup(each.value, "name", null)
   application_type                      = lookup(each.value, "application_type", "other")
   daily_data_cap_in_gb                  = lookup(each.value, "daily_data_cap_in_gb", null)
@@ -14,7 +14,7 @@ module "azurerm_application_insights" {
   sampling_percentage                   = lookup(each.value, "sampling_percentage", null)
   disable_ip_masking                    = lookup(each.value, "disable_ip_masking", null)
   global_settings                       = local.global_settings
-  base_tags                             = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags                             = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
 }
 
 output "application_insights" {

--- a/bastion_service.tf
+++ b/bastion_service.tf
@@ -19,9 +19,9 @@ resource "azurerm_bastion_host" "host" {
   for_each = try(local.compute.bastion_hosts, {})
 
   name                = azurecaf_name.host[each.key].result
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
-  tags                = try(local.global_settings.inherit_tags, false) ? merge(local.resource_groups[each.value.resource_group_key].tags, try(each.value.tags, null)) : try(each.value.tags, null)
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  tags                = try(local.global_settings.inherit_tags, false) ? merge(local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags, try(each.value.tags, null)) : try(each.value.tags, null)
 
   ip_configuration {
     name                 = each.value.name
@@ -38,7 +38,7 @@ module "bastion_host_diagnostics" {
   for_each = try(local.compute.bastion_hosts, {})
 
   resource_id       = azurerm_bastion_host.host[each.key].id
-  resource_location = local.resource_groups[each.value.resource_group_key].location
+  resource_location = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location
   diagnostics       = local.combined_diagnostics
   profiles          = try(each.value.diagnostic_profiles, {})
 }

--- a/container_registry.tf
+++ b/container_registry.tf
@@ -5,8 +5,8 @@ module "container_registry" {
   global_settings          = local.global_settings
   client_config            = local.client_config
   name                     = each.value.name
-  resource_group_name      = local.resource_groups[each.value.resource_group_key].name
-  location                 = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name      = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location                 = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   admin_enabled            = try(each.value.admin_enabled, false)
   sku                      = try(each.value.sku, "Basic")
   tags                     = try(each.value.tags, {})
@@ -17,7 +17,7 @@ module "container_registry" {
   diagnostic_profiles      = try(each.value.diagnostic_profiles, {})
   private_endpoints        = try(each.value.private_endpoints, {})
   resource_groups          = local.resource_groups
-  base_tags                = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags                = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   private_dns              = local.combined_objects_private_dns
 }
 

--- a/container_registry.tf
+++ b/container_registry.tf
@@ -16,7 +16,7 @@ module "container_registry" {
   diagnostics              = local.combined_diagnostics
   diagnostic_profiles      = try(each.value.diagnostic_profiles, {})
   private_endpoints        = try(each.value.private_endpoints, {})
-  resource_groups          = local.resource_groups
+  resource_groups          = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)]
   base_tags                = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   private_dns              = local.combined_objects_private_dns
 }

--- a/cosmos_db.tf
+++ b/cosmos_db.tf
@@ -2,11 +2,11 @@ module "cosmos_dbs" {
   source   = "./modules/databases/cosmos_dbs"
   for_each = local.database.cosmos_dbs
 
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   global_settings     = local.global_settings
   settings            = each.value
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
 }
 
 output "cosmos_dbs" {

--- a/data_factory.tf
+++ b/data_factory.tf
@@ -5,13 +5,13 @@ module "data_factory" {
   for_each = local.data_factory.data_factory
 
   name                 = each.value.name
-  resource_group_name  = local.resource_groups[each.value.resource_group_key].name
-  location             = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name  = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location             = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   github_configuration = try(each.value.github_configuration, null)
   identity             = try(each.value.identity, null)
   vsts_configuration   = try(each.value.vsts_configuration, null)
   global_settings      = local.global_settings
-  base_tags            = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags            = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   tags                 = try(each.value.tags, null)
 }
 
@@ -26,7 +26,7 @@ module "data_factory_pipeline" {
   for_each = local.data_factory.data_factory_pipeline
 
   name                = each.value.name
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   data_factory_name   = module.data_factory[each.value.data_factory_key].name
   description         = try(each.value.description, null)
   annotations         = try(each.value.annotations, null)
@@ -46,7 +46,7 @@ module "data_factory_trigger_schedule" {
   for_each = local.data_factory.data_factory_trigger_schedule
 
   name                = each.value.name
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   data_factory_name   = module.data_factory[each.value.data_factory_key].name
   pipeline_name       = module.data_factory_pipeline[each.value.data_factory_pipeline_key].name
   start_time          = try(each.value.start_time, null)

--- a/data_factory_datasets.tf
+++ b/data_factory_datasets.tf
@@ -5,7 +5,7 @@ module "data_factory_dataset_azure_blob" {
   for_each = local.data_factory.datasets.azure_blob
 
   name                  = each.value.name
-  resource_group_name   = local.resource_groups[each.value.resource_group_key].name
+  resource_group_name   = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   data_factory_name     = module.data_factory[each.value.data_factory_key].name
   linked_service_name   = local.data_factory.linked_services[each.value.linked_service_key]
   folder                = try(each.value.folder, null)
@@ -29,7 +29,7 @@ module "data_factory_dataset_cosmosdb_sqlapi" {
   for_each = local.data_factory.datasets.cosmosdb_sqlapi
 
   name                  = each.value.name
-  resource_group_name   = local.resource_groups[each.value.resource_group_key].name
+  resource_group_name   = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   data_factory_name     = module.data_factory[each.value.data_factory_key].name
   linked_service_name   = local.data_factory.linked_services[each.value.linked_service_key].name
   folder                = try(each.value.folder, null)
@@ -52,7 +52,7 @@ module "data_factory_dataset_delimited_text" {
   for_each = local.data_factory.datasets.delimited_text
 
   name                        = each.value.name
-  resource_group_name         = local.resource_groups[each.value.resource_group_key].name
+  resource_group_name         = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   data_factory_name           = module.data_factory[each.value.data_factory_key].name
   linked_service_name         = local.data_factory.linked_services[each.value.linked_service_key]
   folder                      = try(each.value.folder, null)
@@ -83,7 +83,7 @@ module "data_factory_dataset_http" {
   for_each = local.data_factory.datasets.http
 
   name                  = each.value.name
-  resource_group_name   = local.resource_groups[each.value.resource_group_key].name
+  resource_group_name   = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   data_factory_name     = module.data_factory[each.value.data_factory_key].name
   linked_service_name   = local.data_factory.linked_services[each.value.linked_service_key].name
   folder                = try(each.value.folder, null)
@@ -108,7 +108,7 @@ module "data_factory_dataset_json" {
   for_each = local.data_factory.datasets.json
 
   name                        = each.value.name
-  resource_group_name         = local.resource_groups[each.value.resource_group_key].name
+  resource_group_name         = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   data_factory_name           = module.data_factory[each.value.data_factory_key].name
   linked_service_name         = local.data_factory.linked_services[each.value.linked_service_key].name
   folder                      = try(each.value.folder, null)
@@ -133,7 +133,7 @@ module "data_factory_dataset_mysql" {
   for_each = local.data_factory.datasets.mysql
 
   name                  = each.value.name
-  resource_group_name   = local.resource_groups[each.value.resource_group_key].name
+  resource_group_name   = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   data_factory_name     = module.data_factory[each.value.data_factory_key].name
   linked_service_name   = local.data_factory.linked_services[each.value.linked_service_key].name
   folder                = try(each.value.folder, null)
@@ -156,7 +156,7 @@ module "data_factory_dataset_postgresql" {
   for_each = local.data_factory.datasets.postgresql
 
   name                  = each.value.name
-  resource_group_name   = local.resource_groups[each.value.resource_group_key].name
+  resource_group_name   = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   data_factory_name     = module.data_factory[each.value.data_factory_key].name
   linked_service_name   = local.data_factory.linked_services[each.value.linked_service_key].name
   folder                = try(each.value.folder, null)
@@ -179,7 +179,7 @@ module "data_factory_dataset_sql_server_table" {
   for_each = local.data_factory.datasets.sql_server_table
 
   name                  = each.value.name
-  resource_group_name   = local.resource_groups[each.value.resource_group_key].name
+  resource_group_name   = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   data_factory_name     = module.data_factory[each.value.data_factory_key].name
   linked_service_name   = local.data_factory.linked_services[each.value.linked_service_key].name
   folder                = try(each.value.folder, null)

--- a/data_factory_linked_services.tf
+++ b/data_factory_linked_services.tf
@@ -5,7 +5,7 @@ module "data_factory_linked_service_azure_blob_storage" {
   for_each = local.data_factory.linked_services.azure_blob_storage
 
   name                     = each.value.name
-  resource_group_name      = local.resource_groups[each.value.resource_group_key].name
+  resource_group_name      = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   data_factory_name        = module.data_factory[each.value.data_factory_key].name
   description              = try(each.value.description, null)
   integration_runtime_name = try(each.value.integration_runtime_name, null)

--- a/databricks.tf
+++ b/databricks.tf
@@ -2,13 +2,13 @@ module "databricks_workspaces" {
   source   = "./modules/analytics/databricks_workspace"
   for_each = local.database.databricks_workspaces
 
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   global_settings     = local.global_settings
   client_config       = local.client_config
   settings            = each.value
   vnets               = local.combined_objects_networking
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
 }
 
 output "databricks_workspaces" {

--- a/diagnostics.tf
+++ b/diagnostics.tf
@@ -74,7 +74,7 @@ module "diagnostic_log_analytics" {
 
   global_settings = local.global_settings
   log_analytics   = each.value
-  resource_groups = local.resource_groups
+  resource_groups = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)]
   base_tags       = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
 }
 

--- a/diagnostics.tf
+++ b/diagnostics.tf
@@ -29,9 +29,9 @@ module "diagnostic_storage_accounts" {
   global_settings     = local.global_settings
   client_config       = local.client_config
   storage_account     = each.value
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
 }
 
 resource "azurerm_storage_account_customer_managed_key" "diasacmk" {
@@ -52,10 +52,10 @@ module "diagnostic_event_hub_namespaces" {
 
   global_settings     = local.global_settings
   settings            = each.value
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   client_config       = local.client_config
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
 }
 
 module "diagnostic_event_hub_namespaces_diagnostics" {
@@ -75,7 +75,7 @@ module "diagnostic_log_analytics" {
   global_settings = local.global_settings
   log_analytics   = each.value
   resource_groups = local.resource_groups
-  base_tags       = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags       = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
 }
 
 module "diagnostic_log_analytics_diagnostics" {

--- a/disk_encryption_sets.tf
+++ b/disk_encryption_sets.tf
@@ -5,7 +5,7 @@ module "disk_encryption_sets" {
   global_settings   = local.global_settings
   client_config     = local.client_config
   settings          = each.value
-  resource_groups   = local.resource_groups
+  resource_groups   = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)]
   base_tags         = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   key_vault_key_ids = module.keyvault_keys
   keyvault_id       = local.combined_objects_keyvaults[try(each.value.keyvault.lz_key, local.client_config.landingzone_key)][each.value.keyvault.key].id

--- a/disk_encryption_sets.tf
+++ b/disk_encryption_sets.tf
@@ -6,7 +6,7 @@ module "disk_encryption_sets" {
   client_config     = local.client_config
   settings          = each.value
   resource_groups   = local.resource_groups
-  base_tags         = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags         = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   key_vault_key_ids = module.keyvault_keys
   keyvault_id       = local.combined_objects_keyvaults[try(each.value.keyvault.lz_key, local.client_config.landingzone_key)][each.value.keyvault.key].id
 }

--- a/documentation/conventions.md
+++ b/documentation/conventions.md
@@ -136,8 +136,8 @@ module "networking" {
   source   = "./modules/networking/virtual_network"
   for_each = local.networking.vnets
 
-  location                          = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
-  resource_group_name               = local.resource_groups[each.value.resource_group_key].name
+  location                          = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name               = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   settings                          = each.value
   network_security_group_definition = local.networking.network_security_group_definition
   route_tables                      = module.route_tables
@@ -145,7 +145,7 @@ module "networking" {
   diagnostics                       = local.combined_diagnostics
   global_settings                   = local.global_settings
   ddos_id                           = try(azurerm_network_ddos_protection_plan.ddos_protection_plan[each.value.ddos_services_key].id, "")
-  base_tags                         = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags                         = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   network_watchers                  = try(local.combined_objects_network_watchers, null)
 }
 ```

--- a/event_hubs.tf
+++ b/event_hubs.tf
@@ -6,8 +6,8 @@ module "event_hub_namespaces" {
   global_settings     = local.global_settings
   settings            = each.value
   storage_accounts    = local.combined_objects_storage_accounts
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   client_config       = local.client_config
   base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
 }
@@ -16,7 +16,7 @@ module "event_hub_namespace_auth_rules" {
   source   = "./modules/event_hubs/namespaces/auth_rules"
   for_each = try(var.event_hub_namespace_auth_rules, {})
 
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   client_config       = local.client_config
   global_settings     = local.global_settings
   settings            = each.value
@@ -87,20 +87,20 @@ module "event_hubs" {
   depends_on = [module.event_hub_namespaces]
   for_each   = try(var.event_hubs, {})
 
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   client_config       = local.client_config
   global_settings     = local.global_settings
   settings            = each.value
   namespace_name      = module.event_hub_namespaces[each.value.event_hub_namespace_key].name
   storage_account_id  = try(module.storage_accounts[each.value.storage_account_key].id, null)
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
 }
 
 module "event_hub_auth_rules" {
   source   = "./modules/event_hubs/hubs/auth_rules"
   for_each = try(var.event_hub_auth_rules, {})
 
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   client_config       = local.client_config
   global_settings     = local.global_settings
   settings            = each.value
@@ -117,7 +117,7 @@ module "event_hub_consumer_groups" {
   source   = "./modules/event_hubs/consumer_groups"
   for_each = try(var.event_hub_consumer_groups, {})
 
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   client_config       = local.client_config
   global_settings     = local.global_settings
   settings            = each.value

--- a/event_hubs.tf
+++ b/event_hubs.tf
@@ -70,10 +70,10 @@ locals {
             pe_key              = pe_key
             id                  = module.event_hub_namespaces[eh_ns_key].id
             settings            = pe
-            location            = local.resource_groups[pe.resource_group_key].location
-            resource_group_name = local.resource_groups[pe.resource_group_key].name
+            location            = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][pe.resource_group_key].location
+            resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][pe.resource_group_key].name
             subnet_id           = try(pe.vnet_key, null) == null ? null : try(local.combined_objects_networking[local.client_config.landingzone_key][pe.vnet_key].subnets[pe.subnet_key].id, local.combined_objects_networking[pe.lz_key][pe.vnet_key].subnets[pe.subnet_key].id)
-            base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[pe.resource_group_key].tags : {}
+            base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][pe.resource_group_key].tags : {}
           }
         ]
       ]

--- a/event_hubs.tf
+++ b/event_hubs.tf
@@ -70,10 +70,10 @@ locals {
             pe_key              = pe_key
             id                  = module.event_hub_namespaces[eh_ns_key].id
             settings            = pe
-            location            = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][pe.resource_group_key].location
-            resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][pe.resource_group_key].name
+            location            = local.combined_objects_resource_groups[try(pe.lz_key, local.client_config.landingzone_key)][pe.resource_group_key].location
+            resource_group_name = local.combined_objects_resource_groups[try(pe.lz_key, local.client_config.landingzone_key)][pe.resource_group_key].name
             subnet_id           = try(pe.vnet_key, null) == null ? null : try(local.combined_objects_networking[local.client_config.landingzone_key][pe.vnet_key].subnets[pe.subnet_key].id, local.combined_objects_networking[pe.lz_key][pe.vnet_key].subnets[pe.subnet_key].id)
-            base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][pe.resource_group_key].tags : {}
+            base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(pe.lz_key, local.client_config.landingzone_key)][pe.resource_group_key].tags : {}
           }
         ]
       ]

--- a/front_door_waf_policies.tf
+++ b/front_door_waf_policies.tf
@@ -1,9 +1,9 @@
 module "front_door_waf_policies" {
   source              = "./modules/networking/front_door_waf_policy"
   for_each            = local.networking.front_door_waf_policies
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   global_settings     = local.global_settings
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   settings            = each.value
 
 }

--- a/front_doors.tf
+++ b/front_doors.tf
@@ -2,14 +2,14 @@ module "front_doors" {
   source   = "./modules/networking/front_door"
   for_each = local.networking.front_doors
 
-  base_tags                     = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags                     = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   client_config                 = local.client_config
   diagnostics                   = local.combined_diagnostics
   front_door_waf_policies       = local.combined_objects_front_door_waf_policies
   global_settings               = local.global_settings
   keyvault_id                   = try(each.value.keyvault_key, null) == null ? null : try(local.combined_objects_keyvaults[local.client_config.landingzone_key][each.value.keyvault_key].id, local.combined_objects_keyvaults[each.value.lz_key][each.value.keyvault_key].id)
   keyvault_certificate_requests = local.combined_objects_keyvault_certificate_requests
-  resource_group_name           = local.resource_groups[each.value.resource_group_key].name
+  resource_group_name           = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   settings                      = each.value
 }
 

--- a/function_app.tf
+++ b/function_app.tf
@@ -8,8 +8,8 @@ module "function_apps" {
   client_config              = local.client_config
   dynamic_app_settings       = try(each.value.dynamic_app_settings, {})
   combined_objects           = local.dynamic_app_settings_combined_objects
-  resource_group_name        = local.resource_groups[each.value.resource_group_key].name
-  location                   = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name        = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location                   = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   app_service_plan_id        = try(each.value.lz_key, null) == null ? local.combined_objects_app_service_plans[local.client_config.landingzone_key][each.value.app_service_plan_key].id : local.combined_objects_app_service_plans[each.value.lz_key][each.value.app_service_plan_key].id
   settings                   = each.value.settings
   application_insight        = try(each.value.application_insight_key, null) == null ? null : module.azurerm_application_insights[each.value.application_insight_key]
@@ -19,7 +19,7 @@ module "function_apps" {
   storage_account_access_key = try(data.azurerm_storage_account.function_apps[each.key].primary_access_key, null)
   subnet_id                  = try(local.combined_objects_networking[try(each.value.settings.lz_key, local.client_config.landingzone_key)][each.value.settings.vnet_key].subnets[each.value.settings.subnet_key].id, null)
   global_settings            = local.global_settings
-  base_tags                  = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags                  = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   tags                       = try(each.value.tags, null)
 }
 

--- a/keyvault.tf
+++ b/keyvault.tf
@@ -3,16 +3,16 @@ module "keyvaults" {
   source   = "./modules/security/keyvault"
   for_each = var.keyvaults
 
-  global_settings    = local.global_settings
-  client_config      = local.client_config
-  settings           = each.value
-  resource_groups    = local.resource_groups
-  diagnostics        = local.combined_diagnostics
-  vnets              = local.combined_objects_networking
-  azuread_groups     = local.combined_objects_azuread_groups
-  managed_identities = local.combined_objects_managed_identities
-  base_tags          = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
-  private_dns        = local.combined_objects_private_dns
+  global_settings     = local.global_settings
+  client_config       = local.client_config
+  settings            = each.value
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  diagnostics         = local.combined_diagnostics
+  vnets               = local.combined_objects_networking
+  azuread_groups      = local.combined_objects_azuread_groups
+  managed_identities  = local.combined_objects_managed_identities
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  private_dns         = local.combined_objects_private_dns
 }
 
 #

--- a/keyvault.tf
+++ b/keyvault.tf
@@ -3,16 +3,16 @@ module "keyvaults" {
   source   = "./modules/security/keyvault"
   for_each = var.keyvaults
 
-  global_settings     = local.global_settings
-  client_config       = local.client_config
-  settings            = each.value
-  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
-  diagnostics         = local.combined_diagnostics
-  vnets               = local.combined_objects_networking
-  azuread_groups      = local.combined_objects_azuread_groups
-  managed_identities  = local.combined_objects_managed_identities
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
-  private_dns         = local.combined_objects_private_dns
+  global_settings    = local.global_settings
+  client_config      = local.client_config
+  settings           = each.value
+  resource_groups    = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)]
+  diagnostics        = local.combined_diagnostics
+  vnets              = local.combined_objects_networking
+  azuread_groups     = local.combined_objects_azuread_groups
+  managed_identities = local.combined_objects_managed_identities
+  base_tags          = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
+  private_dns        = local.combined_objects_private_dns
 }
 
 #

--- a/keyvault_certificate_issuers.tf
+++ b/keyvault_certificate_issuers.tf
@@ -3,12 +3,12 @@ module "keyvault_certificate_issuers" {
   depends_on = [module.keyvaults]
   for_each   = local.security.keyvault_certificate_issuers
 
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
-  location            = local.resource_groups[each.value.resource_group_key].location
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location            = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location
   global_settings     = local.global_settings
   settings            = each.value
   keyvault_id         = try(local.combined_objects_keyvaults[each.value.lz_key][each.value.keyvault_key].id, local.combined_objects_keyvaults[local.client_config.landingzone_key][each.value.keyvault_key].id)
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   password            = try(data.azurerm_key_vault_secret.certificate_issuer_password[each.key].value, each.value.cert_issuer_password)
 }
 

--- a/load_balancers.tf
+++ b/load_balancers.tf
@@ -2,7 +2,7 @@ module "load_balancers" {
   source   = "./modules/networking/load_balancers"
   for_each = try(local.networking.load_balancers, {})
 
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   public_ip_addresses = local.combined_objects_public_ip_addresses
   client_config       = local.client_config

--- a/load_balancers.tf
+++ b/load_balancers.tf
@@ -3,7 +3,7 @@ module "load_balancers" {
   for_each = try(local.networking.load_balancers, {})
 
   resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   public_ip_addresses = local.combined_objects_public_ip_addresses
   client_config       = local.client_config
   vnets               = local.combined_objects_networking
@@ -11,7 +11,7 @@ module "load_balancers" {
   diagnostics         = local.combined_diagnostics
   global_settings     = local.global_settings
   settings            = each.value
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   existing_resources = {
     virtual_machines = try(module.virtual_machines, {})
     #vm scale set will be added later

--- a/log_analytics.tf
+++ b/log_analytics.tf
@@ -6,7 +6,7 @@ module "log_analytics" {
   global_settings = local.global_settings
   log_analytics   = each.value
   resource_groups = local.resource_groups
-  base_tags       = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags       = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
 }
 
 module "log_analytics_diagnostics" {

--- a/log_analytics.tf
+++ b/log_analytics.tf
@@ -5,7 +5,7 @@ module "log_analytics" {
 
   global_settings = local.global_settings
   log_analytics   = each.value
-  resource_groups = local.resource_groups
+  resource_groups = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)]
   base_tags       = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
 }
 

--- a/logic_app.tf
+++ b/logic_app.tf
@@ -5,13 +5,13 @@ module "integration_service_environment" {
   for_each = local.logic_app.integration_service_environment
 
   name                       = each.value.name
-  resource_group_name        = local.resource_groups[each.value.resource_group_key].name
-  location                   = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name        = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location                   = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   sku_name                   = each.value.sku_name
   access_endpoint_type       = each.value.access_endpoint_type
   virtual_network_subnet_ids = each.value.virtual_network_subnet_ids
   global_settings            = local.global_settings
-  base_tags                  = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags                  = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   tags                       = try(each.value.tags, null)
 }
 
@@ -60,11 +60,11 @@ module "logic_app_integration_account" {
   for_each = local.logic_app.logic_app_integration_account
 
   name                = each.value.name
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   sku_name            = each.value.sku_name
   global_settings     = local.global_settings
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   tags                = try(each.value.tags, null)
 }
 
@@ -129,15 +129,15 @@ module "logic_app_workflow" {
   for_each = local.logic_app.logic_app_workflow
 
   name                               = each.value.name
-  resource_group_name                = local.resource_groups[each.value.resource_group_key].name
-  location                           = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name                = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location                           = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   integration_service_environment_id = try(each.value.integration_service_environment_key, null) != null ? try(each.value.lz_key, null) == null ? local.combined_objects_integration_service_environment[local.client_config.landingzone_key][each.value.integration_service_environment_key].id : local.combined_objects_integration_service_environment[each.value.lz_key][each.value.integration_service_environment_key].id : null
   logic_app_integration_account_id   = try(each.value.logic_app_integration_account_key, null) != null ? try(each.value.lz_key, null) == null ? local.combined_objects_logic_app_integration_account[local.client_config.landingzone_key][each.value.logic_app_integration_account_key].id : local.combined_objects_logic_app_integration_account[each.value.lz_key][each.value.logic_app_integration_account_key].id : null
   workflow_schema                    = try(each.value.workflow_schema, null)
   workflow_version                   = try(each.value.workflow_version, null)
   parameters                         = try(each.value.parameters, null)
   global_settings                    = local.global_settings
-  base_tags                          = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags                          = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   tags                               = try(each.value.tags, null)
 }
 

--- a/machine_learning.tf
+++ b/machine_learning.tf
@@ -3,15 +3,15 @@ module "machine_learning_workspaces" {
   for_each = local.database.machine_learning_workspaces
 
   client_config           = local.client_config
-  location                = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
-  resource_group_name     = local.resource_groups[each.value.resource_group_key].name
+  location                = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name     = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   global_settings         = local.global_settings
   settings                = each.value
   vnets                   = local.combined_objects_networking
   storage_account_id      = lookup(each.value, "storage_account_key") == null ? null : module.storage_accounts[each.value.storage_account_key].id
   keyvault_id             = lookup(each.value, "keyvault_key") == null ? null : module.keyvaults[each.value.keyvault_key].id
   application_insights_id = lookup(each.value, "application_insights_key") == null ? null : module.azurerm_application_insights[each.value.application_insights_key].id
-  base_tags               = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags               = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
 }
 
 output "machine_learning_workspaces" {

--- a/managed_identities.tf
+++ b/managed_identities.tf
@@ -4,11 +4,11 @@ module "managed_identities" {
   for_each = var.managed_identities
 
   name                = each.value.name
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
-  location            = local.resource_groups[each.value.resource_group_key].location
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location            = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location
   global_settings     = local.global_settings
   settings            = each.value
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
 }
 
 output "managed_identities" {

--- a/mariadb_servers.tf
+++ b/mariadb_servers.tf
@@ -12,8 +12,8 @@ module "mariadb_servers" {
   global_settings     = local.global_settings
   client_config       = local.client_config
   settings            = each.value
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   keyvault_id         = try(each.value.administrator_login_password, null) == null ? module.keyvaults[each.value.keyvault_key].id : null
   storage_accounts    = module.storage_accounts
   vnets               = local.combined_objects_networking
@@ -21,6 +21,6 @@ module "mariadb_servers" {
   azuread_groups      = local.combined_objects_azuread_groups
   private_endpoints   = try(each.value.private_endpoints, {})
   resource_groups     = try(each.value.private_endpoints, {}) == {} ? null : local.resource_groups
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   private_dns         = local.combined_objects_private_dns
 }

--- a/mariadb_servers.tf
+++ b/mariadb_servers.tf
@@ -20,7 +20,7 @@ module "mariadb_servers" {
   subnet_id           = try(each.value.vnet_key, null) == null ? null : try(local.combined_objects_networking[local.client_config.landingzone_key][each.value.vnet_key].subnets[each.value.subnet_key].id, local.combined_objects_networking[each.value.lz_key][each.value.vnet_key].subnets[each.value.subnet_key].id)
   azuread_groups      = local.combined_objects_azuread_groups
   private_endpoints   = try(each.value.private_endpoints, {})
-  resource_groups     = try(each.value.private_endpoints, {}) == {} ? null : local.resource_groups
+  resource_groups     = try(each.value.private_endpoints, {}) == {} ? null : local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)]
   base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   private_dns         = local.combined_objects_private_dns
 }

--- a/modules/security/keyvault/keyvault.tf
+++ b/modules/security/keyvault/keyvault.tf
@@ -18,7 +18,7 @@ resource "azurerm_key_vault" "keyvault" {
 
   name                            = azurecaf_name.keyvault.result
   location                        = lookup(var.settings, "region", null) == null ? var.resource_groups[var.settings.resource_group_key].location : var.global_settings.regions[var.settings.region]
-  resource_group_name             = var.resource_groups[var.settings.resource_group_key].name
+  resource_group_name             = var.resource_group_name
   tenant_id                       = var.client_config.tenant_id
   sku_name                        = try(var.settings.sku_name, "standard")
   tags                            = try(merge(var.base_tags, local.tags), {})

--- a/modules/security/keyvault/keyvault.tf
+++ b/modules/security/keyvault/keyvault.tf
@@ -18,7 +18,7 @@ resource "azurerm_key_vault" "keyvault" {
 
   name                            = azurecaf_name.keyvault.result
   location                        = lookup(var.settings, "region", null) == null ? var.resource_groups[var.settings.resource_group_key].location : var.global_settings.regions[var.settings.region]
-  resource_group_name             = var.resource_group_name
+  resource_group_name             = var.resource_groups[var.settings.resource_group_key].name
   tenant_id                       = var.client_config.tenant_id
   sku_name                        = try(var.settings.sku_name, "standard")
   tags                            = try(merge(var.base_tags, local.tags), {})

--- a/modules/security/keyvault/variables.tf
+++ b/modules/security/keyvault/variables.tf
@@ -4,7 +4,7 @@ variable "global_settings" {
 variable "client_config" {
   description = "Client configuration object (see module README.md)."
 }
-variable "resource_group_name" {}
+variable "resource_groups" {}
 variable "settings" {}
 variable "vnets" {
   default = {}

--- a/modules/security/keyvault/variables.tf
+++ b/modules/security/keyvault/variables.tf
@@ -4,7 +4,7 @@ variable "global_settings" {
 variable "client_config" {
   description = "Client configuration object (see module README.md)."
 }
-variable "resource_groups" {}
+variable "resource_group_name" {}
 variable "settings" {}
 variable "vnets" {
   default = {}

--- a/monitoring.tf
+++ b/monitoring.tf
@@ -3,7 +3,7 @@ module "service_health_alerts" {
   for_each            = local.shared_services.monitoring
   global_settings     = local.global_settings
   settings            = each.value
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
 
 }

--- a/mssql_databases.tf
+++ b/mssql_databases.tf
@@ -10,7 +10,7 @@ module "mssql_databases" {
   global_settings     = local.global_settings
   cloud               = local.cloud
   managed_identities  = local.combined_objects_managed_identities
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   settings            = each.value
   server_id           = try(local.combined_objects_mssql_servers[local.client_config.landingzone_key][each.value.mssql_server_key].id, local.combined_objects_mssql_servers[each.value.lz_key][each.value.mssql_server_key].id)
   server_name         = try(local.combined_objects_mssql_servers[local.client_config.landingzone_key][each.value.mssql_server_key].name, local.combined_objects_mssql_servers[each.value.lz_key][each.value.mssql_server_key].name)
@@ -18,7 +18,7 @@ module "mssql_databases" {
   storage_accounts    = module.storage_accounts
   diagnostic_profiles = try(each.value.diagnostic_profiles, null)
   diagnostics         = local.combined_diagnostics
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
 }
 
 

--- a/mssql_elastic_pools.tf
+++ b/mssql_elastic_pools.tf
@@ -13,9 +13,9 @@ module "mssql_elastic_pools" {
 
   global_settings     = local.global_settings
   settings            = each.value
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   server_name         = module.mssql_servers[each.value.mssql_server_key].name
 }
 
@@ -28,8 +28,8 @@ module "mssql_elastic_pools_remote" {
 
   global_settings     = local.global_settings
   settings            = each.value
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   server_name         = var.remote_objects.mssql_servers[each.value.lz_key][each.value.mssql_server_key].name
 }

--- a/mssql_servers.tf
+++ b/mssql_servers.tf
@@ -12,7 +12,7 @@ module "mssql_servers" {
   global_settings     = local.global_settings
   client_config       = local.client_config
   settings            = each.value
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   storage_accounts    = module.storage_accounts
   azuread_groups      = local.combined_objects_azuread_groups

--- a/mssql_servers.tf
+++ b/mssql_servers.tf
@@ -18,7 +18,7 @@ module "mssql_servers" {
   azuread_groups      = local.combined_objects_azuread_groups
   vnets               = local.combined_objects_networking
   private_endpoints   = try(each.value.private_endpoints, {})
-  resource_groups     = try(each.value.private_endpoints, {}) == {} ? null : local.resource_groups
+  resource_groups     = try(each.value.private_endpoints, {}) == {} ? null : local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)]
   base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   private_dns         = local.combined_objects_private_dns
 }

--- a/mssql_servers.tf
+++ b/mssql_servers.tf
@@ -13,13 +13,13 @@ module "mssql_servers" {
   client_config       = local.client_config
   settings            = each.value
   resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   storage_accounts    = module.storage_accounts
   azuread_groups      = local.combined_objects_azuread_groups
   vnets               = local.combined_objects_networking
   private_endpoints   = try(each.value.private_endpoints, {})
   resource_groups     = try(each.value.private_endpoints, {}) == {} ? null : local.resource_groups
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   private_dns         = local.combined_objects_private_dns
 }
 
@@ -56,7 +56,7 @@ module "mssql_failover_groups" {
   global_settings     = local.global_settings
   client_config       = local.client_config
   settings            = each.value
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   primary_server_name = local.combined_objects_mssql_servers[try(each.value.primary_server.lz_key, local.client_config.landingzone_key)][each.value.primary_server.sql_server_key].name
   secondary_server_id = local.combined_objects_mssql_servers[try(each.value.secondary_server.lz_key, local.client_config.landingzone_key)][each.value.secondary_server.sql_server_key].id
   databases           = local.combined_objects_mssql_databases

--- a/msssql_managed_instances.tf
+++ b/msssql_managed_instances.tf
@@ -17,7 +17,7 @@ module "mssql_managed_instances" {
   resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   location            = try(local.global_settings.regions[each.value.region], local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location)
   subnet_id           = local.combined_objects_networking[try(each.value.networking.lz_key, local.client_config.landingzone_key)][each.value.networking.vnet_key].subnets[each.value.networking.subnet_key].id
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
 }
 
 module "mssql_managed_instances_secondary" {
@@ -31,7 +31,7 @@ module "mssql_managed_instances_secondary" {
   location            = try(local.global_settings.regions[each.value.region], local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location)
   subnet_id           = local.combined_objects_networking[try(each.value.networking.lz_key, local.client_config.landingzone_key)][each.value.networking.vnet_key].subnets[each.value.networking.subnet_key].id
   primary_server_id   = module.mssql_managed_instances[each.value.primary_server.mi_server_key].id
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
 }
 
 module "mssql_mi_failover_groups" {

--- a/mysql_servers.tf
+++ b/mysql_servers.tf
@@ -12,8 +12,8 @@ module "mysql_servers" {
   global_settings     = local.global_settings
   settings            = each.value
   client_config       = local.client_config
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   keyvault_id         = try(each.value.administrator_login_password, null) == null ? module.keyvaults[each.value.keyvault_key].id : null
   storage_accounts    = module.storage_accounts
   azuread_groups      = module.azuread_groups
@@ -21,6 +21,6 @@ module "mysql_servers" {
   subnet_id           = try(each.value.vnet_key, null) == null ? null : try(local.combined_objects_networking[local.client_config.landingzone_key][each.value.vnet_key].subnets[each.value.subnet_key].id, local.combined_objects_networking[each.value.lz_key][each.value.vnet_key].subnets[each.value.subnet_key].id)
   private_endpoints   = try(each.value.private_endpoints, {})
   resource_groups     = try(each.value.private_endpoints, {}) == {} ? null : local.resource_groups
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   private_dns         = local.combined_objects_private_dns
 }

--- a/mysql_servers.tf
+++ b/mysql_servers.tf
@@ -20,7 +20,7 @@ module "mysql_servers" {
   vnets               = local.combined_objects_networking
   subnet_id           = try(each.value.vnet_key, null) == null ? null : try(local.combined_objects_networking[local.client_config.landingzone_key][each.value.vnet_key].subnets[each.value.subnet_key].id, local.combined_objects_networking[each.value.lz_key][each.value.vnet_key].subnets[each.value.subnet_key].id)
   private_endpoints   = try(each.value.private_endpoints, {})
-  resource_groups     = try(each.value.private_endpoints, {}) == {} ? null : local.resource_groups
+  resource_groups     = try(each.value.private_endpoints, {}) == {} ? null : local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)]
   base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   private_dns         = local.combined_objects_private_dns
 }

--- a/netapp.tf
+++ b/netapp.tf
@@ -8,7 +8,7 @@ module "netapp_accounts" {
   resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   vnets               = local.combined_objects_networking
   location            = try(local.global_settings.regions[each.value.region], local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location)
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
 }
 
 output "netapp_accounts" {

--- a/network_security_groups.tf
+++ b/network_security_groups.tf
@@ -6,10 +6,10 @@ module "network_security_groups" {
     if try(value.version, 0) == 1
   }
 
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   diagnostics         = local.combined_diagnostics
   global_settings     = local.global_settings
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   settings            = each.value
 

--- a/network_security_groups.tf
+++ b/network_security_groups.tf
@@ -10,7 +10,7 @@ module "network_security_groups" {
   diagnostics         = local.combined_diagnostics
   global_settings     = local.global_settings
   location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   settings            = each.value
 
   // Module to support the NSG creation outside of the a subnet

--- a/networking.tf
+++ b/networking.tf
@@ -30,7 +30,7 @@ module "networking" {
   network_security_groups           = module.network_security_groups
   network_security_group_definition = local.networking.network_security_group_definition
   network_watchers                  = try(local.combined_objects_network_watchers, null)
-  resource_group_name               = local.resource_groups[each.value.resource_group_key].name
+  resource_group_name               = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   route_tables                      = module.route_tables
   settings                          = each.value
   tags                              = try(each.value.tags, null)

--- a/networking.tf
+++ b/networking.tf
@@ -21,12 +21,12 @@ module "networking" {
   for_each = local.networking.vnets
 
   application_security_groups       = local.combined_objects_application_security_groups
-  base_tags                         = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags                         = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   client_config                     = local.client_config
   ddos_id                           = try(azurerm_network_ddos_protection_plan.ddos_protection_plan[each.value.ddos_services_key].id, "")
   diagnostics                       = local.combined_diagnostics
   global_settings                   = local.global_settings
-  location                          = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  location                          = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   network_security_groups           = module.network_security_groups
   network_security_group_definition = local.networking.network_security_group_definition
   network_watchers                  = try(local.combined_objects_network_watchers, null)
@@ -60,8 +60,8 @@ module "public_ip_addresses" {
   for_each = local.networking.public_ip_addresses
 
   name                       = azurecaf_name.public_ip_addresses[each.key].result
-  resource_group_name        = local.resource_groups[each.value.resource_group_key].name
-  location                   = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name        = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location                   = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   sku                        = try(each.value.sku, "Basic")
   allocation_method          = try(each.value.allocation_method, "Dynamic")
   ip_version                 = try(each.value.ip_version, "IPv4")
@@ -73,7 +73,7 @@ module "public_ip_addresses" {
   zones                      = try(each.value.zones, null)
   diagnostic_profiles        = try(each.value.diagnostic_profiles, {})
   diagnostics                = local.combined_diagnostics
-  base_tags                  = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags                  = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
 }
 
 
@@ -133,11 +133,11 @@ module "route_tables" {
   for_each = local.networking.route_tables
 
   name                          = azurecaf_name.route_tables[each.key].result
-  resource_group_name           = local.resource_groups[each.value.resource_group_key].name
-  location                      = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name           = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location                      = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   disable_bgp_route_propagation = try(each.value.disable_bgp_route_propagation, null)
   tags                          = try(each.value.tags, null)
-  base_tags                     = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags                     = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
 }
 
 resource "azurecaf_name" "routes" {
@@ -158,7 +158,7 @@ module "routes" {
   for_each = local.networking.azurerm_routes
 
   name                      = azurecaf_name.routes[each.key].result
-  resource_group_name       = local.resource_groups[each.value.resource_group_key].name
+  resource_group_name       = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   route_table_name          = module.route_tables[each.value.route_table_key].name
   address_prefix            = each.value.address_prefix
   next_hop_type             = each.value.next_hop_type
@@ -189,9 +189,9 @@ resource "azurerm_network_ddos_protection_plan" "ddos_protection_plan" {
   for_each = local.networking.ddos_services
 
   name                = azurecaf_name.ddos_protection_plan[each.key].result
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
-  tags                = try(local.global_settings.inherit_tags, false) ? merge(local.resource_groups[each.value.resource_group_key].tags, each.value.tags) : try(each.value.tags, null)
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  tags                = try(local.global_settings.inherit_tags, false) ? merge(local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags, each.value.tags) : try(each.value.tags, null)
 }
 
 #
@@ -203,10 +203,10 @@ module "network_watchers" {
   source   = "./modules/networking/network_watcher"
   for_each = local.networking.network_watchers
 
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   settings            = each.value
   tags                = try(each.value.tags, null)
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   global_settings     = local.global_settings
 }

--- a/networking_dns_zones.tf
+++ b/networking_dns_zones.tf
@@ -2,10 +2,10 @@ module "dns_zones" {
   source   = "./modules/networking/dns_zone"
   for_each = try(local.networking.dns_zones, {})
 
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   client_config       = local.client_config
   global_settings     = local.global_settings
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   settings            = each.value
 
   resource_ids = {

--- a/networking_domain_name_registrations.tf
+++ b/networking_domain_name_registrations.tf
@@ -2,10 +2,10 @@ module "domain_name_registrations" {
   source   = "./modules/networking/domain_name_registrations"
   for_each = try(local.networking.domain_name_registrations, {})
 
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   dns_zone_id         = try(each.value.dns_zone.lz_key, null) == null ? local.combined_objects_dns_zones[local.client_config.landingzone_key][each.value.dns_zone.key].id : local.combined_objects_dns_zones[each.value.dns_zone.lz_key][each.value.dns_zone.key].id
   name                = try(each.value.name, "") == "" ? try(local.combined_objects_dns_zones[local.client_config.landingzone_key][each.value.dns_zone.key].name, local.combined_objects_dns_zones[each.value.dns_zone.lz_key][each.value.dns_zone.key].name) : ""
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   settings            = each.value
 }
 

--- a/networking_express_route.tf
+++ b/networking_express_route.tf
@@ -27,7 +27,7 @@ module "express_route_circuit_authorizations" {
   for_each = local.networking.express_route_circuit_authorizations
 
   settings                   = each.value
-  resource_group_name        = try(local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name, null) == null ? module.express_route_circuits[each.value.express_route_key].resource_group_name : local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  resource_group_name        = try(local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name, module.express_route_circuits[each.value.express_route_key].resource_group_name)
   express_route_circuit_name = module.express_route_circuits[each.value.express_route_key].name
 }
 

--- a/networking_express_route.tf
+++ b/networking_express_route.tf
@@ -9,9 +9,9 @@ module "express_route_circuits" {
   for_each = local.networking.express_route_circuits
 
   settings            = each.value
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   resource_groups     = local.resource_groups
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   diagnostics         = local.combined_diagnostics
   global_settings     = local.global_settings
 }
@@ -27,7 +27,7 @@ module "express_route_circuit_authorizations" {
   for_each = local.networking.express_route_circuit_authorizations
 
   settings                   = each.value
-  resource_group_name        = try(local.resource_groups[each.value.resource_group_key].name, null) == null ? module.express_route_circuits[each.value.express_route_key].resource_group_name : local.resource_groups[each.value.resource_group_key].name
+  resource_group_name        = try(local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name, null) == null ? module.express_route_circuits[each.value.express_route_key].resource_group_name : local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   express_route_circuit_name = module.express_route_circuits[each.value.express_route_key].name
 }
 

--- a/networking_express_route.tf
+++ b/networking_express_route.tf
@@ -10,7 +10,7 @@ module "express_route_circuits" {
 
   settings            = each.value
   resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
-  resource_groups     = local.resource_groups
+  resource_groups     = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)]
   location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   diagnostics         = local.combined_diagnostics
   global_settings     = local.global_settings

--- a/networking_firewall.tf
+++ b/networking_firewall.tf
@@ -9,10 +9,10 @@ module "azurerm_firewalls" {
   client_config       = local.client_config
   global_settings     = local.global_settings
   name                = each.value.name
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   tags                = try(each.value.tags, null)
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   subnet_id           = module.networking[each.value.vnet_key].subnets["AzureFirewallSubnet"].id
   public_ip_id        = try(module.public_ip_addresses[each.value.public_ip_key].id, null)
   public_ip_addresses = try(module.public_ip_addresses, null)
@@ -30,10 +30,10 @@ module "azurerm_firewall_policies" {
 
   global_settings     = local.global_settings
   name                = each.value.name
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   tags                = try(each.value.tags, null)
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   policy_settings     = each.value
 }
 

--- a/networking_ip_groups.tf
+++ b/networking_ip_groups.tf
@@ -7,11 +7,11 @@ module "ip_groups" {
   global_settings = local.global_settings
   client_config   = local.client_config
   name            = each.value.name
-  resource_group  = local.resource_groups[each.value.resource_group_key]
+  resource_group  = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key]
   tags            = try(each.value.tags, null)
   vnet            = lookup(each.value, "cidrs", null) != null ? null : lookup(each.value, "lz_key", null) == null ? local.combined_objects_networking[local.client_config.landingzone_key][each.value.vnet_key] : local.combined_objects_networking[each.value.lz_key][each.value.vnet_key]
   settings        = each.value
-  base_tags       = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags       = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
 }
 
 output "ip_groups" {

--- a/networking_private_dns.tf
+++ b/networking_private_dns.tf
@@ -7,12 +7,12 @@ module "private_dns" {
   global_settings     = local.global_settings
   client_config       = local.client_config
   name                = each.value.name
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   records             = try(each.value.records, {})
   vnet_links          = try(each.value.vnet_links, {})
   tags                = try(each.value.tags, null)
   vnets               = local.combined_objects_networking
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
 }
 
 output "private_dns" {

--- a/networking_private_links.tf
+++ b/networking_private_links.tf
@@ -9,7 +9,7 @@ module "private_endpoints" {
   private_endpoints = var.networking.private_endpoints
   private_dns       = local.combined_objects_private_dns
   vnet              = try(local.combined_objects_networking[each.value.lz_key][each.value.vnet_key], local.combined_objects_networking[local.client_config.landingzone_key][each.value.vnet_key])
-  base_tags         = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags         = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
 
   remote_objects = {
     diagnostic_storage_accounts     = local.combined_diagnostics.storage_accounts

--- a/networking_private_links.tf
+++ b/networking_private_links.tf
@@ -4,7 +4,7 @@ module "private_endpoints" {
 
   global_settings   = local.global_settings
   client_config     = local.client_config
-  resource_groups   = local.resource_groups
+  resource_groups   = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)]
   settings          = each.value
   private_endpoints = var.networking.private_endpoints
   private_dns       = local.combined_objects_private_dns

--- a/networking_virtual_hub_er_connection.tf
+++ b/networking_virtual_hub_er_connection.tf
@@ -17,12 +17,12 @@ module "virtual_hub_er_gateway_connections" {
   )
 
   location = lookup(each.value, "region", null) == null ? coalesce(
-    try(local.resource_groups[each.value.resource_group_key].location, null),
+    try(local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location, null),
     try(local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][each.value.resource_group.key].location, null)
   ) : local.global_settings.regions[each.value.region]
 
   resource_group_name = coalesce(
-    try(local.resource_groups[each.value.resource_group_key].name, null),
+    try(local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name, null),
     try(local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][each.value.resource_group.key].name, null)
   )
 

--- a/networking_virtual_wan.tf
+++ b/networking_virtual_wan.tf
@@ -17,12 +17,12 @@ module "virtual_wans" {
 
   client_config       = local.client_config
   settings            = each.value
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   resource_groups     = local.resource_groups
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   diagnostics         = local.combined_diagnostics
   global_settings     = local.global_settings
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   virtual_networks    = local.combined_objects_networking
   public_ip_addresses = local.combined_objects_public_ip_addresses
 }

--- a/networking_virtual_wan.tf
+++ b/networking_virtual_wan.tf
@@ -18,7 +18,7 @@ module "virtual_wans" {
   client_config       = local.client_config
   settings            = each.value
   resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
-  resource_groups     = local.resource_groups
+  resource_groups     = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)]
   location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   diagnostics         = local.combined_diagnostics
   global_settings     = local.global_settings

--- a/networking_vngw.tf
+++ b/networking_vngw.tf
@@ -2,15 +2,15 @@ module "virtual_network_gateways" {
   source   = "./modules/networking/virtual_network_gateways"
   for_each = try(local.networking.virtual_network_gateways, {})
 
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   public_ip_addresses = local.combined_objects_public_ip_addresses
   diagnostics         = local.combined_diagnostics
   client_config       = local.client_config
   vnets               = local.combined_objects_networking
   global_settings     = local.global_settings
   settings            = each.value
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   depends_on = [
     module.networking.public_ip_addresses
   ]
@@ -20,14 +20,14 @@ module "virtual_network_gateway_connections" {
   source   = "./modules/networking/virtual_network_gateway_connections"
   for_each = try(local.networking.virtual_network_gateway_connections, {})
 
-  resource_group_name      = local.resource_groups[each.value.resource_group_key].name
-  location                 = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name      = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location                 = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   global_settings          = local.global_settings
   settings                 = each.value
   diagnostics              = local.combined_diagnostics
   client_config            = local.client_config
   local_network_gateway_id = try(module.local_network_gateways[each.value.local_network_gateway_key].id, null)
-  base_tags                = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags                = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
 
   virtual_network_gateway_id = coalesce(
     try(module.virtual_network_gateways[each.value.virtual_network_gateway_key].id, null)
@@ -54,9 +54,9 @@ module "virtual_network_gateway_connections" {
 module "local_network_gateways" {
   source              = "./modules/networking/local_network_gateways"
   for_each            = try(local.networking.local_network_gateways, {})
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   global_settings     = local.global_settings
   settings            = each.value
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
 }

--- a/postgresql_servers.tf
+++ b/postgresql_servers.tf
@@ -13,8 +13,8 @@ module "postgresql_servers" {
   global_settings     = local.global_settings
   client_config       = local.client_config
   settings            = each.value
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   keyvault_id         = try(each.value.administrator_login_password, null) == null ? module.keyvaults[each.value.keyvault_key].id : null
   storage_accounts    = module.storage_accounts
   azuread_groups      = module.azuread_groups
@@ -22,6 +22,6 @@ module "postgresql_servers" {
   subnet_id           = try(each.value.vnet_key, null) == null ? null : try(local.combined_objects_networking[local.client_config.landingzone_key][each.value.vnet_key].subnets[each.value.subnet_key].id, local.combined_objects_networking[each.value.lz_key][each.value.vnet_key].subnets[each.value.subnet_key].id)
   private_endpoints   = try(each.value.private_endpoints, {})
   resource_groups     = try(each.value.private_endpoints, {}) == {} ? null : local.resource_groups
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   private_dns         = local.combined_objects_private_dns
 }

--- a/postgresql_servers.tf
+++ b/postgresql_servers.tf
@@ -21,7 +21,7 @@ module "postgresql_servers" {
   vnets               = local.combined_objects_networking
   subnet_id           = try(each.value.vnet_key, null) == null ? null : try(local.combined_objects_networking[local.client_config.landingzone_key][each.value.vnet_key].subnets[each.value.subnet_key].id, local.combined_objects_networking[each.value.lz_key][each.value.vnet_key].subnets[each.value.subnet_key].id)
   private_endpoints   = try(each.value.private_endpoints, {})
-  resource_groups     = try(each.value.private_endpoints, {}) == {} ? null : local.resource_groups
+  resource_groups     = try(each.value.private_endpoints, {}) == {} ? null : local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)]
   base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   private_dns         = local.combined_objects_private_dns
 }

--- a/proximity_placement_groups.tf
+++ b/proximity_placement_groups.tf
@@ -7,9 +7,9 @@ module "proximity_placement_groups" {
   global_settings     = local.global_settings
   client_config       = local.client_config
   name                = each.value.name
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
 }
 
 

--- a/recovery_vaults.tf
+++ b/recovery_vaults.tf
@@ -9,12 +9,12 @@ module "recovery_vaults" {
   diagnostics         = local.combined_diagnostics
   identity            = try(each.value.identity, null)
   resource_groups     = local.resource_groups
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   vnets               = try(local.combined_objects_networking, {})
   private_endpoints   = try(each.value.private_endpoints, {})
   private_dns         = local.combined_objects_private_dns
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
 }
 
 output "recovery_vaults" {

--- a/recovery_vaults.tf
+++ b/recovery_vaults.tf
@@ -8,7 +8,7 @@ module "recovery_vaults" {
   settings            = each.value
   diagnostics         = local.combined_diagnostics
   identity            = try(each.value.identity, null)
-  resource_groups     = local.resource_groups
+  resource_groups     = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)]
   resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   vnets               = try(local.combined_objects_networking, {})

--- a/redis_caches.tf
+++ b/redis_caches.tf
@@ -4,13 +4,13 @@ module "redis_caches" {
   depends_on = [module.networking]
   for_each   = local.database.azurerm_redis_caches
 
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   diagnostic_profiles = try(each.value.diagnostic_profiles, null)
   diagnostics         = local.combined_diagnostics
   global_settings     = local.global_settings
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   redis               = each.value.redis
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   subnet_id           = try(local.combined_objects_networking[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id, null)
   tags                = try(each.value.tags, null)
 

--- a/shared_image_gallery.tf
+++ b/shared_image_gallery.tf
@@ -2,13 +2,13 @@ module "shared_image_galleries" {
   source   = "./modules/shared_image_gallery/image_galleries"
   for_each = try(local.shared_services.shared_image_galleries, {})
 
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   diagnostics         = local.diagnostics
   client_config       = local.client_config
   global_settings     = local.global_settings
   settings            = each.value
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   depends_on = [
     module.keyvaults,
   ]
@@ -18,14 +18,14 @@ module "image_definitions" {
   source   = "./modules/shared_image_gallery/image_definitions"
   for_each = try(local.shared_services.image_definitions, {})
 
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   diagnostics         = local.diagnostics
   client_config       = local.client_config
   global_settings     = local.global_settings
   gallery_name        = module.shared_image_galleries[each.value.gallery_key].name
   settings            = each.value
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
 
 }
 
@@ -33,8 +33,8 @@ module "packer_service_principal" {
   source   = "./modules/shared_image_gallery/packer_service_principal"
   for_each = try(local.shared_services.packer_service_principal, {})
 
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   client_config       = local.client_config
   global_settings     = local.global_settings
   subscription        = data.azurerm_subscription.primary.subscription_id
@@ -43,7 +43,7 @@ module "packer_service_principal" {
   image_name          = module.image_definitions[each.value.shared_image_gallery_destination.image_key].name
   key_vault_id        = lookup(each.value, "keyvault_key") == null ? null : module.keyvaults[each.value.keyvault_key].id
   settings            = each.value
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   depends_on = [
     module.shared_image_galleries,
     module.image_definitions,

--- a/storage_accounts.tf
+++ b/storage_accounts.tf
@@ -7,12 +7,12 @@ module "storage_accounts" {
   client_config       = local.client_config
   storage_account     = each.value
   resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   vnets               = local.combined_objects_networking
   private_endpoints   = try(each.value.private_endpoints, {})
   resource_groups     = try(each.value.private_endpoints, {}) == {} ? null : local.resource_groups
   recovery_vaults     = local.combined_objects_recovery_vaults
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   private_dns         = local.combined_objects_private_dns
 }
 

--- a/storage_accounts.tf
+++ b/storage_accounts.tf
@@ -6,7 +6,7 @@ module "storage_accounts" {
   global_settings     = local.global_settings
   client_config       = local.client_config
   storage_account     = each.value
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   vnets               = local.combined_objects_networking
   private_endpoints   = try(each.value.private_endpoints, {})

--- a/storage_accounts.tf
+++ b/storage_accounts.tf
@@ -10,7 +10,7 @@ module "storage_accounts" {
   location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   vnets               = local.combined_objects_networking
   private_endpoints   = try(each.value.private_endpoints, {})
-  resource_groups     = try(each.value.private_endpoints, {}) == {} ? null : local.resource_groups
+  resource_groups     = try(each.value.private_endpoints, {}) == {} ? null : local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)]
   recovery_vaults     = local.combined_objects_recovery_vaults
   base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   private_dns         = local.combined_objects_private_dns

--- a/synapses.tf
+++ b/synapses.tf
@@ -3,13 +3,13 @@ module "synapse_workspaces" {
   depends_on = [module.keyvault_access_policies, module.keyvault_access_policies_azuread_apps]
   for_each   = local.database.synapse_workspaces
 
-  location                             = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
-  resource_group_name                  = local.resource_groups[each.value.resource_group_key].name
+  location                             = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name                  = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   global_settings                      = local.global_settings
   settings                             = each.value
   storage_data_lake_gen2_filesystem_id = try(each.value.lz_key, null) == null ? local.combined_objects_storage_accounts[local.client_config.landingzone_key][each.value.data_lake_filesystem.storage_account_key].data_lake_filesystems[each.value.data_lake_filesystem.container_key].id : local.combined_objects_storage_accounts[each.value.lz_key][each.value.data_lake_filesystem.storage_account_key].data_lake_filesystems[each.value.data_lake_filesystem.container_key].id
   keyvault_id                          = try(each.value.sql_administrator_login_password, null) == null ? module.keyvaults[each.value.keyvault_key].id : null
-  base_tags                            = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags                            = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
 }
 
 output "synapse_workspaces" {

--- a/virtual_machines.tf
+++ b/virtual_machines.tf
@@ -27,7 +27,7 @@ module "virtual_machines" {
   disk_encryption_sets       = local.combined_objects_disk_encryption_sets
   global_settings            = local.global_settings
   keyvaults                  = local.combined_objects_keyvaults
-  location                   = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  location                   = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   managed_identities         = local.combined_objects_managed_identities
   network_security_groups    = local.combined_objects_network_security_groups
   proximity_placement_groups = local.combined_objects_proximity_placement_groups

--- a/virtual_machines.tf
+++ b/virtual_machines.tf
@@ -14,7 +14,7 @@ module "virtual_machines" {
 
   application_security_groups = local.combined_objects_application_security_groups
   availability_sets           = local.combined_objects_availability_sets
-  base_tags                   = try(local.global_settings.inherit_tags, false) ? module.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags                   = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   # if boot_diagnostics_storage_account_key is points to a valid storage account, pass the endpoint
   # if boot_diagnostics_storage_account_key is empty string, pass empty string
   # if boot_diagnostics_storage_account_key not defined, pass null

--- a/virtual_machines.tf
+++ b/virtual_machines.tf
@@ -33,7 +33,7 @@ module "virtual_machines" {
   proximity_placement_groups = local.combined_objects_proximity_placement_groups
   public_ip_addresses        = local.combined_objects_public_ip_addresses
   recovery_vaults            = local.combined_objects_recovery_vaults
-  resource_group_name        = local.resource_groups[each.value.resource_group_key].name
+  resource_group_name        = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   settings                   = each.value
   vnets                      = local.combined_objects_networking
 }

--- a/virtual_machines_scale_sets.tf
+++ b/virtual_machines_scale_sets.tf
@@ -1,6 +1,6 @@
 
 
-module virtual_machine_scale_sets {
+module "virtual_machine_scale_sets" {
   source = "./modules/compute/virtual_machine_scale_set"
   depends_on = [
     module.availability_sets,
@@ -37,7 +37,7 @@ module virtual_machine_scale_sets {
 }
 
 
-output virtual_machine_scale_sets {
+output "virtual_machine_scale_sets" {
   value = module.virtual_machine_scale_sets
 }
 

--- a/virtual_machines_scale_sets.tf
+++ b/virtual_machines_scale_sets.tf
@@ -17,7 +17,7 @@ module "virtual_machine_scale_sets" {
   availability_sets                = local.combined_objects_availability_sets
   application_gateways             = local.combined_objects_application_gateways
   application_security_groups      = local.combined_objects_application_security_groups
-  base_tags                        = try(local.global_settings.inherit_tags, false) ? module.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags                        = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   boot_diagnostics_storage_account = try(local.combined_diagnostics.storage_accounts[each.value.boot_diagnostics_storage_account_key].primary_blob_endpoint, {})
   client_config                    = local.client_config
   diagnostics                      = local.combined_diagnostics
@@ -25,7 +25,7 @@ module "virtual_machine_scale_sets" {
   global_settings                  = local.global_settings
   keyvaults                        = local.combined_objects_keyvaults
   load_balancers                   = local.combined_objects_load_balancers
-  location                         = lookup(each.value, "region", null) == null ? module.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  location                         = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   managed_identities               = local.combined_objects_managed_identities
   network_security_groups          = try(module.network_security_groups, {})
   proximity_placement_groups       = local.combined_objects_proximity_placement_groups

--- a/virtual_machines_scale_sets.tf
+++ b/virtual_machines_scale_sets.tf
@@ -31,7 +31,7 @@ module virtual_machine_scale_sets {
   proximity_placement_groups       = local.combined_objects_proximity_placement_groups
   public_ip_addresses              = local.combined_objects_public_ip_addresses
   recovery_vaults                  = local.combined_objects_recovery_vaults
-  resource_group_name              = module.resource_groups[each.value.resource_group_key].name
+  resource_group_name              = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   settings                         = each.value
   vnets                            = local.combined_objects_networking
 }

--- a/wvd_application_groups.tf
+++ b/wvd_application_groups.tf
@@ -4,9 +4,9 @@ module "wvd_application_groups" {
 
   global_settings     = local.global_settings
   settings            = each.value
-  resource_group_name = module.resource_groups[each.value.resource_group_key].name
-  location            = lookup(each.value, "region", null) == null ? module.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
-  base_tags           = try(local.global_settings.inherit_tags, false) ? module.resource_groups[each.value.resource_group_key].tags : {}
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   host_pool_id        = try(local.combined_objects_wvd_host_pools[local.client_config.landingzone_key][each.value.host_pool_key].id, local.combined_objects_wvd_host_pools[each.value.lz_key][each.value.host_pool_key].id)
   workspace_id        = try(local.combined_objects_wvd_workspaces[local.client_config.landingzone_key][each.value.wvd_workspace_key].id, local.combined_objects_wvd_workspaces[each.value.lz_key][each.value.wvd_workspace_key].id)
   diagnostics         = local.combined_diagnostics

--- a/wvd_host_pools.tf
+++ b/wvd_host_pools.tf
@@ -4,9 +4,9 @@ module "wvd_host_pools" {
 
   global_settings     = local.global_settings
   settings            = each.value
-  resource_group_name = module.resource_groups[each.value.resource_group_key].name
-  location            = lookup(each.value, "region", null) == null ? module.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
-  base_tags           = try(local.global_settings.inherit_tags, false) ? module.resource_groups[each.value.resource_group_key].tags : {}
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   diagnostics         = local.combined_diagnostics
   diagnostic_profiles = try(each.value.diagnostic_profiles, {})
 }

--- a/wvd_workspaces.tf
+++ b/wvd_workspaces.tf
@@ -4,9 +4,9 @@ module "wvd_workspaces" {
 
   global_settings     = local.global_settings
   settings            = each.value
-  resource_group_name = module.resource_groups[each.value.resource_group_key].name
-  location            = lookup(each.value, "region", null) == null ? module.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
-  base_tags           = try(local.global_settings.inherit_tags, false) ? module.resource_groups[each.value.resource_group_key].tags : {}
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
   diagnostics         = local.combined_diagnostics
   diagnostic_profiles = try(each.value.diagnostic_profiles, {})
 }


### PR DESCRIPTION
Issue: #519

# Changes

- Add support for resource groups from remote state using the `local.combined_objects_resource_groups`. Specific changes detailed in the issue
- Minor refactor of `networking_express_route.tf` condition statement involving `resource_group_name` of `express_route_circuit_authorizations`

# Updates

**Update as of 18 June 4:48pm**

For `event_hubs.tf` the pattern is slightly different since it references the resource_groups in a `local` block as per the following snippet that was taken from the current code:

```terraform
locals {
  event_hub_namespaces_private_endpoints = {
    for private_endpoint in
    flatten(
      [
        for eh_ns_key, eh_ns in var.event_hub_namespaces : [
          for pe_key, pe in try(eh_ns.private_endpoints, {}) : {
            # truncated
            location            = local.resource_groups[pe.resource_group_key].location
            resource_group_name = local.resource_groups[pe.resource_group_key].name
            base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[pe.resource_group_key].tags : {}
          }
        ]
      ]
    ) : format("%s-%s", private_endpoint.eh_ns_key, private_endpoint.pe_key) => private_endpoint
  }
}
```

A possible replacement for that (not included in this PR) could be the snippet below where we get the `lz_key` using `pe.lz_key`. Should this be included as one last commit in this PR or are we leaving it to another PR?

```terraform
locals {
  event_hub_namespaces_private_endpoints = {
    for private_endpoint in
    flatten(
      [
        for eh_ns_key, eh_ns in var.event_hub_namespaces : [
          for pe_key, pe in try(eh_ns.private_endpoints, {}) : {
            # truncated
            location            = local.combined_objects_resource_groups[try(pe.lz_key, local.client_config.landingzone_key)][pe.resource_group_key].location
            resource_group_name = local.combined_objects_resource_groups[try(pe.lz_key, local.client_config.landingzone_key)][pe.resource_group_key].name
            base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(pe.lz_key, local.client_config.landingzone_key)][pe.resource_group_key].tags : {}
          }
        ]
      ]
    ) : format("%s-%s", private_endpoint.eh_ns_key, private_endpoint.pe_key) => private_endpoint
  }
}
```