### PR TITLE
Fix vhub connection outputs name

### DIFF
--- a/networking_virtual_hub_connection.tf
+++ b/networking_virtual_hub_connection.tf
@@ -5,7 +5,7 @@
 #
 #
 
-output "virtual_hub_connection" {
+output "virtual_hub_connections" {
   value = azurerm_virtual_hub_connection.vhub_connection
 }
 


### PR DESCRIPTION
Referring to the issue in [here](https://github.com/aztfmod/terraform-azurerm-caf/issues/576)

Fixing to ensure output variable match between landingzones and aztfomd.