### PR TITLE
Add support for a creating an AKS cluster using user managed identity

### DIFF
--- a/aks_clusters.tf
+++ b/aks_clusters.tf
@@ -16,6 +16,7 @@ module "aks_clusters" {
   subnets             = lookup(each.value, "lz_key", null) == null ? local.combined_objects_networking[local.client_config.landingzone_key][each.value.vnet_key].subnets : local.combined_objects_networking[each.value.lz_key][each.value.vnet_key].subnets
   resource_group      = local.resource_groups[each.value.resource_group_key]
   private_dns_zone_id = try(local.combined_objects_private_dns[try(each.value.private_dns_zone.lz_key, local.client_config.landingzone_key)][each.value.key].id, null)
+  managed_identities  = local.combined_objects_managed_identities
 
   admin_group_object_ids = try(each.value.admin_groups.azuread_group_keys, null) == null ? null : try(each.value.admin_groups.ids, [
     for group_key in try(each.value.admin_groups.azuread_groups.keys, {}) : local.combined_objects_azuread_groups[local.client_config.landingzone_key][group_key].id

--- a/examples/compute/kubernetes_services/105-cluster-usermsi/aks.tfvars
+++ b/examples/compute/kubernetes_services/105-cluster-usermsi/aks.tfvars
@@ -1,0 +1,83 @@
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "southeastasia"
+  }
+}
+
+resource_groups = {
+  aks_re1 = {
+    name   = "aks-re1"
+    region = "region1"
+  }
+}
+
+managed_identities = {
+  aks_usermsi = {
+    name               = "aks-useraccess"
+    resource_group_key = "aks_re1"
+  }
+}
+
+aks_clusters = {
+  cluster_re1 = {
+    name               = "akscluster-re1-001"
+    resource_group_key = "aks_re1"
+    os_type            = "Linux"
+
+    identity = {
+      type = "UserAssigned"
+      managed_identity_key = "aks_usermsi"
+    }
+
+    vnet_key = "spoke_aks_re1"
+
+    network_profile = {
+      network_plugin    = "azure"
+      load_balancer_sku = "Standard"
+    }
+
+    # enable_rbac = true
+    role_based_access_control = {
+      enabled = true
+      azure_active_directory = {
+        managed = true
+      }
+    }
+
+    addon_profile = {
+      oms_agent = {
+        enabled           = true
+        log_analytics_key = "central_logs_region1"
+      }
+    }
+    # admin_groups = {
+    #   # ids = []
+    #   # azuread_groups = {
+    #   #   keys = []
+    #   # }
+    # }
+
+    load_balancer_profile = {
+      # Only one option can be set
+      managed_outbound_ip_count = 1
+    }
+
+    default_node_pool = {
+      name                  = "sharedsvc"
+      vm_size               = "Standard_F4s_v2"
+      subnet_key            = "aks_nodepool_system"
+      enabled_auto_scaling  = false
+      enable_node_public_ip = false
+      max_pods              = 30
+      node_count            = 1
+      os_disk_size_gb       = 512
+      tags = {
+        "project" = "system services"
+      }
+    }
+
+    node_resource_group_name = "aks-nodes-re1"
+
+  }
+}

--- a/examples/compute/kubernetes_services/105-cluster-usermsi/diagnostics.tfvars
+++ b/examples/compute/kubernetes_services/105-cluster-usermsi/diagnostics.tfvars
@@ -1,0 +1,7 @@
+diagnostic_log_analytics = {
+  central_logs_region1 = {
+    region             = "region1"
+    name               = "logs"
+    resource_group_key = "aks_re1"
+  }
+}

--- a/examples/compute/kubernetes_services/105-cluster-usermsi/networking.tfvars
+++ b/examples/compute/kubernetes_services/105-cluster-usermsi/networking.tfvars
@@ -1,0 +1,190 @@
+vnets = {
+  spoke_aks_re1 = {
+    resource_group_key = "aks_re1"
+    region             = "region1"
+    vnet = {
+      name          = "aks"
+      address_space = ["100.64.48.0/22"]
+    }
+    specialsubnets = {}
+    subnets = {
+      aks_nodepool_system = {
+        name    = "aks_nodepool_system"
+        cidr    = ["100.64.48.0/24"]
+        nsg_key = "azure_kubernetes_cluster_nsg"
+      }
+      aks_nodepool_user1 = {
+        name    = "aks_nodepool_user1"
+        cidr    = ["100.64.49.0/24"]
+        nsg_key = "azure_kubernetes_cluster_nsg"
+      }
+      aks_nodepool_user2 = {
+        name    = "aks_nodepool_user2"
+        cidr    = ["100.64.50.0/24"]
+        nsg_key = "azure_kubernetes_cluster_nsg"
+      }
+      AzureBastionSubnet = {
+        name    = "AzureBastionSubnet" #Must be called AzureBastionSubnet
+        cidr    = ["100.64.51.64/27"]
+        nsg_key = "azure_bastion_nsg"
+      }
+      private_endpoints = {
+        name                                           = "private_endpoints"
+        cidr                                           = ["100.64.51.0/27"]
+        enforce_private_link_endpoint_network_policies = true
+      }
+      jumpbox = {
+        name    = "jumpbox"
+        cidr    = ["100.64.51.128/27"]
+        nsg_key = "azure_bastion_nsg"
+      }
+    }
+
+  }
+}
+
+network_security_group_definition = {
+  # This entry is applied to all subnets with no NSG defined
+  empty_nsg = {}
+  azure_kubernetes_cluster_nsg = {
+    nsg = [
+      {
+        name                       = "aks-http-in-allow",
+        priority                   = "100"
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_range     = "80"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+      },
+      {
+        name                       = "aks-https-in-allow",
+        priority                   = "110"
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_range     = "443"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+      },
+      {
+        name                       = "aks-api-out-allow-1194",
+        priority                   = "100"
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "udp"
+        source_port_range          = "*"
+        destination_port_range     = "1194"
+        source_address_prefix      = "*"
+        destination_address_prefix = "AzureCloud"
+      },
+      {
+        name                       = "aks-api-out-allow-9000",
+        priority                   = "110"
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_range     = "9000"
+        source_address_prefix      = "*"
+        destination_address_prefix = "AzureCloud"
+      },
+      {
+        name                       = "aks-ntp-out-allow",
+        priority                   = "120"
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "udp"
+        source_port_range          = "*"
+        destination_port_range     = "123"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+      },
+      {
+        name                       = "aks-https-out-allow-443",
+        priority                   = "130"
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_range     = "443"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+      },
+    ]
+  }
+  azure_bastion_nsg = {
+
+    nsg = [
+      {
+        name                       = "bastion-in-allow",
+        priority                   = "100"
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_range     = "443"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+      },
+      {
+        name                       = "bastion-control-in-allow-443",
+        priority                   = "120"
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_range     = "135"
+        source_address_prefix      = "GatewayManager"
+        destination_address_prefix = "*"
+      },
+      {
+        name                       = "Kerberos-password-change",
+        priority                   = "121"
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_range     = "4443"
+        source_address_prefix      = "GatewayManager"
+        destination_address_prefix = "*"
+      },
+      {
+        name                       = "bastion-vnet-out-allow-22",
+        priority                   = "103"
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_range     = "22"
+        source_address_prefix      = "*"
+        destination_address_prefix = "VirtualNetwork"
+      },
+      {
+        name                       = "bastion-vnet-out-allow-3389",
+        priority                   = "101"
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_range     = "3389"
+        source_address_prefix      = "*"
+        destination_address_prefix = "VirtualNetwork"
+      },
+      {
+        name                       = "bastion-azure-out-allow",
+        priority                   = "120"
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_range     = "443"
+        source_address_prefix      = "*"
+        destination_address_prefix = "AzureCloud"
+      }
+    ]
+  }
+}

--- a/modules/compute/aks/variables.tf
+++ b/modules/compute/aks/variables.tf
@@ -18,3 +18,6 @@ variable "diagnostic_profiles" {
 variable "private_dns_zone_id" {
   default = null
 }
+variable "managed_identities" {
+  default = {}
+}


### PR DESCRIPTION
### Summary

- Add support for a creating an AKS cluster using user managed identity
- Add an example `105-cluster-usermsi` to demonstrate how to use this feature.
- This feature is needed in order to register the cluster against a private dns zone: (See note in terraform registry -  https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster#private_dns_zone_id)

### Testing
- Locally tested the example (with user assigned identity) using terraform commands 
    - Both terraform plan and apply succeeded.
