### PR TITLE
New Sub module - cognitive service account

### DIFF
--- a/cognitive_service.tf
+++ b/cognitive_service.tf
@@ -1,0 +1,10 @@
+module "cognitive_service_account" {
+  source   = "./modules/cognitive_service/cognitive_service_account"
+  for_each = local.cognitive_service.cognitive_service_account
+
+  client_config       = local.client_config
+  global_settings     = local.global_settings
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].name
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].location : local.global_settings.regions[each.value.region]
+  settings            = each.value
+}

--- a/examples/cognitive_service/100-cognitive-service-account/configuration.tfvars
+++ b/examples/cognitive_service/100-cognitive-service-account/configuration.tfvars
@@ -1,0 +1,31 @@
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "southeastasia"
+  }
+  random_length = 5
+}
+
+resource_groups = {
+  test = {
+    name = "test"
+  }
+}
+
+cognitive_service_account = {
+  test_account = {
+    resource_group = {
+      # accepts either id or key to get resource group id
+      # id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1"
+      # lz_key = "examples"
+      key = "test"
+    }
+    name     = "example"
+    kind     = "Academic"
+    sku_name = "S0"
+    tags = {
+      env = "test"
+    }
+  }
+}
+

--- a/examples/cognitive_service/100-cognitive-service-account/configuration.tfvars
+++ b/examples/cognitive_service/100-cognitive-service-account/configuration.tfvars
@@ -26,11 +26,11 @@ cognitive_service_account = {
     tags = {
       env = "test"
     }
-		custom_subdomain_name = "cs-alz-caf-test-1"
-		network_acls = {
-			default_action = "Allow"
-			ip_rules = ["10.10.10.0/16"]
-		}
+    custom_subdomain_name = "cs-alz-caf-test-1"
+    network_acls = {
+      default_action = "Allow"
+      ip_rules       = ["10.10.10.0/16"]
+    }
   }
   test_account-2 = {
     resource_group = {
@@ -45,8 +45,8 @@ cognitive_service_account = {
     tags = {
       env = "test"
     }
-		qna_runtime_endpoint = "https://cs-alz-caf-test-2.azurewebsites.net"
-		
+    qna_runtime_endpoint = "https://cs-alz-caf-test-2.azurewebsites.net"
+
   }
 }
 

--- a/examples/cognitive_service/100-cognitive-service-account/configuration.tfvars
+++ b/examples/cognitive_service/100-cognitive-service-account/configuration.tfvars
@@ -1,31 +1,52 @@
 global_settings = {
   default_region = "region1"
   regions = {
-    region1 = "southeastasia"
+    region1 = "westus"
   }
-  random_length = 5
+  #random_length = 5
 }
 
 resource_groups = {
-  test = {
-    name = "test"
+  test-rg = {
+    name = "rg-alz-caf-test-1"
   }
 }
 
 cognitive_service_account = {
-  test_account = {
+  test_account-1 = {
     resource_group = {
       # accepts either id or key to get resource group id
       # id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1"
       # lz_key = "examples"
-      key = "test"
+      key = "test-rg"
     }
-    name     = "example"
-    kind     = "Academic"
-    sku_name = "S0"
+    name     = "cs-alz-caf-test-1"
+    kind     = "ComputerVision"
+    sku_name = "F0"
     tags = {
       env = "test"
     }
+		custom_subdomain_name = "cs-alz-caf-test-1"
+		network_acls = {
+			default_action = "Allow"
+			ip_rules = ["10.10.10.0/16"]
+		}
+  }
+  test_account-2 = {
+    resource_group = {
+      # accepts either id or key to get resource group id
+      # id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1"
+      # lz_key = "examples"
+      key = "test-rg"
+    }
+    name     = "cs-alz-caf-test-2"
+    kind     = "QnAMaker"
+    sku_name = "F0"
+    tags = {
+      env = "test"
+    }
+		qna_runtime_endpoint = "https://cs-alz-caf-test-2.azurewebsites.net"
+		
   }
 }
 

--- a/examples/cognitive_service/main.tf
+++ b/examples/cognitive_service/main.tf
@@ -1,0 +1,2 @@
+# This is an empty file for Terraform registry visibility.
+# For examples on how to consume the CAF module, please refer to https://github.com/aztfmod/terraform-azurerm-caf/tree/master/examples

--- a/examples/module.tf
+++ b/examples/module.tf
@@ -70,6 +70,11 @@ module "example" {
   #   synapseAnalyticsResourceId                  = var.synapseAnalyticsResourceId
   #   vmImageAliasDoc                             = var.vmImageAliasDoc
   # }
+
+  cognitive_service = {
+    cognitive_service_account = var.cognitive_service_account
+  }
+
   compute = {
     aks_clusters               = var.aks_clusters
     availability_sets          = var.availability_sets

--- a/examples/variables.tf
+++ b/examples/variables.tf
@@ -552,3 +552,6 @@ variable "storage_account_queues" {
 variable "storage_account_blobs" {
   default = {}
 }
+variable "cognitive_service_account" {
+  default = {}
+}

--- a/locals.combined_objects.tf
+++ b/locals.combined_objects.tf
@@ -17,6 +17,7 @@ locals {
   combined_objects_azuread_groups                      = merge(tomap({ (local.client_config.landingzone_key) = module.azuread_groups }), try(var.remote_objects.azuread_groups, {}))
   combined_objects_azuread_users                       = merge(tomap({ (local.client_config.landingzone_key) = module.azuread_users }), try(var.remote_objects.azuread_users, {}))
   combined_objects_azurerm_firewalls                   = merge(tomap({ (local.client_config.landingzone_key) = module.azurerm_firewalls }), try(var.remote_objects.azurerm_firewalls, {}))
+  combined_objects_cognitive_service_accounts          = merge(tomap({ (local.client_config.landingzone_key) = module.cognitive_service_account }), try(var.remote_objects.cognitive_service_account, {}))
   combined_objects_consumption_budgets_resource_groups = merge(tomap({ (local.client_config.landingzone_key) = module.consumption_budgets_resource_groups }), try(var.remote_objects.consumption_budgets_resource_groups, {}))
   combined_objects_consumption_budgets_subscriptions   = merge(tomap({ (local.client_config.landingzone_key) = module.consumption_budgets_subscriptions }), try(var.remote_objects.consumption_budgets_subscriptions, {}))
   combined_objects_container_registry                  = merge(tomap({ (local.client_config.landingzone_key) = module.container_registry }), try(var.remote_objects.container_registry, {}))

--- a/locals.tf
+++ b/locals.tf
@@ -179,6 +179,10 @@ locals {
     logic_app_workflow              = try(var.logic_app.logic_app_workflow, {})
   }
 
+  cognitive_service = {
+    cognitive_service_account = try(var.cognitive_service.cognitive_service_account, {})
+  }
+
   networking = {
     application_gateway_applications                        = try(var.networking.application_gateway_applications, {})
     application_gateway_waf_policies                        = try(var.networking.application_gateway_waf_policies, {})

--- a/modules/cognitive_service/cognitive_service_account/cognitive_service_account.tf
+++ b/modules/cognitive_service/cognitive_service_account/cognitive_service_account.tf
@@ -1,0 +1,20 @@
+resource "azurecaf_name" "service" {
+  name          = var.settings.name
+  prefixes      = var.global_settings.prefixes
+  resource_type = "azurerm_consumption_budget_resource_group"
+  random_length = var.global_settings.random_length
+  clean_input   = true
+  passthrough   = var.global_settings.passthrough
+  use_slug      = var.global_settings.use_slug
+}
+
+resource "azurerm_cognitive_account" "service" {
+  name                = azurecaf_name.service.result
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  kind                = var.settings.kind
+
+  sku_name = var.settings.sku_name
+
+  tags = var.settings.tags
+}

--- a/modules/cognitive_service/cognitive_service_account/cognitive_service_account.tf
+++ b/modules/cognitive_service/cognitive_service_account/cognitive_service_account.tf
@@ -1,7 +1,7 @@
 resource "azurecaf_name" "service" {
   name          = var.settings.name
   prefixes      = var.global_settings.prefixes
-  resource_type = "azurerm_consumption_budget_resource_group"
+  resource_type = "azurerm_cognitive_account"
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough
@@ -13,8 +13,20 @@ resource "azurerm_cognitive_account" "service" {
   location            = var.location
   resource_group_name = var.resource_group_name
   kind                = var.settings.kind
-
   sku_name = var.settings.sku_name
 
-  tags = var.settings.tags
+	qna_runtime_endpoint = var.settings.kind == "QnAMaker" ? var.settings.qna_runtime_endpoint : try(var.settings.qna_runtime_endpoint, null)
+	
+	dynamic "network_acls" {
+		for_each = try(var.settings.network_acls, null) == null ? [] : [1]
+		content {
+			default_action   = var.settings.network_acls.default_action
+			ip_rules = var.settings.network_acls.ip_rules
+			virtual_network_subnet_ids = var.settings.network_acls.virtual_network_subnet_ids
+		}
+	}
+
+	custom_subdomain_name = try(var.settings.custom_subdomain_name, null)
+
+  tags = try(var.settings.tags, {})
 }

--- a/modules/cognitive_service/cognitive_service_account/cognitive_service_account.tf
+++ b/modules/cognitive_service/cognitive_service_account/cognitive_service_account.tf
@@ -13,20 +13,20 @@ resource "azurerm_cognitive_account" "service" {
   location            = var.location
   resource_group_name = var.resource_group_name
   kind                = var.settings.kind
-  sku_name = var.settings.sku_name
+  sku_name            = var.settings.sku_name
 
-	qna_runtime_endpoint = var.settings.kind == "QnAMaker" ? var.settings.qna_runtime_endpoint : try(var.settings.qna_runtime_endpoint, null)
-	
-	dynamic "network_acls" {
-		for_each = try(var.settings.network_acls, null) == null ? [] : [1]
-		content {
-			default_action   = var.settings.network_acls.default_action
-			ip_rules = var.settings.network_acls.ip_rules
-			virtual_network_subnet_ids = var.settings.network_acls.virtual_network_subnet_ids
-		}
-	}
+  qna_runtime_endpoint = var.settings.kind == "QnAMaker" ? var.settings.qna_runtime_endpoint : try(var.settings.qna_runtime_endpoint, null)
 
-	custom_subdomain_name = try(var.settings.custom_subdomain_name, null)
+  dynamic "network_acls" {
+    for_each = try(var.settings.network_acls, null) == null ? [] : [1]
+    content {
+      default_action             = var.settings.network_acls.default_action
+      ip_rules                   = try(var.settings.network_acls.ip_rules, null)
+      virtual_network_subnet_ids = try(var.settings.network_acls.virtual_network_subnet_ids, null)
+    }
+  }
+
+  custom_subdomain_name = try(var.settings.custom_subdomain_name, null)
 
   tags = try(var.settings.tags, {})
 }

--- a/modules/cognitive_service/cognitive_service_account/main.tf
+++ b/modules/cognitive_service/cognitive_service_account/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    azurecaf = {
+      source = "aztfmod/azurecaf"
+    }
+  }
+}

--- a/modules/cognitive_service/cognitive_service_account/variables.tf
+++ b/modules/cognitive_service/cognitive_service_account/variables.tf
@@ -1,0 +1,17 @@
+variable "global_settings" {
+  description = "Global settings object (see module README.md)"
+}
+variable "client_config" {
+  description = "Client configuration object (see module README.md)."
+}
+variable "location" {
+  description = "(Required) Specifies the supported Azure location where to create the resource. Changing this forces a new resource to be created."
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Name of the existing resource group to deploy the virtual machine"
+}
+
+variable "settings" {}
+

--- a/variables.tf
+++ b/variables.tf
@@ -354,3 +354,8 @@ variable "random_strings" {
   description = "Configuration object - Random string generator resources"
   default     = {}
 }
+
+variable "cognitive_service" {
+  description = "onfiguration object - Cognitive Service Resource "
+  default     = {}
+}


### PR DESCRIPTION
# Overview
This PR contains a new module for creating a cognitive services account. It references the current version of TF being used by ALZ (`2.64.0`). Within the `locals.tf` file a new local object is created for `cognitive_service` since there wasn't another one where it would fit.

# Testing
This code was tested by a QnAMaker `kind` and a non `QnaMaker` resource. It also leverages __most__ of the optional parameters. The only one that wasn't fully tested was the `virtual_network_subnet_ids`, the reason being that the necessary subnet service endpoint was not configured. but I believe this is fine since my code was able to reference a subnet ID and Terraform was successfully able to pick it up (even if it didn't accept it).

```
.....
virtualNetworks/vnet-eus2-test-spoke do not have ServiceEndpoints for Microsoft.CognitiveServices resources configured. Add Microsoft.CognitiveServices to subnet's ServiceEndpoints collection before trying to ACL Microsoft.CognitiveServices resources to these subnets."
````