### PR TITLE
Enhance/consumption-budget

### DIFF
--- a/.github/workflows/standalone-scenarios.json
+++ b/.github/workflows/standalone-scenarios.json
@@ -36,6 +36,7 @@
     "consumption_budget/102-consumption-budget-rg-alerts",
     "consumption_budget/103-consumption-budget-subscription-alerts",
     "consumption_budget/104-consumption-budget-subscription-vm",
+    "consumption_budget/105-consumption-budget-subscription-aks",
     "compute/virtual_machine_scale_set/100-linux-win-vmss-lb",
     "compute/virtual_machine_scale_set/101-linux-win-vmss-agw",
     "compute/windows_virtual_desktop/wvd_resources",

--- a/.github/workflows/standalone-scenarios.json
+++ b/.github/workflows/standalone-scenarios.json
@@ -35,6 +35,7 @@
     "consumption_budget/101-consumption-budget-subscription",
     "consumption_budget/102-consumption-budget-rg-alerts",
     "consumption_budget/103-consumption-budget-subscription-alerts",
+    "consumption_budget/104-consumption-budget-subscription-vm",
     "compute/virtual_machine_scale_set/100-linux-win-vmss-lb",
     "compute/virtual_machine_scale_set/101-linux-win-vmss-agw",
     "compute/windows_virtual_desktop/wvd_resources",

--- a/consumption_budgets.tf
+++ b/consumption_budgets.tf
@@ -5,11 +5,12 @@ module "consumption_budgets_resource_groups" {
     if try(value.resource_group, null) != null
   }
 
-  client_config         = local.client_config
-  global_settings       = local.global_settings
-  monitor_action_groups = local.combined_objects_monitor_action_groups
-  # lz_key used in dimension to reference remote state
-  resource_groups = local.combined_objects_resource_groups
+  local_combined_resources = {
+    monitor_action_groups = local.combined_objects_monitor_action_groups,
+    resource_groups       = local.combined_objects_resource_groups,
+  }
+  client_config   = local.client_config
+  global_settings = local.global_settings
   settings        = each.value
 }
 

--- a/consumption_budgets.tf
+++ b/consumption_budgets.tf
@@ -24,15 +24,11 @@ module "consumption_budgets_subscriptions" {
   local_combined_resources = {
     monitor_action_groups = local.combined_objects_monitor_action_groups,
     resource_groups       = local.combined_objects_resource_groups,
+    subscriptions         = local.combined_objects_subscriptions,
   }
   client_config   = local.client_config
   global_settings = local.global_settings
   settings        = each.value
-  subscription_id = coalesce(
-    try(each.value.subscription.id, null),
-    try(local.combined_objects_subscriptions[try(each.value.subscription.lz_key, local.client_config.landingzone_key)][each.value.subscription.key].subscription_id, null),
-    local.client_config.subscription_id
-  )
 }
 
 output "consumption_budgets_resource_groups" {

--- a/consumption_budgets.tf
+++ b/consumption_budgets.tf
@@ -21,11 +21,12 @@ module "consumption_budgets_subscriptions" {
     if try(value.subscription, null) != null
   }
 
-  client_config         = local.client_config
-  global_settings       = local.global_settings
-  monitor_action_groups = local.combined_objects_monitor_action_groups
-  # lz_key used in dimension to reference remote state
-  resource_groups = local.combined_objects_resource_groups
+  local_combined_resources = {
+    monitor_action_groups = local.combined_objects_monitor_action_groups,
+    resource_groups       = local.combined_objects_resource_groups,
+  }
+  client_config   = local.client_config
+  global_settings = local.global_settings
   settings        = each.value
   subscription_id = coalesce(
     try(each.value.subscription.id, null),

--- a/consumption_budgets.tf
+++ b/consumption_budgets.tf
@@ -7,6 +7,7 @@ module "consumption_budgets_resource_groups" {
 
   local_combined_resources = {
     # Add combined objects that need to be included in the filter
+    aks                   = local.combined_objects_aks_clusters,
     monitor_action_groups = local.combined_objects_monitor_action_groups,
     resource_groups       = local.combined_objects_resource_groups,
     virtual_machines      = local.combined_objects_virtual_machines,
@@ -25,6 +26,7 @@ module "consumption_budgets_subscriptions" {
 
   local_combined_resources = {
     # Add combined objects that need to be included in the filter
+    aks                   = local.combined_objects_aks_clusters,
     monitor_action_groups = local.combined_objects_monitor_action_groups,
     resource_groups       = local.combined_objects_resource_groups,
     subscriptions         = local.combined_objects_subscriptions,

--- a/consumption_budgets.tf
+++ b/consumption_budgets.tf
@@ -6,8 +6,10 @@ module "consumption_budgets_resource_groups" {
   }
 
   local_combined_resources = {
+    # Add combined objects that need to be included in the filter
     monitor_action_groups = local.combined_objects_monitor_action_groups,
     resource_groups       = local.combined_objects_resource_groups,
+    virtual_machines      = local.combined_objects_virtual_machines,
   }
   client_config   = local.client_config
   global_settings = local.global_settings
@@ -22,9 +24,11 @@ module "consumption_budgets_subscriptions" {
   }
 
   local_combined_resources = {
+    # Add combined objects that need to be included in the filter
     monitor_action_groups = local.combined_objects_monitor_action_groups,
     resource_groups       = local.combined_objects_resource_groups,
     subscriptions         = local.combined_objects_subscriptions,
+    virtual_machines      = local.combined_objects_virtual_machines,
   }
   client_config   = local.client_config
   global_settings = local.global_settings

--- a/examples/consumption_budget/100-consumption-budget-rg/configuration.tfvars
+++ b/examples/consumption_budget/100-consumption-budget-rg/configuration.tfvars
@@ -64,9 +64,10 @@ consumption_budgets = {
             "example",
           ]
         },
-        resource_group_key = {
+        resource_key = {
           # lz_key = "examples"
-          name = "resource_group_key"
+          name         = "resource_key"
+          resource_key = "resource_groups"
           values = [
             "test",
           ]
@@ -94,9 +95,10 @@ consumption_budgets = {
         #   #     "example",
         #   #   ]
         #   # },
-        #   resource_group_key = {
+        #   resource_key = {
         #     # lz_key = "examples"
-        #     name = "resource_group_key"
+        #     name         = "resource_key"
+        #     resource_key = "resource_groups"
         #     values = [
         #       "test",
         #     ]

--- a/examples/consumption_budget/101-consumption-budget-subscription/configuration.tfvars
+++ b/examples/consumption_budget/101-consumption-budget-subscription/configuration.tfvars
@@ -63,9 +63,10 @@ consumption_budgets = {
             "example",
           ]
         },
-        resource_group_key = {
+        resource_key = {
           # lz_key = "examples"
-          name = "resource_group_key"
+          name         = "resource_key"
+          resource_key = "resource_groups"
           values = [
             "test",
           ]
@@ -93,9 +94,10 @@ consumption_budgets = {
         #   #     "example",
         #   #   ]
         #   # },
-        #   resource_group_key = {
+        #   resource_key = {
         #     # lz_key = "examples"
-        #     name = "resource_group_key"
+        #     name         = "resource_key"
+        #     resource_key = "resource_groups"
         #     values = [
         #       "test",
         #     ]

--- a/examples/consumption_budget/102-consumption-budget-rg-alerts/configuration.tfvars
+++ b/examples/consumption_budget/102-consumption-budget-rg-alerts/configuration.tfvars
@@ -81,9 +81,10 @@ consumption_budgets = {
             "example",
           ]
         },
-        resource_group_key = {
+        resource_key = {
           # lz_key = "examples"
-          name = "resource_group_key"
+          name         = "resource_key"
+          resource_key = "resource_groups"
           values = [
             "test",
           ]
@@ -111,9 +112,10 @@ consumption_budgets = {
         #   #     "example",
         #   #   ]
         #   # },
-        #   resource_group_key = {
+        #   resource_key = {
         #     # lz_key = "examples"
-        #     name = "resource_group_key"
+        #     name         = "resource_key"
+        #     resource_key = "resource_groups"
         #     values = [
         #       "test",
         #     ]

--- a/examples/consumption_budget/103-consumption-budget-subscription-alerts/configuration.tfvars
+++ b/examples/consumption_budget/103-consumption-budget-subscription-alerts/configuration.tfvars
@@ -80,9 +80,10 @@ consumption_budgets = {
             "example",
           ]
         },
-        resource_group_key = {
+        resource_key = {
           # lz_key = "examples"
-          name = "resource_group_key"
+          name         = "resource_key"
+          resource_key = "resource_groups"
           values = [
             "test",
           ]
@@ -110,9 +111,10 @@ consumption_budgets = {
         #   #     "example",
         #   #   ]
         #   # },
-        #   resource_group_key = {
+        #   resource_key = {
         #     # lz_key = "examples"
-        #     name = "resource_group_key"
+        #     name         = "resource_key"
+        #     resource_key = "resource_groups"
         #     values = [
         #       "test",
         #     ]

--- a/examples/consumption_budget/104-consumption-budget-subscription-vm/consumption-budgets.tfvars
+++ b/examples/consumption_budget/104-consumption-budget-subscription-vm/consumption-budgets.tfvars
@@ -34,8 +34,8 @@ consumption_budgets = {
         # },
         resource_key = {
           # lz_key = "examples"
-          name     = "resource_key"
-          resource = "virtual_machines"
+          name         = "resource_key"
+          resource_key = "virtual_machines"
           values = [
             "example_vm1",
           ]

--- a/examples/consumption_budget/104-consumption-budget-subscription-vm/consumption-budgets.tfvars
+++ b/examples/consumption_budget/104-consumption-budget-subscription-vm/consumption-budgets.tfvars
@@ -1,0 +1,46 @@
+consumption_budgets = {
+  test_budget = {
+    subscription = {
+      # id     = "<subscription_id>"
+      # lz_key = ""
+      # key    = ""
+    }
+    name       = "example"
+    amount     = 1000
+    time_grain = "Monthly"
+    time_period = {
+      # uncomment to customize start_date
+      # start_date = "2022-06-01T00:00:00Z"
+    }
+    notifications = {
+      default = {
+        enabled   = true
+        threshold = 95.0
+        operator  = "EqualTo"
+        contact_emails = [
+          "foo@example.com",
+          "bar@example.com",
+        ]
+      }
+    }
+    filter = {
+      dimensions = {
+        # explicit_name = {
+        #   name     = "ResourceGroupName"
+        #   operator = "In"
+        #   values = [
+        #     "example",
+        #   ]
+        # },
+        resource_key = {
+          # lz_key = "examples"
+          name     = "resource_key"
+          resource = "virtual_machines"
+          values = [
+            "example_vm1",
+          ]
+        }
+      }
+    }
+  }
+}

--- a/examples/consumption_budget/104-consumption-budget-subscription-vm/consumption-budgets.tfvars
+++ b/examples/consumption_budget/104-consumption-budget-subscription-vm/consumption-budgets.tfvars
@@ -25,13 +25,6 @@ consumption_budgets = {
     }
     filter = {
       dimensions = {
-        # explicit_name = {
-        #   name     = "ResourceGroupName"
-        #   operator = "In"
-        #   values = [
-        #     "example",
-        #   ]
-        # },
         resource_key = {
           # lz_key = "examples"
           name         = "resource_key"

--- a/examples/consumption_budget/104-consumption-budget-subscription-vm/single-windows-vm.tfvars
+++ b/examples/consumption_budget/104-consumption-budget-subscription-vm/single-windows-vm.tfvars
@@ -1,0 +1,134 @@
+
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "southeastasia"
+  }
+}
+
+resource_groups = {
+  vm_region1 = {
+    name = "example-virtual-machine-rg1"
+  }
+}
+
+# Virtual machines
+virtual_machines = {
+
+  # Configuration to deploy a bastion host linux virtual machine
+  example_vm1 = {
+    resource_group_key = "vm_region1"
+    provision_vm_agent = true
+    # when boot_diagnostics_storage_account_key is empty string "", boot diagnostics will be put on azure managed storage
+    # when boot_diagnostics_storage_account_key is a non-empty string, it needs to point to the key of a user managed storage defined in diagnostic_storage_accounts
+    # if boot_diagnostics_storage_account_key is not defined, but global_settings.resource_defaults.virtual_machines.use_azmanaged_storage_for_boot_diagnostics is true, boot diagnostics will be put on azure managed storage
+    boot_diagnostics_storage_account_key = "bootdiag_region1"
+
+    os_type = "windows"
+
+    # the auto-generated ssh key in keyvault secret. Secret name being {VM name}-ssh-public and {VM name}-ssh-private
+    keyvault_key = "example_vm_rg1"
+
+    # Define the number of networking cards to attach the virtual machine
+    networking_interfaces = {
+      nic0 = {
+        # Value of the keys from networking.tfvars
+        vnet_key                = "vnet_region1"
+        subnet_key              = "example"
+        name                    = "0"
+        enable_ip_forwarding    = false
+        internal_dns_name_label = "nic0"
+        public_ip_address_key   = "example_vm_pip1_rg1"
+      }
+    }
+
+    virtual_machine_settings = {
+      windows = {
+        name           = "example_vm2"
+        size           = "Standard_F2"
+        admin_username = "adminuser"
+
+        # Spot VM to save money
+        priority        = "Spot"
+        eviction_policy = "Deallocate"
+
+        # Value of the nic keys to attach the VM. The first one in the list is the default nic
+        network_interface_keys = ["nic0"]
+
+        os_disk = {
+          name                 = "example_vm1-os"
+          caching              = "ReadWrite"
+          storage_account_type = "Standard_LRS"
+        }
+
+        source_image_reference = {
+          publisher = "MicrosoftWindowsServer"
+          offer     = "WindowsServer"
+          sku       = "2019-Datacenter"
+          version   = "latest"
+        }
+
+      }
+    }
+
+  }
+}
+
+
+diagnostic_storage_accounts = {
+  # Stores boot diagnostic for region1
+  bootdiag_region1 = {
+    name                     = "bootrg1"
+    resource_group_key       = "vm_region1"
+    account_kind             = "StorageV2"
+    account_tier             = "Standard"
+    account_replication_type = "LRS"
+    access_tier              = "Cool"
+  }
+}
+
+
+
+keyvaults = {
+  example_vm_rg1 = {
+    name               = "vmsecrets"
+    resource_group_key = "vm_region1"
+    sku_name           = "standard"
+    creation_policies = {
+      logged_in_user = {
+        secret_permissions = ["Set", "Get", "List", "Delete", "Purge", "Recover"]
+      }
+    }
+  }
+}
+
+
+vnets = {
+  vnet_region1 = {
+    resource_group_key = "vm_region1"
+    vnet = {
+      name          = "virtual_machines"
+      address_space = ["10.100.100.0/24"]
+    }
+    specialsubnets = {}
+    subnets = {
+      example = {
+        name = "examples"
+        cidr = ["10.100.100.0/29"]
+      }
+    }
+
+  }
+}
+
+public_ip_addresses = {
+  example_vm_pip1_rg1 = {
+    name                    = "example_vm_pip1"
+    resource_group_key      = "vm_region1"
+    sku                     = "Standard"
+    allocation_method       = "Static"
+    ip_version              = "IPv4"
+    idle_timeout_in_minutes = "4"
+
+  }
+}

--- a/examples/consumption_budget/105-consumption-budget-subscription-aks/aks.tfvars
+++ b/examples/consumption_budget/105-consumption-budget-subscription-aks/aks.tfvars
@@ -1,0 +1,75 @@
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "southeastasia"
+  }
+}
+
+resource_groups = {
+  aks_re1 = {
+    name   = "aks-re1"
+    region = "region1"
+  }
+}
+
+aks_clusters = {
+  cluster_re1 = {
+    name               = "akscluster-re1-001"
+    resource_group_key = "aks_re1"
+    os_type            = "Linux"
+
+    identity = {
+      type = "SystemAssigned"
+    }
+
+    vnet_key = "spoke_aks_re1"
+
+    network_profile = {
+      network_plugin    = "azure"
+      load_balancer_sku = "Standard"
+    }
+
+    # enable_rbac = true
+    role_based_access_control = {
+      enabled = true
+      azure_active_directory = {
+        managed = true
+      }
+    }
+
+    addon_profile = {
+      oms_agent = {
+        enabled           = true
+        log_analytics_key = "central_logs_region1"
+      }
+    }
+    # admin_groups = {
+    #   # ids = []
+    #   # azuread_groups = {
+    #   #   keys = []
+    #   # }
+    # }
+
+    load_balancer_profile = {
+      # Only one option can be set
+      managed_outbound_ip_count = 1
+    }
+
+    default_node_pool = {
+      name                  = "sharedsvc"
+      vm_size               = "Standard_F4s_v2"
+      subnet_key            = "aks_nodepool_system"
+      enabled_auto_scaling  = false
+      enable_node_public_ip = false
+      max_pods              = 30
+      node_count            = 1
+      os_disk_size_gb       = 512
+      tags = {
+        "project" = "system services"
+      }
+    }
+
+    node_resource_group_name = "aks-nodes-re1"
+
+  }
+}

--- a/examples/consumption_budget/105-consumption-budget-subscription-aks/consumption-budgets.tfvars
+++ b/examples/consumption_budget/105-consumption-budget-subscription-aks/consumption-budgets.tfvars
@@ -1,0 +1,39 @@
+consumption_budgets = {
+  test_budget = {
+    subscription = {
+      # id     = "<subscription_id>"
+      # lz_key = ""
+      # key    = ""
+    }
+    name       = "example"
+    amount     = 1000
+    time_grain = "Monthly"
+    time_period = {
+      # uncomment to customize start_date
+      # start_date = "2022-06-01T00:00:00Z"
+    }
+    notifications = {
+      default = {
+        enabled   = true
+        threshold = 95.0
+        operator  = "EqualTo"
+        contact_emails = [
+          "foo@example.com",
+          "bar@example.com",
+        ]
+      }
+    }
+    filter = {
+      dimensions = {
+        resource_key = {
+          # lz_key = "examples"
+          name         = "resource_key"
+          resource_key = "aks"
+          values = [
+            "cluster_re1",
+          ]
+        }
+      }
+    }
+  }
+}

--- a/examples/consumption_budget/105-consumption-budget-subscription-aks/diagnostics.tfvars
+++ b/examples/consumption_budget/105-consumption-budget-subscription-aks/diagnostics.tfvars
@@ -1,0 +1,7 @@
+diagnostic_log_analytics = {
+  central_logs_region1 = {
+    region             = "region1"
+    name               = "logs"
+    resource_group_key = "aks_re1"
+  }
+}

--- a/examples/consumption_budget/105-consumption-budget-subscription-aks/networking.tfvars
+++ b/examples/consumption_budget/105-consumption-budget-subscription-aks/networking.tfvars
@@ -1,0 +1,190 @@
+vnets = {
+  spoke_aks_re1 = {
+    resource_group_key = "aks_re1"
+    region             = "region1"
+    vnet = {
+      name          = "aks"
+      address_space = ["100.64.48.0/22"]
+    }
+    specialsubnets = {}
+    subnets = {
+      aks_nodepool_system = {
+        name    = "aks_nodepool_system"
+        cidr    = ["100.64.48.0/24"]
+        nsg_key = "azure_kubernetes_cluster_nsg"
+      }
+      aks_nodepool_user1 = {
+        name    = "aks_nodepool_user1"
+        cidr    = ["100.64.49.0/24"]
+        nsg_key = "azure_kubernetes_cluster_nsg"
+      }
+      aks_nodepool_user2 = {
+        name    = "aks_nodepool_user2"
+        cidr    = ["100.64.50.0/24"]
+        nsg_key = "azure_kubernetes_cluster_nsg"
+      }
+      AzureBastionSubnet = {
+        name    = "AzureBastionSubnet" #Must be called AzureBastionSubnet
+        cidr    = ["100.64.51.64/27"]
+        nsg_key = "azure_bastion_nsg"
+      }
+      private_endpoints = {
+        name                                           = "private_endpoints"
+        cidr                                           = ["100.64.51.0/27"]
+        enforce_private_link_endpoint_network_policies = true
+      }
+      jumpbox = {
+        name    = "jumpbox"
+        cidr    = ["100.64.51.128/27"]
+        nsg_key = "azure_bastion_nsg"
+      }
+    }
+
+  }
+}
+
+network_security_group_definition = {
+  # This entry is applied to all subnets with no NSG defined
+  empty_nsg = {}
+  azure_kubernetes_cluster_nsg = {
+    nsg = [
+      {
+        name                       = "aks-http-in-allow",
+        priority                   = "100"
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_range     = "80"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+      },
+      {
+        name                       = "aks-https-in-allow",
+        priority                   = "110"
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_range     = "443"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+      },
+      {
+        name                       = "aks-api-out-allow-1194",
+        priority                   = "100"
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "udp"
+        source_port_range          = "*"
+        destination_port_range     = "1194"
+        source_address_prefix      = "*"
+        destination_address_prefix = "AzureCloud"
+      },
+      {
+        name                       = "aks-api-out-allow-9000",
+        priority                   = "110"
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_range     = "9000"
+        source_address_prefix      = "*"
+        destination_address_prefix = "AzureCloud"
+      },
+      {
+        name                       = "aks-ntp-out-allow",
+        priority                   = "120"
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "udp"
+        source_port_range          = "*"
+        destination_port_range     = "123"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+      },
+      {
+        name                       = "aks-https-out-allow-443",
+        priority                   = "130"
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_range     = "443"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+      },
+    ]
+  }
+  azure_bastion_nsg = {
+
+    nsg = [
+      {
+        name                       = "bastion-in-allow",
+        priority                   = "100"
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_range     = "443"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+      },
+      {
+        name                       = "bastion-control-in-allow-443",
+        priority                   = "120"
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_range     = "135"
+        source_address_prefix      = "GatewayManager"
+        destination_address_prefix = "*"
+      },
+      {
+        name                       = "Kerberos-password-change",
+        priority                   = "121"
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_range     = "4443"
+        source_address_prefix      = "GatewayManager"
+        destination_address_prefix = "*"
+      },
+      {
+        name                       = "bastion-vnet-out-allow-22",
+        priority                   = "103"
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_range     = "22"
+        source_address_prefix      = "*"
+        destination_address_prefix = "VirtualNetwork"
+      },
+      {
+        name                       = "bastion-vnet-out-allow-3389",
+        priority                   = "101"
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_range     = "3389"
+        source_address_prefix      = "*"
+        destination_address_prefix = "VirtualNetwork"
+      },
+      {
+        name                       = "bastion-azure-out-allow",
+        priority                   = "120"
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_range     = "443"
+        source_address_prefix      = "*"
+        destination_address_prefix = "AzureCloud"
+      }
+    ]
+  }
+}

--- a/examples/consumption_budget/README.md
+++ b/examples/consumption_budget/README.md
@@ -23,6 +23,7 @@ The following examples are available:
 | [102-consumption-budget-rg-alerts](./102-consumption-budget-rg-alerts) | Simple example for consumption budget deployed at resource group scope, integrated with action groups. |
 | [103-consumption-budget-subscription-alerts](./103-consumption-budget-subscription-alerts) | Simple example for consumption budget deployed at subscription scope, integrated with action groups. |
 | [104-consumption-budget-subscription-vm](./104-consumption-budget-subscription-vm) | Consumption budget deployed at subscription scope, integrated with Azure windows virtual machine. |
+| [105-consumption-budget-subscription-aks](./105-consumption-budget-subscription-vm) | Consumption budget deployed at subscription scope, integrated with Azure Kubernetes Service single cluster |
 
 ## Run this example
 

--- a/examples/consumption_budget/README.md
+++ b/examples/consumption_budget/README.md
@@ -22,6 +22,7 @@ The following examples are available:
 | [101-consumption-budget-subscription](./101-consumption-budget-subscription) | Simple example for consumption budget deployed at subscription scope. |
 | [102-consumption-budget-rg-alerts](./102-consumption-budget-rg-alerts) | Simple example for consumption budget deployed at resource group scope, integrated with action groups. |
 | [103-consumption-budget-subscription-alerts](./103-consumption-budget-subscription-alerts) | Simple example for consumption budget deployed at subscription scope, integrated with action groups. |
+| [104-consumption-budget-subscription-vm](./104-consumption-budget-subscription-vm) | Consumption budget deployed at subscription scope, integrated with Azure windows virtual machine. |
 
 ## Run this example
 

--- a/modules/consumption_budget/resource_group/resource_group_budget.tf
+++ b/modules/consumption_budget/resource_group/resource_group_budget.tf
@@ -12,7 +12,7 @@ resource "azurerm_consumption_budget_resource_group" "this" {
   name = azurecaf_name.this_name.result
   resource_group_id = coalesce(
     try(var.settings.resource_group.id, null),
-    try(var.resource_groups[try(var.settings.resource_group.lz_key, var.client_config.landingzone_key)][var.settings.resource_group.key].id, null)
+    try(var.local_combined_resources["resource_groups"][try(var.settings.resource_group.lz_key, var.client_config.landingzone_key)][var.settings.resource_group.key].id, null)
   )
 
   amount     = var.settings.amount
@@ -32,7 +32,7 @@ resource "azurerm_consumption_budget_resource_group" "this" {
 
       contact_emails = try(notification.value.contact_emails, [])
       contact_groups = try(notification.value.contact_groups, try(flatten([
-        for key, value in var.monitor_action_groups[try(notification.value.lz_key, var.client_config.landingzone_key)] : value.id
+        for key, value in var.local_combined_resources["monitor_action_groups"][try(notification.value.lz_key, var.client_config.landingzone_key)] : value.id
         if contains(notification.value.contact_groups_keys, key)
         ]), [])
       )
@@ -48,7 +48,7 @@ resource "azurerm_consumption_budget_resource_group" "this" {
       dynamic "dimension" {
         for_each = {
           for key, value in try(var.settings.filter.dimensions, {}) : key => value
-          if lower(value.name) != "resource_group_key"
+          if lower(value.name) != "resource_key"
         }
 
         content {
@@ -61,14 +61,14 @@ resource "azurerm_consumption_budget_resource_group" "this" {
       dynamic "dimension" {
         for_each = {
           for key, value in try(var.settings.filter.dimensions, {}) : key => value
-          if lower(value.name) == "resource_group_key"
+          if lower(value.name) == "resource_key"
         }
 
         content {
           name     = "ResourceId"
           operator = try(dimension.value.operator, "In")
           values = try(flatten([
-            for key, value in var.resource_groups[try(dimension.value.lz_key, var.client_config.landingzone_key)] : value.id
+            for key, value in var.local_combined_resources[dimension.value.resource_key][try(dimension.value.lz_key, var.client_config.landingzone_key)] : value.id
             if contains(dimension.value.values, key)
           ]), [])
         }
@@ -93,7 +93,7 @@ resource "azurerm_consumption_budget_resource_group" "this" {
           dynamic "dimension" {
             for_each = {
               for key, value in try(var.settings.filter.not.dimension, {}) : key => value
-              if lower(value.name) != "resource_group_key"
+              if lower(value.name) != "resource_key"
             }
 
             content {
@@ -106,14 +106,14 @@ resource "azurerm_consumption_budget_resource_group" "this" {
           dynamic "dimension" {
             for_each = {
               for key, value in try(var.settings.filter.not.dimension, {}) : key => value
-              if lower(value.name) == "resource_group_key"
+              if lower(value.name) == "resource_key"
             }
 
             content {
               name     = "ResourceId"
               operator = try(dimension.value.operator, "In")
               values = try(flatten([
-                for key, value in var.resource_groups[try(dimension.value.lz_key, var.client_config.landingzone_key)] : value.id
+                for key, value in var.local_combined_resources[dimension.value.resource_key][try(dimension.value.lz_key, var.client_config.landingzone_key)] : value.id
                 if contains(dimension.value.values, key)
               ]), [])
             }

--- a/modules/consumption_budget/resource_group/variables.tf
+++ b/modules/consumption_budget/resource_group/variables.tf
@@ -6,12 +6,8 @@ variable "global_settings" {
   description = "Global settings object"
 }
 
-variable "monitor_action_groups" {
-  description = "Map of monitor action group keys to monitor action groups group ids"
-}
-
-variable "resource_groups" {
-  description = "Map of resource group keys to resource group attributes"
+variable "local_combined_resources" {
+  description = "object of local combined resources"
 }
 
 variable "settings" {

--- a/modules/consumption_budget/subscription/subscription_budget.tf
+++ b/modules/consumption_budget/subscription/subscription_budget.tf
@@ -29,7 +29,7 @@ resource "azurerm_consumption_budget_subscription" "this" {
 
       contact_emails = try(notification.value.contact_emails, [])
       contact_groups = try(notification.value.contact_groups, try(flatten([
-        for key, value in var.monitor_action_groups[try(notification.value.lz_key, var.client_config.landingzone_key)] : value.id
+        for key, value in var.local_combined_resources["monitor_action_groups"][try(notification.value.lz_key, var.client_config.landingzone_key)] : value.id
         if contains(notification.value.contact_groups_keys, key)
         ]), [])
       )
@@ -45,7 +45,7 @@ resource "azurerm_consumption_budget_subscription" "this" {
       dynamic "dimension" {
         for_each = {
           for key, value in try(var.settings.filter.dimensions, {}) : key => value
-          if lower(value.name) != "resource_group_key"
+          if lower(value.name) != "resource_key"
         }
 
         content {
@@ -58,14 +58,14 @@ resource "azurerm_consumption_budget_subscription" "this" {
       dynamic "dimension" {
         for_each = {
           for key, value in try(var.settings.filter.dimensions, {}) : key => value
-          if lower(value.name) == "resource_group_key"
+          if lower(value.name) == "resource_key"
         }
 
         content {
           name     = "ResourceId"
           operator = try(dimension.value.operator, "In")
           values = try(flatten([
-            for key, value in var.resource_groups[try(dimension.value.lz_key, var.client_config.landingzone_key)] : value.id
+            for key, value in var.local_combined_resources[dimension.value.resource_key][try(dimension.value.lz_key, var.client_config.landingzone_key)] : value.id
             if contains(dimension.value.values, key)
           ]), [])
         }
@@ -90,7 +90,7 @@ resource "azurerm_consumption_budget_subscription" "this" {
           dynamic "dimension" {
             for_each = {
               for key, value in try(var.settings.filter.not.dimension, {}) : key => value
-              if lower(value.name) != "resource_group_key"
+              if lower(value.name) != "resource_key"
             }
 
             content {
@@ -103,14 +103,14 @@ resource "azurerm_consumption_budget_subscription" "this" {
           dynamic "dimension" {
             for_each = {
               for key, value in try(var.settings.filter.not.dimension, {}) : key => value
-              if lower(value.name) == "resource_group_key"
+              if lower(value.name) == "resource_key"
             }
 
             content {
               name     = "ResourceId"
               operator = try(dimension.value.operator, "In")
               values = try(flatten([
-                for key, value in var.resource_groups[try(dimension.value.lz_key, var.client_config.landingzone_key)] : value.id
+                for key, value in var.local_combined_resources[dimension.value.resource_key][try(dimension.value.lz_key, var.client_config.landingzone_key)] : value.id
                 if contains(dimension.value.values, key)
               ]), [])
             }

--- a/modules/consumption_budget/subscription/subscription_budget.tf
+++ b/modules/consumption_budget/subscription/subscription_budget.tf
@@ -9,8 +9,12 @@ resource "azurecaf_name" "this_name" {
 }
 
 resource "azurerm_consumption_budget_subscription" "this" {
-  name            = azurecaf_name.this_name.result
-  subscription_id = var.subscription_id
+  name = azurecaf_name.this_name.result
+  subscription_id = coalesce(
+    try(var.settings.subscription.id, null),
+    try(var.local_combined_resources["subscriptions"][try(var.settings.subscription.lz_key, var.client_config.landingzone_key)][var.settings.subscription.key].subscription_id, null),
+    var.client_config.subscription_id
+  )
 
   amount     = var.settings.amount
   time_grain = var.settings.time_grain

--- a/modules/consumption_budget/subscription/variables.tf
+++ b/modules/consumption_budget/subscription/variables.tf
@@ -6,12 +6,8 @@ variable "global_settings" {
   description = "Global settings object"
 }
 
-variable "monitor_action_groups" {
-  description = "Map of monitor action group keys to monitor action groups group ids"
-}
-
-variable "resource_groups" {
-  description = "Map of resource group keys to resource group attributes"
+variable "local_combined_resources" {
+  description = "object of local combined resources"
 }
 
 variable "settings" {

--- a/modules/consumption_budget/subscription/variables.tf
+++ b/modules/consumption_budget/subscription/variables.tf
@@ -13,8 +13,3 @@ variable "local_combined_resources" {
 variable "settings" {
   description = "Configuration object for the consumption budget subscription"
 }
-
-variable "subscription_id" {
-  description = "The ID of the Subscription to create the consumption budget for"
-  type        = string
-}

--- a/networking_firewall_policy.tf
+++ b/networking_firewall_policy.tf
@@ -10,7 +10,7 @@ module "azurerm_firewall_policies" {
   settings        = each.value
   tags            = try(each.value.tags, null)
 
-  resource_group  = coalesce(
+  resource_group = coalesce(
     try(local.combined_objects_resource_groups[each.value.lz_key][each.value.resource_group_key], null),
     try(local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group.key], null),
     try(local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group_key], null),

--- a/networking_virtual_hub_connection.tf
+++ b/networking_virtual_hub_connection.tf
@@ -61,8 +61,8 @@ resource "azurerm_virtual_hub_connection" "vhub_connection" {
         for_each = try(routing.value.static_vnet_route, {})
 
         content {
-          name                = static_vnet_route.value.name
-          address_prefixes    = static_vnet_route.value.address_prefixes
+          name             = static_vnet_route.value.name
+          address_prefixes = static_vnet_route.value.address_prefixes
           next_hop_ip_address = coalesce(
             try(static_vnet_route.value.next_hop_ip_address, null),
             try(local.combined_objects_azurerm_firewalls[static_vnet_route.value.next_hop.lz_key][static_vnet_route.value.next_hop.key].ip_configuration[static_vnet_route.value.next_hop.interface_index].private_ip_address, null),


### PR DESCRIPTION
# Description

Move all references of `local.combined_objects_*` to a `local_combined_resources` object at the root level.

# Motivation

This allows additional `local.combined_objects_*` to be passed in which can then be used in the `filter` property of the consumption budget to filter on specific resources like a virtual machine.

# Examples added

`examples/consumption_budget/104-consumption-budget-subscription-vm`

![image](https://user-images.githubusercontent.com/31919569/126496268-da0c0607-db4d-4127-b8f6-3524e863a8c8.png)

- `filter` now contains the reference to the virtual machine

`examples/consumption_budget/105-consumption-budget-subscription-aks`

![image](https://user-images.githubusercontent.com/31919569/126498998-94344003-1e89-4b95-976b-2944debdb274.png)

- `filter` now contains the reference to the aks cluster

