### PR TITLE
Storage - Add files to storage shares

### DIFF
--- a/examples/storage_accounts/104-file-share-with-backup/configuration.tfvars
+++ b/examples/storage_accounts/104-file-share-with-backup/configuration.tfvars
@@ -36,6 +36,22 @@ storage_accounts = {
             name = "testdirectory"
           }
         }
+        files = {
+          file1 = {
+            name = "fileA"
+            source = "/tf/caf/examples/storage_accounts/104-file-share-with-backup/fileA"
+          }
+          file2 = {
+            name = "fileB"
+            source = "/tf/caf/examples/storage_accounts/104-file-share-with-backup/fileB"
+            path = "testdirectory"
+          }
+          file3 = {
+            name = "fileC"
+            source = "./storage_accounts/104-file-share-with-backup/fileC"
+            path = "testdirectory"
+          }
+        }
 
         # backups = {
         #   policy_key = "policy1"

--- a/examples/storage_accounts/104-file-share-with-backup/fileA
+++ b/examples/storage_accounts/104-file-share-with-backup/fileA
@@ -1,0 +1,1 @@
+This is fileA

--- a/examples/storage_accounts/104-file-share-with-backup/fileB
+++ b/examples/storage_accounts/104-file-share-with-backup/fileB
@@ -1,0 +1,1 @@
+This is file B

--- a/examples/storage_accounts/104-file-share-with-backup/fileC
+++ b/examples/storage_accounts/104-file-share-with-backup/fileC
@@ -1,0 +1,1 @@
+This is fileC

--- a/modules/storage_account/file_share/share_file.tf
+++ b/modules/storage_account/file_share/share_file.tf
@@ -1,0 +1,8 @@
+module "file_share_file" {
+  source   = "../file_share_file"
+  depends_on = [module.file_share_directory]
+  for_each = try(var.settings.files, {})
+
+  share_id = azurerm_storage_share.fs.id
+  settings = each.value
+}

--- a/modules/storage_account/file_share_file/file.tf
+++ b/modules/storage_account/file_share_file/file.tf
@@ -1,0 +1,11 @@
+resource "azurerm_storage_share_file" "share_file" {
+  name                = var.settings.name
+  storage_share_id    = var.share_id
+  path                = try(var.settings.path, null)
+  source              = try(var.settings.source, null)
+  content_type        = try(var.settings.content_type, null)
+  content_md5         = try(var.settings.content_md5, null)
+  content_encoding    = try(var.settings.content_encoding, null)
+  content_disposition = try(var.settings.content_disposition, null)
+  metadata            = try(var.settings.metadata, null)
+}

--- a/modules/storage_account/file_share_file/output.tf
+++ b/modules/storage_account/file_share_file/output.tf
@@ -1,0 +1,4 @@
+output "id" {
+  value = azurerm_storage_share_file.share_file.id
+}
+

--- a/modules/storage_account/file_share_file/variables.tf
+++ b/modules/storage_account/file_share_file/variables.tf
@@ -1,0 +1,2 @@
+variable "share_id" {}
+variable "settings" {}


### PR DESCRIPTION
Currently, users can create directories in in storage shares using CAF but not [files](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_share_file). This code will allow those files, using either a relative or absolute path.