### PR TITLE
Update to support more resource reference in RT nexthop

### DIFF
--- a/modules/networking/virtual_hub_route_tables/route_local.tf
+++ b/modules/networking/virtual_hub_route_tables/route_local.tf
@@ -8,6 +8,8 @@ locals {
         nextHopType     = "ResourceId"
         nextHop = coalesce(
           try(value.next_hop_id, ""),
+          try(var.remote_objects.virtual_hub_connections[value.next_hop.lz_key][value.next_hop.key].id, ""),
+          try(var.remote_objects.azurerm_firewalls[value.next_hop.lz_key][value.next_hop.key].id, ""),
           try(var.resource_ids[value.next_hop.resource_type][value.next_hop.lz_key][value.next_hop.key].id, "")   # Note the virtual_hub_connection must come from a remote tfstate only. PB with circular reference in the object model of vhub tables and connections
         )
       }

--- a/modules/networking/virtual_hub_route_tables/variables.tf
+++ b/modules/networking/virtual_hub_route_tables/variables.tf
@@ -1,5 +1,6 @@
 variable "client_config" {}
 variable "name" {}
+variable "remote_objects" {}
 variable "resource_ids" {}
 variable "settings" {}
 variable "virtual_hub" {}

--- a/networking_virtual_hub_route_table.tf
+++ b/networking_virtual_hub_route_table.tf
@@ -54,9 +54,10 @@ resource "azurerm_virtual_hub_route_table" "route_table" {
 }
 
 module "azurerm_virtual_hub_route_table" {
-  depends_on = [azurerm_virtual_hub_route_table.route_table]
-  source     = "./modules/networking/virtual_hub_route_tables"
-  for_each   = local.networking.virtual_hub_route_tables
+  remote_objects  = var.remote_objects
+  depends_on      = [azurerm_virtual_hub_route_table.route_table]
+  source          = "./modules/networking/virtual_hub_route_tables"
+  for_each        = local.networking.virtual_hub_route_tables
 
   client_config = local.client_config
   name          = each.value.name

--- a/networking_virtual_hub_route_table.tf
+++ b/networking_virtual_hub_route_table.tf
@@ -54,7 +54,6 @@ resource "azurerm_virtual_hub_route_table" "route_table" {
 }
 
 module "azurerm_virtual_hub_route_table" {
-  remote_objects  = var.remote_objects
   depends_on      = [azurerm_virtual_hub_route_table.route_table]
   source          = "./modules/networking/virtual_hub_route_tables"
   for_each        = local.networking.virtual_hub_route_tables
@@ -63,6 +62,11 @@ module "azurerm_virtual_hub_route_table" {
   name          = each.value.name
   settings      = each.value
 
+  remote_objects = {
+    virtual_hub_connections = local.combined_objects_virtual_hub_connections
+    azurerm_firewalls       = local.combined_objects_azurerm_firewalls 
+  }
+  
   virtual_hub = {
     id = coalesce(
       try(local.combined_objects_virtual_hubs[try(each.value.virtual_hub.lz_key, local.client_config.landingzone_key)][each.value.virtual_hub.key].id, null),


### PR DESCRIPTION
Add additional support to allow referencing remote firewall resource ID when secure vhub are used. 

Adding resources from `networking_virtual_hub_route_table.tf` might cause confusion when the merge state include both `var.remote_objects.virtual_hub_connections` and `var.remote_objects.azurerm_firewalls`. 

Might have multiple route block defined in `modules/networking/virtual_hub_route_tables/route_local.tf`, each of them may reference to its own landing zone, using the module inside might be more accurate.


Hence decided to use the inner module by passing in `var.emote_objects` into module.