### PR TITLE
Support for application gateway rewrite rule sets

### DIFF
--- a/examples/app_gateway/101-private-public/application.tfvars
+++ b/examples/app_gateway/101-private-public/application.tfvars
@@ -18,11 +18,43 @@ application_gateway_applications = {
         front_end_port_key             = "81"
         host_name                      = "cafdemo.com"
       }
+      public_82 = {
+        name                           = "demo-app1-82-public"
+        front_end_ip_configuration_key = "public"
+        front_end_port_key             = "82"
+        host_name                      = "cafdemo.com"
+        request_routing_rule_key       = "path_based"
+      }
     }
 
     request_routing_rules = {
       default = {
         rule_type = "Basic"
+        #rewrite_rule_set_key = "rule_set_1"
+      }
+      path_based = {
+        rule_type         = "PathBasedRouting"
+        url_path_map_key  = "path_map_1"
+      }
+    }
+
+    url_path_maps = {
+      path_map_1 = {
+        name = "path_map_1"
+        default_rewrite_rule_set_key = "rule_set_1"
+        path_rules = {
+          pathRuleIdentity = {
+              name    = "pathRuleIdentity"
+              paths   = ["/identity*"]
+              #rewrite_rule_set_key = "rule_set_1"
+          }
+
+          pathRuleAuthorisation = {
+              name    = "pathRuleAuthorization"
+              paths   = ["/authorization*"]
+              #rewrite_rule_set_key = "rule_set_1"
+          }
+        }
       }
     }
 
@@ -38,5 +70,83 @@ application_gateway_applications = {
       ]
     }
 
+    rewrite_rule_sets = {
+      rule_set_1 = {
+        name = "headers-response-processing"
+        rewrite_rules = {
+          rule_1 = {
+            name = "server-header-remove"
+            rule_sequence = 100
+            #conditions = {
+              #condition_1 = {
+                #variable = "http_status"
+                #pattern = "200"
+                #ignore_case = true
+                #negate = false
+              #}
+            #}
+            response_header_configurations = {
+              server_header = {
+                  header_name     = "Server"
+                  header_value    = ""  # Use blank value to remove header
+              }
+            }
+            # url = {
+            #   path          = ""
+            #   query_string  = ""
+            #   reroute       = false
+            # }
+          }
+
+          rule_2 = {
+            name = "hsts-add-header"
+            rule_sequence = 101
+            #conditions = {
+              #condition_1 = {
+                #variable = "http_status"
+                #pattern = "200"
+                #ignore_case = true
+                #negate = false
+              #}
+            #}
+            response_header_configurations = {
+              hsts_header = {
+                  header_name     = "Strict-Transport-Security"
+                  header_value    = "max-age=31536000"
+              }
+            }
+            # url = {
+            #   path          = ""
+            #   query_string  = ""
+            #   reroute       = false
+            # }
+          }
+
+          rule_3 = {
+            name = "add-request-header"
+            rule_sequence = 102
+            #conditions = {
+              #condition_1 = {
+                #variable = "http_status"
+                #pattern = "200"
+                #ignore_case = true
+                #negate = false
+              #}
+            #}
+            request_header_configurations = {
+              foo_header = {
+                  header_name     = "foo"
+                  header_value    = "123456"
+              }
+            }
+            # url = {
+            #   path          = ""
+            #   query_string  = ""
+            #   reroute       = false
+            # }
+          }
+        }
+      }
+    }
   }
 }

--- a/examples/app_gateway/101-private-public/application.tfvars
+++ b/examples/app_gateway/101-private-public/application.tfvars
@@ -72,7 +72,7 @@ application_gateway_applications = {
 
     rewrite_rule_sets = {
       rule_set_1 = {
-        name = "headers-response-processing"
+        name = "header-rules"
         rewrite_rules = {
           rule_1 = {
             name = "server-header-remove"
@@ -87,8 +87,8 @@ application_gateway_applications = {
             #}
             response_header_configurations = {
               server_header = {
-                  header_name     = "Server"
-                  header_value    = ""  # Use blank value to remove header
+                header_name     = "Server"
+                header_value    = ""  # Use blank value to remove header
               }
             }
             # url = {
@@ -111,8 +111,8 @@ application_gateway_applications = {
             #}
             response_header_configurations = {
               hsts_header = {
-                  header_name     = "Strict-Transport-Security"
-                  header_value    = "max-age=31536000"
+                header_name     = "Strict-Transport-Security"
+                header_value    = "max-age=31536000"
               }
             }
             # url = {
@@ -135,8 +135,8 @@ application_gateway_applications = {
             #}
             request_header_configurations = {
               foo_header = {
-                  header_name     = "foo"
-                  header_value    = "123456"
+                header_name     = "foo"
+                header_value    = "123456"
               }
             }
             # url = {

--- a/examples/app_gateway/101-private-public/application_gateways.tfvars
+++ b/examples/app_gateway/101-private-public/application_gateways.tfvars
@@ -42,6 +42,11 @@ application_gateways = {
         port     = 81
         protocol = "Http"
       }
+      82 = {
+        name     = "http-82"
+        port     = 82
+        protocol = "Http"
+      }
       443 = {
         name     = "https-443"
         port     = 443

--- a/modules/networking/application_gateway/application_gateway.tf
+++ b/modules/networking/application_gateway/application_gateway.tf
@@ -324,8 +324,9 @@ resource "azurerm_application_gateway" "agw" {
           dynamic "url" {
             for_each = try(rewrite_rule.value.url, null) == null ? [] : [1]
             content {
-              path              = url.value.path
-              query_string      = url.value.query_string
+              path              = try(url.value.path,null)
+              query_string      = try(url.value.query_string,null)
+              reroute           = try(url.value.reroute,null)
             }
           }
         }

--- a/modules/networking/application_gateway/application_gateway.tf
+++ b/modules/networking/application_gateway/application_gateway.tf
@@ -113,8 +113,8 @@ resource "azurerm_application_gateway" "agw" {
       http_listener_name         = request_routing_rule.value.name
       backend_http_settings_name = local.backend_http_settings[request_routing_rule.value.app_key].name
       backend_address_pool_name  = local.backend_pools[request_routing_rule.value.app_key].name
-      url_path_map_name = try(local.request_routing_rules[format("%s-%s", request_routing_rule.value.app_key, request_routing_rule.value.request_routing_rule_key)].rule.url_path_map_name, try(local.url_path_maps[format("%s-%s", request_routing_rule.value.app_key,
-      local.request_routing_rules[format("%s-%s", request_routing_rule.value.app_key, request_routing_rule.value.request_routing_rule_key)].rule.url_path_map_key)].name, null))
+      url_path_map_name          = try(local.request_routing_rules[format("%s-%s", request_routing_rule.value.app_key, request_routing_rule.value.request_routing_rule_key)].rule.url_path_map_name, 
+                                   try(local.url_path_maps[format("%s-%s", request_routing_rule.value.app_key,local.request_routing_rules[format("%s-%s", request_routing_rule.value.app_key, request_routing_rule.value.request_routing_rule_key)].rule.url_path_map_key)].name, null))
       rewrite_rule_set_name      = try(local.rewrite_rule_sets[format("%s-%s", request_routing_rule.value.app_key, local.request_routing_rules[format("%s-%s", request_routing_rule.value.app_key, request_routing_rule.value.request_routing_rule_key)].rule.rewrite_rule_set_key)].name, null)
     }
   }

--- a/modules/networking/application_gateway/locals.tf
+++ b/modules/networking/application_gateway/locals.tf
@@ -61,6 +61,19 @@ locals {
     ) : format("%s-%s", probe.value.app_key, probe.value.probe_key) => probe.value
   }
 
+  rewrite_rule_sets = {
+    for rewrite_rule_set in
+    flatten(
+      [
+        for app_key, config in var.application_gateway_applications : [
+          for key, value in try(config.rewrite_rule_sets, []) : {
+            value = merge({ app_key = app_key, rewrite_rule_set_key = key }, value)
+          }
+        ]
+      ]
+    ) : format("%s-%s", rewrite_rule_set.value.app_key, rewrite_rule_set.value.rewrite_rule_set_key) => rewrite_rule_set.value
+  }
+
   certificate_keys = distinct(flatten([
     for key, value in local.listeners : [try(value.keyvault_certificate.certificate_key, [])]
   ]))


### PR DESCRIPTION
This PR provides support for configuring rewrite rule sets against an application gateway

Included in the changes is an example of how to apply rule sets at different levels of the application gateway configuration.