### PR TITLE
Add remote firewall policy to rule_collection_groups

### DIFF
--- a/modules/networking/firewall_policy_rule_collection_groups/firewall_policy_rule_collection_groups.tf
+++ b/modules/networking/firewall_policy_rule_collection_groups/firewall_policy_rule_collection_groups.tf
@@ -48,7 +48,7 @@ resource "azurecaf_name" "nat_rule" {
 resource "azurerm_firewall_policy_rule_collection_group" "polgroup" {
   name               = azurecaf_name.polgroup.result
   priority           = var.policy_settings.priority
-  firewall_policy_id = try(var.policy_settings.firewall_policy_id, null) != null ? var.policy_settings.firewall_policy_id : var.firewall_policies[var.policy_settings.firewall_policy_key].id
+  firewall_policy_id = var.firewall_policy_id
 
   dynamic "application_rule_collection" {
     for_each = try(var.policy_settings.application_rule_collections, {})

--- a/modules/networking/firewall_policy_rule_collection_groups/variables.tf
+++ b/modules/networking/firewall_policy_rule_collection_groups/variables.tf
@@ -6,14 +6,16 @@ variable "global_settings" {
   description = "Global settings object (see module README.md)"
 }
 
-variable "firewall_policies" {
-
+variable "firewall_policy_id" {
+  description = "(Required) The ID of the Firewall Policy where the Firewall Policy Rule Collection Group should exist. Changing this forces a new Firewall Policy Rule Collection Group to be created."
 }
 
 variable "ip_groups" {
-
+  description = "(Optional) Specifies a map of source IP groups."
+  default = {}
 }
 
 variable "public_ip_addresses" {
-
+  description = "(Optional) A map of destination IP addresses (including CIDR)."
+  default     = {}
 }

--- a/networking_firewall.tf
+++ b/networking_firewall.tf
@@ -49,7 +49,10 @@ module "azurerm_firewall_policy_rule_collection_groups" {
   ip_groups           = module.ip_groups
   policy_settings     = each.value
   public_ip_addresses = module.public_ip_addresses
-  firewall_policies   = try(module.azurerm_firewall_policies[each.value.firewall_policy_key].id, null)
+  firewall_policy_id  = coalesce(
+    try(local.combined_objects_azurerm_firewall_policies[try(each.value.firewall_policy.lz_key, local.client_config.landingzone_key)][each.value.firewall_policy.key].id, null),
+    try(local.combined_objects_azurerm_firewall_policies[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.firewall_policy_key].id, null)
+  )
 }
 
 


### PR DESCRIPTION
This PR add support to create an azurerm_firewall_policy_rule_collection_group and attach it to a remote firewall policy