### PR TITLE
Feature/657- Module for creating storage account management policy

### DIFF
--- a/examples/storage_accounts/107-storage-account-management-policy/configuration.tfvars
+++ b/examples/storage_accounts/107-storage-account-management-policy/configuration.tfvars
@@ -1,0 +1,117 @@
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "southeastasia"
+  }
+}
+
+resource_groups = {
+  test = {
+    name = "test"
+  }
+}
+
+# https://docs.microsoft.com/en-us/azure/storage/
+storage_accounts = {
+  sa1 = {
+    name                     = "sa1dev"
+    resource_group_key       = "test"
+    account_kind             = "StorageV2" #Valid options are BlobStorage, BlockBlobStorage, FileStorage, Storage and StorageV2. Defaults to StorageV2
+    account_tier             = "Standard"  #Valid options are Standard and Premium. For BlockBlobStorage and FileStorage accounts only Premium is valid
+    account_replication_type = "LRS"       # https://docs.microsoft.com/en-us/azure/storage/common/storage-redundancy
+    min_tls_version          = "TLS1_2"    # Possible values are TLS1_0, TLS1_1, and TLS1_2. Defaults to TLS1_0 for new storage accounts.
+    large_file_share_enabled = true
+
+    # azure_files_authentication = {
+    #   directory_type = "AADDS"
+    # }
+
+    management_policies = {
+      rules = {
+        rule_1 = {
+          name    = "rule1"
+          enabled = true
+          filters = {
+            filter_specs = {
+              prefix_match = ["container1/prefix1"]
+              blob_types   = ["blockBlob"]
+              # This code can only be used if enable `BlobIndex`
+              #match_blob_index_tag = {
+              #match_blob_index_tag_specs = {
+              #  name      = "tag1"
+              #  operation = "=="
+              #  value     = "val1"
+              #}
+              #}
+            }
+          }
+          actions = {
+            # Only have one blob object
+            base_blob = {
+              blob_specs = {
+                tier_to_cool_after_days_since_modification_greater_than    = 11
+                tier_to_archive_after_days_since_modification_greater_than = 51
+                delete_after_days_since_modification_greater_than          = 101
+              }
+            }
+            snapshot = {
+              snapshot_specs = {
+                change_tier_to_archive_after_days_since_creation = 90
+                change_tier_to_cool_after_days_since_creation    = 23
+                delete_after_days_since_creation_greater_than    = 31
+              }
+            }
+            version = {
+              version_specs = {
+                change_tier_to_archive_after_days_since_creation = 9
+                change_tier_to_cool_after_days_since_creation    = 90
+                delete_after_days_since_creation                 = 3
+              }
+            }
+          }
+        }
+        #        rule_2 = {
+        #          name = "rule2"
+        #          enabled = false
+        #        }
+      }
+    }
+
+    backup = {
+      vault_key = "asr1"
+      # lz_key = ""
+    }
+
+    tags = {
+      environment = "dev"
+      team        = "IT"
+    }
+  }
+}
+
+recovery_vaults = {
+  asr1 = {
+    name               = "asr-container-protection"
+    resource_group_key = "test"
+
+    region = "region1"
+    backup_policies = {
+
+      fs = {
+        policy1 = {
+          name      = "FSBackupPolicy1"
+          vault_key = "asr1"
+          rg_key    = "primary"
+          timezone  = "UTC"
+          backup = {
+            frequency = "Daily"
+            time      = "23:00"
+          }
+          retention_daily = {
+            count = 10
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/storage_accounts/107-storage-account-management-policy/configuration.tfvars
+++ b/examples/storage_accounts/107-storage-account-management-policy/configuration.tfvars
@@ -47,7 +47,6 @@ storage_accounts = {
             }
           }
           actions = {
-            # Only have one blob object
             base_blob = {
               blob_specs = {
                 tier_to_cool_after_days_since_modification_greater_than    = 11
@@ -90,7 +89,6 @@ storage_accounts = {
             }
           }
           actions = {
-            # Only have one blob object
             base_blob = {
               blob_specs = {
                 tier_to_cool_after_days_since_modification_greater_than    = 11

--- a/examples/storage_accounts/107-storage-account-management-policy/configuration.tfvars
+++ b/examples/storage_accounts/107-storage-account-management-policy/configuration.tfvars
@@ -36,6 +36,50 @@ storage_accounts = {
               prefix_match = ["container1/prefix1"]
               blob_types   = ["blockBlob"]
               # This code can only be used if enable `BlobIndex`
+              # https://azure.microsoft.com/en-us/blog/manage-and-find-data-with-blob-index-for-azure-storage-now-in-preview/
+              #match_blob_index_tag = {
+              #match_blob_index_tag_specs = {
+              #  name      = "tag1"
+              #  operation = "=="
+              #  value     = "val1"
+              #}
+              #}
+            }
+          }
+          actions = {
+            # Only have one blob object
+            base_blob = {
+              blob_specs = {
+                tier_to_cool_after_days_since_modification_greater_than    = 11
+                tier_to_archive_after_days_since_modification_greater_than = 51
+                delete_after_days_since_modification_greater_than          = 101
+              }
+            }
+            snapshot = {
+              snapshot_specs = {
+                change_tier_to_archive_after_days_since_creation = 90
+                change_tier_to_cool_after_days_since_creation    = 23
+                delete_after_days_since_creation_greater_than    = 31
+              }
+            }
+            version = {
+              version_specs = {
+                change_tier_to_archive_after_days_since_creation = 9
+                change_tier_to_cool_after_days_since_creation    = 90
+                delete_after_days_since_creation                 = 3
+              }
+            }
+          }
+        },
+        rule_2 = {
+          name    = "rule2"
+          enabled = true
+          filters = {
+            filter_specs = {
+              prefix_match = ["container1/prefix2"]
+              blob_types   = ["blockBlob"]
+              # This code can only be used if enable `BlobIndex`
+              # https://azure.microsoft.com/en-us/blog/manage-and-find-data-with-blob-index-for-azure-storage-now-in-preview/
               #match_blob_index_tag = {
               #match_blob_index_tag_specs = {
               #  name      = "tag1"
@@ -70,10 +114,6 @@ storage_accounts = {
             }
           }
         }
-        #        rule_2 = {
-        #          name = "rule2"
-        #          enabled = false
-        #        }
       }
     }
 

--- a/modules/storage_account/management_policy/management_policy.tf
+++ b/modules/storage_account/management_policy/management_policy.tf
@@ -1,0 +1,63 @@
+resource "azurerm_storage_management_policy" "mgmt_policy" {
+  storage_account_id = var.storage_account_id
+
+  dynamic "rule" {
+    for_each = var.settings.rules
+
+    content {
+      name    = rule.value.name
+      enabled = rule.value.enabled
+
+      dynamic "filters" {
+        for_each = try(rule.value.filters, {})
+
+        content {
+          prefix_match = filters.value.prefix_match
+          blob_types   = filters.value.blob_types
+          
+          dynamic "match_blob_index_tag" {
+            for_each = try(filters.match_blob_index_tag, {})
+
+            content {
+              name      = match_blob_index_tag.value.name
+              operation = match_blob_index_tag.value.operation
+              value     = match_blob_index_tag.value.value
+            }
+          }
+        }
+
+      }
+      actions {
+        dynamic "base_blob" {
+          for_each = try(rule.value.actions.base_blob, {})
+
+          content {
+            tier_to_cool_after_days_since_modification_greater_than    = base_blob.value.tier_to_cool_after_days_since_modification_greater_than
+            tier_to_archive_after_days_since_modification_greater_than = base_blob.value.tier_to_archive_after_days_since_modification_greater_than
+            delete_after_days_since_modification_greater_than          = base_blob.value.delete_after_days_since_modification_greater_than
+          }
+        }
+
+        dynamic "snapshot" {
+          for_each = try(rule.value.actions.snapshot, {})
+
+          content {
+            change_tier_to_archive_after_days_since_creation = snapshot.value.change_tier_to_archive_after_days_since_creation
+            change_tier_to_cool_after_days_since_creation    = snapshot.value.change_tier_to_cool_after_days_since_creation
+            delete_after_days_since_creation_greater_than    = snapshot.value.delete_after_days_since_creation_greater_than
+          }
+        }
+
+        dynamic "version" {
+          for_each = try(rule.value.actions.version, {})
+
+          content {
+            change_tier_to_archive_after_days_since_creation = version.value.change_tier_to_archive_after_days_since_creation
+            change_tier_to_cool_after_days_since_creation    = version.value.change_tier_to_cool_after_days_since_creation
+            delete_after_days_since_creation                 = version.value.delete_after_days_since_creation
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/storage_account/management_policy/management_policy.tf
+++ b/modules/storage_account/management_policy/management_policy.tf
@@ -12,16 +12,16 @@ resource "azurerm_storage_management_policy" "mgmt_policy" {
         for_each = try(rule.value.filters, {})
 
         content {
-          prefix_match = filters.value.prefix_match
-          blob_types   = filters.value.blob_types
-          
+          prefix_match = try(filters.value.prefix_match, null)
+          blob_types   = try(filters.value.blob_types, null)
+
           dynamic "match_blob_index_tag" {
             for_each = try(filters.match_blob_index_tag, {})
 
             content {
-              name      = match_blob_index_tag.value.name
-              operation = match_blob_index_tag.value.operation
-              value     = match_blob_index_tag.value.value
+              name      = try(match_blob_index_tag.value.name, null)
+              operation = try(match_blob_index_tag.value.operation, null)
+              value     = try(match_blob_index_tag.value.value, null)
             }
           }
         }
@@ -32,9 +32,9 @@ resource "azurerm_storage_management_policy" "mgmt_policy" {
           for_each = try(rule.value.actions.base_blob, {})
 
           content {
-            tier_to_cool_after_days_since_modification_greater_than    = base_blob.value.tier_to_cool_after_days_since_modification_greater_than
-            tier_to_archive_after_days_since_modification_greater_than = base_blob.value.tier_to_archive_after_days_since_modification_greater_than
-            delete_after_days_since_modification_greater_than          = base_blob.value.delete_after_days_since_modification_greater_than
+            tier_to_cool_after_days_since_modification_greater_than    = try(base_blob.value.tier_to_cool_after_days_since_modification_greater_than, null)
+            tier_to_archive_after_days_since_modification_greater_than = try(base_blob.value.tier_to_archive_after_days_since_modification_greater_than, null)
+            delete_after_days_since_modification_greater_than          = try(base_blob.value.delete_after_days_since_modification_greater_than, null)
           }
         }
 
@@ -42,9 +42,9 @@ resource "azurerm_storage_management_policy" "mgmt_policy" {
           for_each = try(rule.value.actions.snapshot, {})
 
           content {
-            change_tier_to_archive_after_days_since_creation = snapshot.value.change_tier_to_archive_after_days_since_creation
-            change_tier_to_cool_after_days_since_creation    = snapshot.value.change_tier_to_cool_after_days_since_creation
-            delete_after_days_since_creation_greater_than    = snapshot.value.delete_after_days_since_creation_greater_than
+            change_tier_to_archive_after_days_since_creation = try(snapshot.value.change_tier_to_archive_after_days_since_creation, null)
+            change_tier_to_cool_after_days_since_creation    = try(snapshot.value.change_tier_to_cool_after_days_since_creation, null)
+            delete_after_days_since_creation_greater_than    = try(snapshot.value.delete_after_days_since_creation_greater_than, null)
           }
         }
 
@@ -52,9 +52,9 @@ resource "azurerm_storage_management_policy" "mgmt_policy" {
           for_each = try(rule.value.actions.version, {})
 
           content {
-            change_tier_to_archive_after_days_since_creation = version.value.change_tier_to_archive_after_days_since_creation
-            change_tier_to_cool_after_days_since_creation    = version.value.change_tier_to_cool_after_days_since_creation
-            delete_after_days_since_creation                 = version.value.delete_after_days_since_creation
+            change_tier_to_archive_after_days_since_creation = try(version.value.change_tier_to_archive_after_days_since_creation, null)
+            change_tier_to_cool_after_days_since_creation    = try(version.value.change_tier_to_cool_after_days_since_creation, null)
+            delete_after_days_since_creation                 = try(version.value.delete_after_days_since_creation, null)
           }
         }
       }

--- a/modules/storage_account/management_policy/variables.tf
+++ b/modules/storage_account/management_policy/variables.tf
@@ -1,0 +1,2 @@
+variable "settings" {}
+variable "storage_account_id" {}

--- a/modules/storage_account/storage_account.tf
+++ b/modules/storage_account/storage_account.tf
@@ -231,3 +231,10 @@ module "file_share" {
   recovery_vault       = local.recovery_vault
   resource_group_name  = var.resource_group_name
 }
+
+module "management_policy" {
+  source     = "./management_policy"
+  #for_each   = try(var.storage_account.management_policies, {})
+  storage_account_id   = azurerm_storage_account.stg.id
+  settings             = try(var.storage_account.management_policies, {})
+}

--- a/modules/storage_account/storage_account.tf
+++ b/modules/storage_account/storage_account.tf
@@ -233,8 +233,8 @@ module "file_share" {
 }
 
 module "management_policy" {
-  source     = "./management_policy"
-  #for_each   = try(var.storage_account.management_policies, {})
+  source               = "./management_policy"
+  for_each             = try(var.storage_account.management_policies, {})
   storage_account_id   = azurerm_storage_account.stg.id
   settings             = try(var.storage_account.management_policies, {})
 }


### PR DESCRIPTION
# Overview
This module contains all the code needed for the storage account management policy. A few notes:

# Code Structure
* I do not loop through the `management_policies` block since users can only have one `management_policy` (`modules/storage_account/storage_account.tf`).
* I nest my blocks one level deeper due to the `dynamic` block. For example, in `examples/storage_accounts/107-storage-account-management-policy/configuration.tfvars`, line 51, 52:
    *  I tried to simply loop through `base_blob`, but in `modules/storage_account/management_policy/management_policy.tf` lines 31 and 32, I am unable to use the dynamic block to validate that `base_blob` exists and loop through it. Therefore I must have a buffer called `blob_specs`.
    * If there is a cleaner way to do this please let me know. Currently, the extra layer is annoying me but I was unable to find a cleaner solution.

  