### PR TITLE
Custom Data - Allow Txt for `custom_data` on linux vm creation

### DIFF
--- a/examples/compute/virtual_machine/100-single-linux-vm/configuration.tfvars
+++ b/examples/compute/virtual_machine/100-single-linux-vm/configuration.tfvars
@@ -63,7 +63,11 @@ virtual_machines = {
         disable_password_authentication = true
 
         #custom_data                     = "scripts/cloud-init/install-rover-tools.config"
-        custom_data = "compute/virtual_machine/100-single-linux-vm/scripts/cloud-init/install-rover-tools.config"
+        #custom_data = "compute/virtual_machine/100-single-linux-vm/scripts/cloud-init/install-rover-tools.config"
+        custom_data = <<CUSTOM_DATA
+#!/bin/bash
+echo "Execute your super awesome commands here!"
+CUSTOM_DATA
 
         # Spot VM to save money
         priority        = "Spot"

--- a/examples/compute/virtual_machine/100-single-linux-vm/configuration.tfvars
+++ b/examples/compute/virtual_machine/100-single-linux-vm/configuration.tfvars
@@ -62,6 +62,7 @@ virtual_machines = {
         admin_username                  = "adminuser"
         disable_password_authentication = true
 
+        #custom_data - Users can either reference a local file path or a block of code as seen below.
         #custom_data                     = "scripts/cloud-init/install-rover-tools.config"
         #custom_data = "compute/virtual_machine/100-single-linux-vm/scripts/cloud-init/install-rover-tools.config"
         custom_data = <<CUSTOM_DATA

--- a/modules/compute/virtual_machine/vm_linux.tf
+++ b/modules/compute/virtual_machine/vm_linux.tf
@@ -73,7 +73,7 @@ resource "azurerm_linux_virtual_machine" "vm" {
   provision_vm_agent              = try(each.value.provision_vm_agent, true)
   zone                            = try(each.value.zone, null)
   disable_password_authentication = try(each.value.disable_password_authentication, true)
-  custom_data                     = try(each.value.custom_data, null) == null ? null : filebase64(format("%s/%s", path.cwd, each.value.custom_data))
+  custom_data                     = try(each.value.custom_data, null) == null ? null : try(filebase64(format("%s/%s", path.cwd, each.value.custom_data)), base64encode(each.value.custom_data))
   availability_set_id             = try(var.availability_sets[var.client_config.landingzone_key][each.value.availability_set_key].id, var.availability_sets[each.value.availability_sets].id, null)
   proximity_placement_group_id    = try(var.proximity_placement_groups[var.client_config.landingzone_key][each.value.proximity_placement_group_key].id, var.proximity_placement_groups[each.value.proximity_placement_groups].id, null)
   dedicated_host_id = try(coalesce(


### PR DESCRIPTION
Currently, the linux VM's custom data can only be passed in as a file. This will allow text to be added. Perhaps in the future a `locals` object will be created to allow variables such as `storage_account_key` to be passed into the `custom_data`.