### PR TITLE
Fix the bugs in AKS specific examples

### DIFF
--- a/examples/compute/kubernetes_services/103-multi-clusters/aks.tfvars
+++ b/examples/compute/kubernetes_services/103-multi-clusters/aks.tfvars
@@ -10,7 +10,6 @@ aks_clusters = {
 
     # kubernetes_version = "1.19.6"
 
-    lz_key   = "networking_spoke_aks"
     vnet_key = "spoke_aks_re1"
 
 
@@ -68,7 +67,6 @@ aks_clusters = {
       type = "SystemAssigned"
     }
 
-    lz_key   = "networking_spoke_aks"
     vnet_key = "spoke_aks_re2"
 
     network_policy = {

--- a/examples/compute/kubernetes_services/103-multi-clusters/networking.tfvars
+++ b/examples/compute/kubernetes_services/103-multi-clusters/networking.tfvars
@@ -1,6 +1,6 @@
 vnets = {
   spoke_aks_re1 = {
-    resource_group_key = "aks_spoke_re1"
+    resource_group_key = "aks_re1"
     region             = "region1"
     vnet = {
       name          = "aks-re1"
@@ -43,7 +43,7 @@ vnets = {
   }
 
   spoke_aks_re2 = {
-    resource_group_key = "aks_spoke_re2"
+    resource_group_key = "aks_re2"
     region             = "region2"
     vnet = {
       name          = "aks-re2"

--- a/examples/compute/kubernetes_services/104-private-cluster/acr.tfvars
+++ b/examples/compute/kubernetes_services/104-private-cluster/acr.tfvars
@@ -1,7 +1,7 @@
 azure_container_registries = {
   acr1 = {
     name               = "acr-test"
-    resource_group_key = "aks1_re1"
+    resource_group_key = "aks_re1"
     sku                = "Premium"
     diagnostic_profiles = {
       operations = {
@@ -17,9 +17,8 @@ azure_container_registries = {
       # Require enforce_private_link_endpoint_network_policies set to true on the subnet
       spoke_aks_re1-aks_nodepool_system = {
         name               = "acr-test-private-link"
-        resource_group_key = "aks1_re1"
+        resource_group_key = "aks_re1"
 
-        lz_key     = "networking_spoke_aks"
         vnet_key   = "spoke_aks_re1"
         subnet_key = "private_endpoints"
 

--- a/examples/compute/kubernetes_services/104-private-cluster/aks.tfvars
+++ b/examples/compute/kubernetes_services/104-private-cluster/aks.tfvars
@@ -1,7 +1,7 @@
 aks_clusters = {
   cluster_re1 = {
     name               = "akscluster-001"
-    resource_group_key = "aks1_re1"
+    resource_group_key = "aks_re1"
     os_type            = "Linux"
 
     diagnostic_profiles = {
@@ -16,7 +16,6 @@ aks_clusters = {
       type = "SystemAssigned"
     }
 
-    lz_key   = "networking_spoke_aks"
     vnet_key = "spoke_aks_re1"
 
     network_policy = {

--- a/examples/compute/kubernetes_services/104-private-cluster/configuration.tfvars
+++ b/examples/compute/kubernetes_services/104-private-cluster/configuration.tfvars
@@ -8,7 +8,7 @@ global_settings = {
 
 
 resource_groups = {
-  aks1_re1 = {
+  aks_re1 = {
     name   = "aks-re1"
     region = "region1"
   }

--- a/examples/compute/kubernetes_services/104-private-cluster/diagnostics.tfvars
+++ b/examples/compute/kubernetes_services/104-private-cluster/diagnostics.tfvars
@@ -5,3 +5,15 @@ diagnostic_log_analytics = {
     resource_group_key = "aks_re1"
   }
 }
+
+diagnostic_storage_accounts = {
+  # Stores boot diagnostic for region1
+  bootdiag_region1 = {
+    name                     = "bootrg1"
+    resource_group_key       = "aks_jumpbox_re1"
+    account_kind             = "StorageV2"
+    account_tier             = "Standard"
+    account_replication_type = "LRS"
+    access_tier              = "Cool"
+  }
+}

--- a/examples/compute/kubernetes_services/104-private-cluster/networking.tfvars
+++ b/examples/compute/kubernetes_services/104-private-cluster/networking.tfvars
@@ -1,6 +1,6 @@
 vnets = {
   spoke_aks_re1 = {
-    resource_group_key = "aks_spoke_re1"
+    resource_group_key = "aks_re1"
     region             = "region1"
     vnet = {
       name          = "aks-re1"
@@ -42,48 +42,6 @@ vnets = {
 
   }
 
-  spoke_aks_re2 = {
-    resource_group_key = "aks_spoke_re2"
-    region             = "region2"
-    vnet = {
-      name          = "aks-re2"
-      address_space = ["100.65.48.0/22"]
-    }
-    specialsubnets = {}
-    subnets = {
-      aks_nodepool_system = {
-        name    = "aks_nodepool_system"
-        cidr    = ["100.65.48.0/24"]
-        nsg_key = "azure_kubernetes_cluster_nsg"
-      }
-      aks_nodepool_user1 = {
-        name    = "aks_nodepool_user1"
-        cidr    = ["100.65.49.0/24"]
-        nsg_key = "azure_kubernetes_cluster_nsg"
-      }
-      aks_nodepool_user2 = {
-        name    = "aks_nodepool_user2"
-        cidr    = ["100.65.50.0/24"]
-        nsg_key = "azure_kubernetes_cluster_nsg"
-      }
-      AzureBastionSubnet = {
-        name    = "AzureBastionSubnet" #Must be called AzureBastionSubnet
-        cidr    = ["100.65.51.64/27"]
-        nsg_key = "azure_bastion_nsg"
-      }
-      private_endpoints = {
-        name                                           = "private_endpoints"
-        cidr                                           = ["100.65.51.0/27"]
-        enforce_private_link_endpoint_network_policies = true
-      }
-      jumpbox = {
-        name    = "jumpbox"
-        cidr    = ["100.65.51.128/27"]
-        nsg_key = "azure_bastion_nsg"
-      }
-    }
-
-  }
 }
 
 network_security_group_definition = {
@@ -262,41 +220,6 @@ vnet_peerings = {
     }
     to = {
       vnet_key = "spoke_aks_re1"
-    }
-    allow_virtual_network_access = true
-    allow_forwarded_traffic      = true
-    allow_gateway_transit        = true
-    use_remote_gateways          = false
-  }
-
-  #
-  # Peering Region2
-  #
-  spoke_aks_re2_TO_hub_re2 = {
-    name = "spoke_aks_re2_TO_hub_re2"
-    from = {
-      vnet_key = "spoke_aks_re2"
-    }
-    to = {
-      lz_key     = "networking_hub"
-      output_key = "vnets"
-      vnet_key   = "hub_re2"
-    }
-    allow_virtual_network_access = true
-    allow_forwarded_traffic      = false
-    allow_gateway_transit        = false
-    use_remote_gateways          = false
-  }
-
-  hub_re2_TO_spoke_aks_re2 = {
-    name = "hub_re2_TO_spoke_aks_re2"
-    from = {
-      lz_key     = "networking_hub"
-      output_key = "vnets"
-      vnet_key   = "hub_re2"
-    }
-    to = {
-      vnet_key = "spoke_aks_re2"
     }
     allow_virtual_network_access = true
     allow_forwarded_traffic      = true

--- a/examples/compute/kubernetes_services/104-private-cluster/vm.tfvars
+++ b/examples/compute/kubernetes_services/104-private-cluster/vm.tfvars
@@ -16,7 +16,6 @@ virtual_machines = {
       nic0 = {
         # AKS rely on a remote network and need the details of the tfstate to connect (tfstate_key), assuming RBAC authorization.
 
-        lz_key                  = "networking_spoke_aks"
         vnet_key                = "spoke_aks_re1"
         subnet_key              = "jumpbox"
         name                    = "0"


### PR DESCRIPTION
## Summary
1. **Example - 103-multi-clusters**
    - Fix the resource group keys and unused lz_keys in the kubernetes multi-clusters examples
    
2. **Example - 104-private-cluster**
    - Add the missing storage account diagnostics and resource group
    - Remove unused vnet and peering
    - Fix the incorrect/unused landing zone keys

Issue:  https://github.com/aztfmod/terraform-azurerm-caf/issues/595

## Testing
- Tested all the examples locally by running terraform plan, apply and destroy. All examples now succeed.