### PR TITLE
Feature/managed identity remote

### DIFF
--- a/examples/managed_service_identity/100-msi-levels/configuration.tfvars
+++ b/examples/managed_service_identity/100-msi-levels/configuration.tfvars
@@ -17,8 +17,15 @@ managed_identities = {
   level0 = {
     # Used by the release agent to access the level0 keyvault and storage account with the tfstates in read / write
     # Assign read access to level0
-    name               = "msi-level0"
-    resource_group_key = "msi_region1"
+    name = "msi-level0"
+    resource_group = {
+      # accepts either id or key to get resource group id
+      # id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1"
+      # lz_key = "examples"
+      key = "msi_region1"
+    }
+    # resource_group_key will be deprecated in the future
+    # resource_group_key = "msi_region1"
     tags = {
       level = "level0"
     }
@@ -26,8 +33,15 @@ managed_identities = {
   level1 = {
     # Used by the release agent to access the level1 keyvault and storage account with the tfstates in read / write
     # Assign read access to level0
-    name               = "msi-level1"
-    resource_group_key = "msi_region1"
+    name = "msi-level1"
+    resource_group = {
+      # accepts either id or key to get resource group id
+      # id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1"
+      # lz_key = "examples"
+      key = "msi_region1"
+    }
+    # resource_group_key will be deprecated in the future
+    # resource_group_key = "msi_region1"
     tags = {
       level = "level1"
     }
@@ -35,8 +49,15 @@ managed_identities = {
   level2 = {
     # Used by the release agent to access the level2 keyvault and storage account with the tfstates in read / write
     # Assign read access to level1
-    name               = "msi-level2"
-    resource_group_key = "msi_region1"
+    name = "msi-level2"
+    resource_group = {
+      # accepts either id or key to get resource group id
+      # id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1"
+      # lz_key = "examples"
+      key = "msi_region1"
+    }
+    # resource_group_key will be deprecated in the future
+    # resource_group_key = "msi_region1"
     tags = {
       level = "level2"
     }
@@ -44,8 +65,15 @@ managed_identities = {
   level3 = {
     # Used by the release agent to access the level3 keyvault and storage account with the tfstates in read / write
     # Assign read access to level2
-    name               = "msi-level3"
-    resource_group_key = "msi_region1"
+    name = "msi-level3"
+    resource_group = {
+      # accepts either id or key to get resource group id
+      # id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1"
+      # lz_key = "examples"
+      key = "msi_region1"
+    }
+    # resource_group_key will be deprecated in the future
+    # resource_group_key = "msi_region1"
     tags = {
       level = "level3"
     }
@@ -53,8 +81,15 @@ managed_identities = {
   level4 = {
     # Used by the release agent to access the level4 keyvault and storage account with the tfstates in read / write
     # Assign read access to level3
-    name               = "msi-level4"
-    resource_group_key = "msi_region1"
+    name = "msi-level4"
+    resource_group = {
+      # accepts either id or key to get resource group id
+      # id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1"
+      # lz_key = "examples"
+      key = "msi_region1"
+    }
+    # resource_group_key will be deprecated in the future
+    # resource_group_key = "msi_region1"
     tags = {
       level = "level4"
     }

--- a/examples/managed_service_identity/100-msi-levels/configuration.tfvars
+++ b/examples/managed_service_identity/100-msi-levels/configuration.tfvars
@@ -19,8 +19,6 @@ managed_identities = {
     # Assign read access to level0
     name = "msi-level0"
     resource_group = {
-      # accepts either id or key to get resource group id
-      # id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1"
       # lz_key = "examples"
       key = "msi_region1"
     }
@@ -35,8 +33,6 @@ managed_identities = {
     # Assign read access to level0
     name = "msi-level1"
     resource_group = {
-      # accepts either id or key to get resource group id
-      # id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1"
       # lz_key = "examples"
       key = "msi_region1"
     }
@@ -51,8 +47,6 @@ managed_identities = {
     # Assign read access to level1
     name = "msi-level2"
     resource_group = {
-      # accepts either id or key to get resource group id
-      # id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1"
       # lz_key = "examples"
       key = "msi_region1"
     }
@@ -67,8 +61,6 @@ managed_identities = {
     # Assign read access to level2
     name = "msi-level3"
     resource_group = {
-      # accepts either id or key to get resource group id
-      # id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1"
       # lz_key = "examples"
       key = "msi_region1"
     }
@@ -83,8 +75,6 @@ managed_identities = {
     # Assign read access to level3
     name = "msi-level4"
     resource_group = {
-      # accepts either id or key to get resource group id
-      # id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1"
       # lz_key = "examples"
       key = "msi_region1"
     }

--- a/examples/managed_service_identity/README.md
+++ b/examples/managed_service_identity/README.md
@@ -7,7 +7,46 @@ You can instantiate this directly using the following parameters:
 ```hcl
 module "caf" {
   source  = "aztfmod/caf/azurerm"
-  version = "5.1.0"
+  version = "5.4.2"
   # insert the 7 required variables here
 }
+```
+
+## Example scenarios
+
+The following examples are available:
+
+| Scenario                                                     | Description                                                  |
+| ------------------------------------------------------------ | ------------------------------------------------------------ |
+| [100-msi-levels](./100-msi-levels)     | Deploys 4 levels of managed service identities. |
+
+## Run this example
+
+You can run this example directly using Terraform or via rover:
+
+### With Terraform
+
+```bash
+#Login to your Azure subscription
+az login
+
+#Run the example
+cd /tf/caf/examples
+
+terraform init
+
+terraform [plan | apply | destroy] \
+  -var-file ./managed_service_identity/100-msi-levels/configuration.tfvars
+```
+
+### With rover
+
+To test this deployment in the example landingzone, make sure the launchpad has been deployed first, then run the following command:
+
+```bash
+rover \
+  -lz /tf/caf/examples \
+  -var-folder  /tf/caf/examples/managed_service_identity/100-msi-levels/ \
+  -level level1 \
+  -a [plan | apply | destroy]
 ```

--- a/managed_identities.tf
+++ b/managed_identities.tf
@@ -3,12 +3,11 @@ module "managed_identities" {
   source   = "./modules/security/managed_identity"
   for_each = var.managed_identities
 
-  name                = each.value.name
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
-  location            = local.resource_groups[each.value.resource_group_key].location
-  global_settings     = local.global_settings
-  settings            = each.value
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  client_config   = local.client_config
+  global_settings = local.global_settings
+  name            = each.value.name
+  resource_groups = local.combined_objects_resource_groups
+  settings        = each.value
 }
 
 output "managed_identities" {

--- a/modules/security/managed_identity/managed_identity.tf
+++ b/modules/security/managed_identity/managed_identity.tf
@@ -12,10 +12,32 @@ resource "azurecaf_name" "msi" {
 }
 
 resource "azurerm_user_assigned_identity" "msi" {
-  name                = azurecaf_name.msi.result
-  resource_group_name = var.resource_group_name
-  location            = var.location
-  tags                = try(merge(var.base_tags, local.tags), {})
+  name = azurecaf_name.msi.result
+  resource_group_name = coalesce(
+    try(var.resource_groups[var.settings.resource_group.lz_key][var.settings.resource_group.key].name, null),
+    try(var.resource_groups[var.client_config.landingzone_key][var.settings.resource_group.key].name, null),
+    try(var.resource_groups[var.settings.resource_group.lz_key][var.settings.resource_group_key].name, null),
+    try(var.resource_groups[var.client_config.landingzone_key][var.settings.resource_group_key].name, null),
+  )
+  location = coalesce(
+    try(var.resource_groups[var.settings.resource_group.lz_key][var.settings.resource_group.key].location, null),
+    try(var.resource_groups[var.client_config.landingzone_key][var.settings.resource_group.key].location, null),
+    try(var.resource_groups[var.settings.resource_group.lz_key][var.settings.resource_group_key].location, null),
+    try(var.resource_groups[var.client_config.landingzone_key][var.settings.resource_group_key].location, null),
+  )
+  tags = try(
+    merge(
+      try(var.global_settings.inherit_tags, false) ?
+      coalesce(
+        try(var.resource_groups[var.settings.resource_group.lz_key][var.settings.resource_group.key].tags, null),
+        try(var.resource_groups[var.client_config.landingzone_key][var.settings.resource_group.key].tags, null),
+        try(var.resource_groups[var.settings.resource_group.lz_key][var.settings.resource_group_key].tags, null),
+        try(var.resource_groups[var.client_config.landingzone_key][var.settings.resource_group_key].tags, null),
+      ) : {},
+      local.tags
+    ),
+    {}
+  )
 }
 
 resource "time_sleep" "propagate_to_azuread" {

--- a/modules/security/managed_identity/variables.tf
+++ b/modules/security/managed_identity/variables.tf
@@ -1,20 +1,14 @@
-variable "resource_group_name" {
-  description = "(Required) The name of the resource group where to create the resource."
-  type        = string
-}
-variable "location" {
-  description = "(Required) Specifies the supported Azure location where to create the resource. Changing this forces a new resource to be created."
-  type        = string
+variable "client_config" {
+  description = "Client configuration object"
 }
 variable "name" {}
 variable "global_settings" {
   description = "Global settings object (see module README.md)"
 }
-variable "settings" {}
-variable "base_tags" {
-  description = "Base tags for the resource to be inherited from the resource group."
-  type        = map(any)
+variable "resource_groups" {
+  description = "Combined object of local and remote resource groups."
 }
+variable "settings" {}
 variable "tags" {
   default = null
 }


### PR DESCRIPTION
# Description

Issue ID: #597

Enable remote resource group references for managed identity module. This uses the `local.combined_objects_resource_groups` at the root level in `./managed_identities.tf` and destructures the `resource_group_name`, `location`, and `base_tags` at the resource level.

Examples in the `configuration.tfvars` have been refactored to reference the `key` within a `resource_group` object

# Verifying the changes

Ran `rover -lz /tf/caf/examples -var-folder /tf/caf/examples/managed_service_identity/100-msi-levels/ -level level1 -a apply` and verified deployment in the Azure portal

Level 0

![image](https://user-images.githubusercontent.com/31919569/126465640-0594d9b5-f544-44cb-b02a-aad4436eb766.png)

Level 1

![image](https://user-images.githubusercontent.com/31919569/126465279-456b0548-d113-4e51-9285-33a7324dc685.png)

Level 2

![image](https://user-images.githubusercontent.com/31919569/126465129-aa2c6c26-74fe-4c39-85f1-e1b7b898ed5e.png)

Level 3

![image](https://user-images.githubusercontent.com/31919569/126464838-f91ff107-483c-4de4-811a-b4caa7851002.png)

Level 4

![image](https://user-images.githubusercontent.com/31919569/126464909-c1856904-21a9-475a-bcb6-bd3d2d9e587c.png)

