### PR TITLE
ci/ignore all README file updates

### DIFF
--- a/.github/workflows/master-standalone-tf100.yaml
+++ b/.github/workflows/master-standalone-tf100.yaml
@@ -12,8 +12,7 @@ on:
       - .github/workflows/master-100.yaml
       - 'documentation/**'
       - '_pictures/**'
-      - 'README.md'
-      - 'examples/README.md'
+      - '**/README.md'
       - 'CHANGELOG.md'
   schedule:
     - cron:  '0 0 * * 0' #1 AM on Sunday


### PR DESCRIPTION
# Description

Now that we have README files in `examples/<module-name>/README.md`, it is better to have the CI ignore those changes to save on CI hours and free up the queue for other developers