### PR TITLE
added support for configuring application gateway health probes and assigning to backend settings

### DIFF
--- a/examples/app_gateway/100-simple-app-gateway/application.tfvars
+++ b/examples/app_gateway/100-simple-app-gateway/application.tfvars
@@ -24,6 +24,7 @@ application_gateway_applications = {
       port                                = 443
       protocol                            = "Https"
       pick_host_name_from_backend_address = true
+      probe_key                           = "probe_1"
     }
 
     backend_pool = {
@@ -31,6 +32,21 @@ application_gateway_applications = {
         "cafdemo.appserviceenvironment.net"
       ]
     }
+
+    probes = {
+          probe_1 = {
+              name                = "probe-backend-443"
+              protocol            = "Https"
+              path                = "/status-0123456789abcdef"
+              host                = "cafdemo.appserviceenvironment.net"
+              interval            = 30
+              timeout             = 30
+              unhealthy_threshold = 3
+              match               = {
+                  status_code = ["200-399"]
+              }
+          }
+     }
 
   }
 }

--- a/modules/networking/application_gateway/application_gateway.tf
+++ b/modules/networking/application_gateway/application_gateway.tf
@@ -139,6 +139,29 @@ resource "azurerm_application_gateway" "agw" {
       }
     }
   }
+  dynamic "probe" {
+    for_each = local.probes
+
+    content {
+      name                                      = probe.value.name
+      host                                      = probe.value.host
+      interval                                  = probe.value.interval
+      protocol                                  = probe.value.protocol
+      path                                      = probe.value.path
+      timeout                                   = probe.value.timeout
+      unhealthy_threshold                       = probe.value.unhealthy_threshold
+      port                                      = try(probe.value.port,null)
+      pick_host_name_from_backend_http_settings = try(probe.value.pick_host_name_from_backend_http_settings, false)
+      minimum_servers                           = try(probe.value.minimum_servers, 0)
+      dynamic "match" {
+        for_each = try(probe.value.match, null) == null ? [] : [1]
+        content {
+          body        = try(probe.value.match.body,null)
+          status_code = try(probe.value.match.status_code,null)
+        }
+      }
+    }
+  }
 
   dynamic "backend_http_settings" {
     for_each = local.backend_http_settings
@@ -151,6 +174,7 @@ resource "azurerm_application_gateway" "agw" {
       request_timeout                     = try(backend_http_settings.value.request_timeout, 30)
       pick_host_name_from_backend_address = try(backend_http_settings.value.pick_host_name_from_backend_address, false)
       trusted_root_certificate_names      = try(backend_http_settings.value.trusted_root_certificate_names, null)
+      probe_name                          = local.probes[format("%s-%s",backend_http_settings.key, backend_http_settings.value.probe_key)].name
     }
   }
 

--- a/modules/networking/application_gateway/locals.tf
+++ b/modules/networking/application_gateway/locals.tf
@@ -48,6 +48,19 @@ locals {
     ) : format("%s-%s", url_path_map.value.app_key, url_path_map.value.url_path_map_key) => url_path_map.value
   }
 
+  probes = {
+    for probe in
+    flatten(
+      [
+        for app_key, config in var.application_gateway_applications : [
+          for key, value in try(config.probes, []) : {
+            value = merge({ app_key = app_key, probe_key = key }, value)
+          }
+        ]
+      ]
+    ) : format("%s-%s", probe.value.app_key, probe.value.probe_key) => probe.value
+  }
+
   certificate_keys = distinct(flatten([
     for key, value in local.listeners : [try(value.keyvault_certificate.certificate_key, [])]
   ]))


### PR DESCRIPTION
Addresses issue #432,  #557

Example

Specifying the health probe(s).
```hcl

application_gateway_applications = {
  aspnetapp_az1_agw1 = {

    name                    = "apim"
    application_gateway_key = "agw1"

    listeners ...
    
    probes = {
          probe_1 = {
              name                = "probe-apim-443"
              protocol            = "Https"
              path                = "/status-0123456789abcdef"
              host                = "someserver-apim.azure-api.net"
              interval            = 30
              timeout             = 30
              unhealthy_threshold = 3
              match               = {
                  status_code = ["200-399"]
              }
          }
     }
  }
}
```

Specifying the health probe assignment for the backend setting. Note: the use of probe_key which refers to the key of the previous configured probe for the given app gateway application.

```hcl

backend_http_setting = {
      port                                = 443
      protocol                            = "Https"
      host_name                           = "someserver-apim.azure-api.net"
      probe_key                           = "probe_1"
    }

```