### PR TITLE
Support remote rg lz referencing

### DIFF
--- a/examples/storage_accounts/100-simple-storage-account-blob-container/configuration.tfvars
+++ b/examples/storage_accounts/100-simple-storage-account-blob-container/configuration.tfvars
@@ -20,6 +20,12 @@ resource_groups = {
 storage_accounts = {
   sa1 = {
     name               = "sa1dev"
+    # This option is to enable remote RG reference
+    # resource_group = {
+    #   lz_key = ""
+    #   key    = ""
+    # }
+
     resource_group_key = "test"
     # Account types are BlobStorage, BlockBlobStorage, FileStorage, Storage and StorageV2. Defaults to StorageV2
     account_kind = "BlobStorage"

--- a/managed_identities.tf
+++ b/managed_identities.tf
@@ -1,15 +1,16 @@
+
 module "managed_identities" {
   source   = "./modules/security/managed_identity"
   for_each = var.managed_identities
 
-  name                = each.value.name
-  resource_group_name = local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].name
-  location            = local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].location
-  global_settings     = local.global_settings
-  settings            = each.value
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].tags : {}
+  client_config   = local.client_config
+  global_settings = local.global_settings
+  name            = each.value.name
+  resource_groups = local.combined_objects_resource_groups
+  settings        = each.value
 }
 
 output "managed_identities" {
   value = module.managed_identities
+
 }

--- a/managed_identities.tf
+++ b/managed_identities.tf
@@ -1,16 +1,15 @@
-
 module "managed_identities" {
   source   = "./modules/security/managed_identity"
   for_each = var.managed_identities
 
-  client_config   = local.client_config
-  global_settings = local.global_settings
-  name            = each.value.name
-  resource_groups = local.combined_objects_resource_groups
-  settings        = each.value
+  name                = each.value.name
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].name
+  location            = local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].location
+  global_settings     = local.global_settings
+  settings            = each.value
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].tags : {}
 }
 
 output "managed_identities" {
   value = module.managed_identities
-
 }

--- a/storage_accounts.tf
+++ b/storage_accounts.tf
@@ -15,19 +15,19 @@ module "storage_accounts" {
   location = coalesce(
     try(local.global_settings.regions[each.value.region],null),
     local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group.key].location,
-    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key)].location,
+    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key].location,
     local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group.key].location,
     local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group_key].location
   )
   base_tags = try(local.global_settings.inherit_tags, false) ? coalese(
     local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group.key].tags,
-    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key)].tags,
+    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key].tags,
     local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group.key].tags,
     local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group_key].tags
   ) : {}
   resource_group_name = coalesce(
     local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group.key].name,
-    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key)].name,
+    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key].name,
     local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group.key].name,
     local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group_key].name
   )

--- a/storage_accounts.tf
+++ b/storage_accounts.tf
@@ -12,7 +12,7 @@ module "storage_accounts" {
   recovery_vaults     = local.combined_objects_recovery_vaults
   private_dns         = local.combined_objects_private_dns
 
-  location = coalese(
+  location = coalesce(
     try(local.global_settings.regions[each.value.region],null),
     local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group.key].location,
     local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key)].location,
@@ -25,7 +25,7 @@ module "storage_accounts" {
     local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group.key].tags,
     local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group_key].tags
   ) : {}
-  resource_group_name = coalese(
+  resource_group_name = coalesce(
     local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group.key].name,
     local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key)].name,
     local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group.key].name,

--- a/storage_accounts.tf
+++ b/storage_accounts.tf
@@ -6,14 +6,31 @@ module "storage_accounts" {
   global_settings     = local.global_settings
   client_config       = local.client_config
   storage_account     = each.value
-  resource_group_name = local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].name
-  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].location : local.global_settings.regions[each.value.region]
   vnets               = local.combined_objects_networking
   private_endpoints   = try(each.value.private_endpoints, {})
   resource_groups     = try(each.value.private_endpoints, {}) == {} ? null : local.resource_groups
   recovery_vaults     = local.combined_objects_recovery_vaults
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].tags : {}
   private_dns         = local.combined_objects_private_dns
+
+  location = coalese(
+    try(local.global_settings.regions[each.value.region],null),
+    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group.key].location,
+    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key)].location,
+    local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group.key].location,
+    local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group_key].location
+  )
+  base_tags = try(local.global_settings.inherit_tags, false) ? coalese(
+    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group.key].tags,
+    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key)].tags,
+    local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group.key].tags,
+    local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group_key].tags
+  ) : {}
+  resource_group_name = coalese(
+    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group.key].name,
+    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key)].name,
+    local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group.key].name,
+    local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group_key].name
+  )
 }
 
 output "storage_accounts" {

--- a/storage_accounts.tf
+++ b/storage_accounts.tf
@@ -19,7 +19,7 @@ module "storage_accounts" {
     local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group.key].location,
     local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group_key].location
   )
-  base_tags = try(local.global_settings.inherit_tags, false) ? coalese(
+  base_tags = try(local.global_settings.inherit_tags, false) ? coalesce(
     local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group.key].tags,
     local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key].tags,
     local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group.key].tags,

--- a/storage_accounts.tf
+++ b/storage_accounts.tf
@@ -6,13 +6,13 @@ module "storage_accounts" {
   global_settings     = local.global_settings
   client_config       = local.client_config
   storage_account     = each.value
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].name
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].location : local.global_settings.regions[each.value.region]
   vnets               = local.combined_objects_networking
   private_endpoints   = try(each.value.private_endpoints, {})
   resource_groups     = try(each.value.private_endpoints, {}) == {} ? null : local.resource_groups
   recovery_vaults     = local.combined_objects_recovery_vaults
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].tags : {}
   private_dns         = local.combined_objects_private_dns
 }
 

--- a/storage_accounts.tf
+++ b/storage_accounts.tf
@@ -14,22 +14,22 @@ module "storage_accounts" {
 
   location = coalesce(
     try(local.global_settings.regions[each.value.region],null),
-    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group.key].location,
-    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key].location,
-    local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group.key].location,
-    local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group_key].location
+    try(local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group.key].location,null),
+    try(local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key].location,null),
+    try(local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group.key].location,null),
+    try(local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group_key].location,null)
   )
   base_tags = try(local.global_settings.inherit_tags, false) ? coalesce(
-    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group.key].tags,
-    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key].tags,
-    local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group.key].tags,
-    local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group_key].tags
+    try(local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group.key].tags,null),
+    try(local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key].tags,null),
+    try(local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group.key].tags,null),
+    try(local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group_key].tags,null)
   ) : {}
   resource_group_name = coalesce(
-    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group.key].name,
-    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key].name,
-    local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group.key].name,
-    local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group_key].name
+    try(local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group.key].name,null),
+    try(local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key].name,null),
+    try(local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group.key].name,null),
+    try(local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group_key].name,null)
   )
 }
 

--- a/virtual_machines.tf
+++ b/virtual_machines.tf
@@ -38,19 +38,19 @@ module "virtual_machines" {
   location = coalesce(
     try(local.global_settings.regions[each.value.region],null),
     local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group.key].location,
-    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key)].location,
+    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key].location,
     local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group.key].location,
     local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group_key].location
   )
   base_tags = try(local.global_settings.inherit_tags, false) ? coalese(
     local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group.key].tags,
-    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key)].tags,
+    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key].tags,
     local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group.key].tags,
     local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group_key].tags
   ) : {}
   resource_group_name = coalesce(
     local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group.key].name,
-    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key)].name,
+    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key].name,
     local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group.key].name,
     local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group_key].name
   )

--- a/virtual_machines.tf
+++ b/virtual_machines.tf
@@ -35,7 +35,7 @@ module "virtual_machines" {
   vnets                      = local.combined_objects_networking
   dedicated_hosts            = local.combined_objects_dedicated_hosts
 
-  location = coalese(
+  location = coalesce(
     try(local.global_settings.regions[each.value.region],null),
     local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group.key].location,
     local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key)].location,
@@ -48,7 +48,7 @@ module "virtual_machines" {
     local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group.key].tags,
     local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group_key].tags
   ) : {}
-  resource_group_name = coalese(
+  resource_group_name = coalesce(
     local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group.key].name,
     local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key)].name,
     local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group.key].name,

--- a/virtual_machines.tf
+++ b/virtual_machines.tf
@@ -42,7 +42,7 @@ module "virtual_machines" {
     local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group.key].location,
     local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group_key].location
   )
-  base_tags = try(local.global_settings.inherit_tags, false) ? coalese(
+  base_tags = try(local.global_settings.inherit_tags, false) ? coalesce(
     local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group.key].tags,
     local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key].tags,
     local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group.key].tags,

--- a/virtual_machines.tf
+++ b/virtual_machines.tf
@@ -37,22 +37,22 @@ module "virtual_machines" {
 
   location = coalesce(
     try(local.global_settings.regions[each.value.region],null),
-    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group.key].location,
-    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key].location,
-    local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group.key].location,
-    local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group_key].location
+    try(local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group.key].location,null),
+    try(local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key].location,null),
+    try(local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group.key].location,null),
+    try(local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group_key].location,null)
   )
   base_tags = try(local.global_settings.inherit_tags, false) ? coalesce(
-    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group.key].tags,
-    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key].tags,
-    local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group.key].tags,
-    local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group_key].tags
+    try(local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group.key].tags,null),
+    try(local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key].tags,null),
+    try(local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group.key].tags,null),
+    try(local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group_key].tags,null)
   ) : {}
   resource_group_name = coalesce(
-    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group.key].name,
-    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key].name,
-    local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group.key].name,
-    local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group_key].name
+    try(local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group.key].name,null),
+    try(local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key].name,null),
+    try(local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group.key].name,null),
+    try(local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group_key].name,null)
   )
 }
 

--- a/virtual_machines.tf
+++ b/virtual_machines.tf
@@ -35,9 +35,25 @@ module "virtual_machines" {
   vnets                      = local.combined_objects_networking
   dedicated_hosts            = local.combined_objects_dedicated_hosts
 
-  resource_group_name = local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].name
-  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].location : local.global_settings.regions[each.value.region]
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].tags : {}
+  location = coalese(
+    try(local.global_settings.regions[each.value.region],null),
+    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group.key].location,
+    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key)].location,
+    local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group.key].location,
+    local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group_key].location
+  )
+  base_tags = try(local.global_settings.inherit_tags, false) ? coalese(
+    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group.key].tags,
+    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key)].tags,
+    local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group.key].tags,
+    local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group_key].tags
+  ) : {}
+  resource_group_name = coalese(
+    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group.key].name,
+    local.combined_objects_resource_groups[each.value.resource_group.lz_key][each.value.resource_group_key)].name,
+    local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group.key].name,
+    local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group_key].name
+  )
 }
 
 


### PR DESCRIPTION
Current Storage account only can use the RG that is created within the same tfstate only. Adding support for remote lz_key and key in order to be able to deploy to remote RG if required.