### PR TITLE
Create a `custom_data` string with Terraform Ouputs

### DIFF
--- a/examples/compute/virtual_machine/108-single-linux-storage-connect-custom-data/configuration.tfvars
+++ b/examples/compute/virtual_machine/108-single-linux-storage-connect-custom-data/configuration.tfvars
@@ -67,6 +67,11 @@ virtual_machines = {
 #echo "Execute your super awesome commands here!"
 #CUSTOM_DATA
         custom_data = "palo_alto_connection_string"
+        palo_alto_connection_string = {
+          storage_account = "sa1"
+          file_share = "share1"
+          file_share_directory = "dir1"
+        }
 
         # Spot VM to save money
         priority        = "Spot"

--- a/examples/compute/virtual_machine/108-single-linux-storage-connect-custom-data/configuration.tfvars
+++ b/examples/compute/virtual_machine/108-single-linux-storage-connect-custom-data/configuration.tfvars
@@ -1,0 +1,264 @@
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "southeastasia"
+  }
+  resource_defaults = {
+    virtual_machines = {
+      # set the below to enable az managed boot diagostics for vms
+      # this will be override if a user managed storage account is defined for the vm
+      # use_azmanaged_storage_for_boot_diagnostics = true
+    }
+  }
+}
+
+resource_groups = {
+  vm_region1 = {
+    name = "example-virtual-machine-rg1"
+  }
+}
+
+# Virtual machines
+virtual_machines = {
+
+  # Configuration to deploy a bastion host linux virtual machine
+  example_vm1 = {
+    resource_group_key = "vm_region1"
+    provision_vm_agent = true
+    # when boot_diagnostics_storage_account_key is empty string "", boot diagnostics will be put on azure managed storage
+    # when boot_diagnostics_storage_account_key is a non-empty string, it needs to point to the key of a user managed storage defined in diagnostic_storage_accounts
+    # if boot_diagnostics_storage_account_key is not defined, but global_settings.resource_defaults.virtual_machines.use_azmanaged_storage_for_boot_diagnostics is true, boot diagnostics will be put on azure managed storage
+    boot_diagnostics_storage_account_key = "bootdiag_region1"
+
+    os_type = "linux"
+
+    # the auto-generated ssh key in keyvault secret. Secret name being {VM name}-ssh-public and {VM name}-ssh-private
+    keyvault_key = "example_vm_rg1"
+
+    # Define the number of networking cards to attach the virtual machine
+    networking_interfaces = {
+      nic0 = {
+        # Value of the keys from networking.tfvars
+        vnet_key                = "vnet_region1"
+        subnet_key              = "example"
+        primary                 = true
+        name                    = "0"
+        enable_ip_forwarding    = false
+        internal_dns_name_label = "nic0"
+        public_ip_address_key   = "example_vm_pip1_rg1"
+        # example with external network objects
+        # subnet_id = "/subscriptions/sub-id/resourceGroups/test-manual/providers/Microsoft.Network/virtualNetworks/vnet/subnets/default"
+        # public_address_id = "/subscriptions/sub-id/resourceGroups/test-manual/providers/Microsoft.Network/publicIPAddresses/arnaudip"
+        # nsg_id = "/subscriptions/sub-id/resourceGroups/test-manual/providers/Microsoft.Network/networkSecurityGroups/nsgtest"
+
+      }
+    }
+
+    virtual_machine_settings = {
+      linux = {
+        name                            = "example_vm1"
+        size                            = "Standard_F2"
+        admin_username                  = "adminuser"
+        disable_password_authentication = true
+
+        #custom_data                     = "scripts/cloud-init/install-rover-tools.config"
+#        custom_data = <<CUSTOM_DATA
+##!/bin/bash
+#echo "Execute your super awesome commands here!"
+#CUSTOM_DATA
+        custom_data = "palo_alto_connection_string"
+
+        # Spot VM to save money
+        priority        = "Spot"
+        eviction_policy = "Deallocate"
+
+        # Value of the nic keys to attach the VM. The first one in the list is the default nic
+        network_interface_keys = ["nic0"]
+
+        os_disk = {
+          name                    = "example_vm1-os"
+          caching                 = "ReadWrite"
+          storage_account_type    = "Standard_LRS"
+          disk_encryption_set_key = "set1"
+        }
+        identity = {
+          type = "SystemAssigned"
+        }
+        source_image_reference = {
+          publisher = "Canonical"
+          offer     = "UbuntuServer"
+          sku       = "18.04-LTS"
+          version   = "latest"
+        }
+
+      }
+    }
+    data_disks = {
+      data1 = {
+        name                 = "server1-data1"
+        storage_account_type = "Standard_LRS"
+        # Only Empty is supported. More community contributions required to cover other scenarios
+        create_option           = "Empty"
+        disk_size_gb            = "10"
+        lun                     = 1
+        zones                   = ["1"]
+        disk_encryption_set_key = "set1"
+      }
+    }
+  }
+}
+
+
+diagnostic_storage_accounts = {
+  # Stores boot diagnostic for region1
+  bootdiag_region1 = {
+    name                     = "bootrg1"
+    resource_group_key       = "vm_region1"
+    account_kind             = "StorageV2"
+    account_tier             = "Standard"
+    account_replication_type = "LRS"
+    access_tier              = "Cool"
+  }
+}
+
+storage_accounts = {
+  sa1 = {
+    name                     = "sa1dev"
+    resource_group_key       = "vm_region1"
+    account_kind             = "StorageV2" #Valid options are BlobStorage, BlockBlobStorage, FileStorage, Storage and StorageV2. Defaults to StorageV2
+    account_tier             = "Standard"  #Valid options are Standard and Premium. For BlockBlobStorage and FileStorage accounts only Premium is valid
+    account_replication_type = "LRS"       # https://docs.microsoft.com/en-us/azure/storage/common/storage-redundancy
+    min_tls_version          = "TLS1_2"    # Possible values are TLS1_0, TLS1_1, and TLS1_2. Defaults to TLS1_0 for new storage accounts.
+    allow_blob_public_access = false
+    is_hns_enabled           = false
+
+    file_shares = {
+      share1 = {
+        name  = "myfileshare"
+        quota = "10"
+
+        directories = {
+          dir1 = {
+            name = "testdirectory"
+          }
+        }
+      }
+    }
+
+    # Enable this block, if you have a valid domain name
+    # custom_domain = {
+    #   name          = "any-valid-domain.name" #will be validated by Azure
+    #   use_subdomain = true
+    # }
+
+    enable_system_msi = {
+      type = "SystemAssigned"
+    }
+
+    blob_properties = {
+      delete_retention_policy = {
+        days = "7"
+      }
+
+      container_delete_retention_policy = {
+        days = "7"
+      }
+    }
+
+    backup = {
+      vault_key = "asr1"
+    }
+
+    tags = {
+      environment = "dev"
+      team        = "IT"
+    }
+
+    containers = {
+      dev = {
+        name = "random"
+      }
+    }
+  }
+}
+
+keyvaults = {
+  example_vm_rg1 = {
+    name                        = "vmlinuxakv"
+    resource_group_key          = "vm_region1"
+    sku_name                    = "standard"
+    soft_delete_enabled         = true
+    purge_protection_enabled    = true
+    enabled_for_disk_encryption = true
+    tags = {
+      env = "Standalone"
+    }
+    creation_policies = {
+      logged_in_user = {
+        secret_permissions = ["Set", "Get", "List", "Delete", "Purge", "Recover"]
+        key_permissions    = ["Get", "List", "Update", "Create", "Import", "Delete", "Recover", "Backup", "Restore", "Decrypt", "Encrypt", "UnwrapKey", "WrapKey", "Verify", "Sign", "Purge"]
+      }
+    }
+  }
+}
+
+keyvault_keys = {
+  key1 = {
+    keyvault_key       = "example_vm_rg1"
+    resource_group_key = "vm_region1"
+    name               = "disk-key"
+    key_type           = "RSA"
+    key_size           = "2048"
+    key_opts           = ["encrypt", "decrypt", "sign", "verify", "wrapKey", "unwrapKey"]
+  }
+}
+
+disk_encryption_sets = {
+  set1 = {
+    name               = "deskey1"
+    resource_group_key = "vm_region1"
+    key_vault_key_key  = "key1"
+    keyvault = {
+      key = "example_vm_rg1"
+    }
+  }
+}
+vnets = {
+  vnet_region1 = {
+    resource_group_key = "vm_region1"
+    vnet = {
+      name          = "virtual_machines"
+      address_space = ["10.100.100.0/24"]
+    }
+    specialsubnets = {}
+    subnets = {
+      example = {
+        name = "examples"
+        cidr = ["10.100.100.0/29"]
+      }
+    }
+
+  }
+}
+
+public_ip_addresses = {
+  example_vm_pip1_rg1 = {
+    name                    = "example_vm_pip1"
+    resource_group_key      = "vm_region1"
+    sku                     = "Standard"
+    allocation_method       = "Static"
+    ip_version              = "IPv4"
+    idle_timeout_in_minutes = "4"
+
+  }
+}
+
+recovery_vaults = {
+  asr1 = {
+    name               = "asr-container-protection"
+    resource_group_key = "vm_region1"
+
+    region = "region1"
+
+  }
+}

--- a/modules/compute/virtual_machine/variables.tf
+++ b/modules/compute/virtual_machine/variables.tf
@@ -48,6 +48,10 @@ variable "recovery_vaults" {
   default = {}
 }
 
+variable "storage_accounts" {
+  default = {}
+}
+
 variable "availability_sets" {
   default = {}
 }

--- a/modules/compute/virtual_machine/vm_linux.tf
+++ b/modules/compute/virtual_machine/vm_linux.tf
@@ -82,7 +82,6 @@ resource "azurerm_linux_virtual_machine" "vm" {
   provision_vm_agent              = try(each.value.provision_vm_agent, true)
   zone                            = try(each.value.zone, null)
   disable_password_authentication = try(each.value.disable_password_authentication, true)
-  #custom_data                     = try(each.value.custom_data, null) == null ? null : try(filebase64(format("%s/%s", path.cwd, each.value.custom_data)), base64encode(each.value.custom_data))
   custom_data = (
                   try(each.value.custom_data, null) == null 
                     ? null 

--- a/modules/storage_account/file_share/output.tf
+++ b/modules/storage_account/file_share/output.tf
@@ -3,6 +3,11 @@ output "id" {
   value       = azurerm_storage_share.fs.id
 }
 
+output "name" {
+  description = "The URL of the File Share"
+  value       = azurerm_storage_share.fs.name
+}
+
 output "url" {
   description = "The URL of the File Share"
   value       = azurerm_storage_share.fs.url

--- a/modules/storage_account/file_share_directory/output.tf
+++ b/modules/storage_account/file_share_directory/output.tf
@@ -2,3 +2,7 @@ output "id" {
   value = azurerm_storage_share_directory.share_directory.id
 }
 
+output "name" {
+  value = azurerm_storage_share_directory.share_directory.name
+}
+

--- a/modules/storage_account/output.tf
+++ b/modules/storage_account/output.tf
@@ -23,6 +23,11 @@ output "primary_blob_endpoint" {
   value       = azurerm_storage_account.stg.primary_blob_endpoint
 }
 
+output "primary_access_key" {
+  description = "The endpoint URL for blob storage in the primary location."
+  value       = azurerm_storage_account.stg.primary_access_key
+}
+
 output "containers" {
   description = "The containers output objects as created by the container submodule."
   value       = module.container

--- a/virtual_machines.tf
+++ b/virtual_machines.tf
@@ -31,6 +31,7 @@ module "virtual_machines" {
   proximity_placement_groups = local.combined_objects_proximity_placement_groups
   public_ip_addresses        = local.combined_objects_public_ip_addresses
   recovery_vaults            = local.combined_objects_recovery_vaults
+  storage_accounts           = local.combined_objects_storage_accounts
   settings                   = each.value
   vnets                      = local.combined_objects_networking
   dedicated_hosts            = local.combined_objects_dedicated_hosts


### PR DESCRIPTION
# Overview
Currently, users have the ability to add `custom_data` to a Linux VM in two ways:

1. Passing a local path to a script.
2. Directly inserting code in the `tfvars`

This allows users to manually enter `custom_data` for these machines. But it does __not__ allow users to dynamically build a string for the `custom_data` from Terraform outputs.

# Our Use Case
In our use case, we need to set the following string as the `custom_data`, assuming a storage account, file share, and directory exist.:
```
storage-account=stname, access-key=some-secret, file-share=myfileshare, share-directory=testdirectory
```

# Implementation
The implementation I propose is to use a locals block that contains a map called `dynamic_custom_data`. Here, any developer would be able to add their condition. The key would be used to reference their condition, and the value would contain the dynamic string created from Terraform outputs for each server.

## Our Example

The example (and use case) of this PR is the following:
* 
```
  dynamic_custom_data = {
    palo_alto_connection_string = {
      for item in var.settings.virtual_machine_settings: 
        item.name => try(base64encode("storage-account=${var.storage_accounts[var.client_config.landingzone_key][item.palo_alto_connection_string.storage_account].name}, access-key=${var.storage_accounts[var.client_config.landingzone_key][item.palo_alto_connection_string.storage_account].primary_access_key}, file-share=${var.storage_accounts[var.client_config.landingzone_key][item.palo_alto_connection_string.storage_account].file_share[item.palo_alto_connection_string.file_share].name}, share-directory=${var.storage_accounts[var.client_config.landingzone_key][item.palo_alto_connection_string.storage_account].file_share[item.palo_alto_connection_string.file_share].file_share_directories[item.palo_alto_connection_string.file_share_directory].name}"), null)
    }
  }
```
* `custom_data` defined by the user in `.tfvars`: `custom_data: palo_alto_connection_string`
* A map called `palo_alto_connection_string`:
```
        palo_alto_connection_string = {
          storage_account = "sa1"
          file_share = "share1"
          file_share_directory = "dir1"        
```

The following occurs:
1. The user sets the `custom_data` to a key found in `dynamic_custom_data` -- `palo_alto_connection_string`.
2. The user sets all the attributes that will be needed to construct the `custom_data` object within `dynamic_custom_data`.
   a. `palo_alto_connection_string = {...}`
2. TF loops through each VM's settings and checks to see if `custom_data` exists.
3. If it exists, it checks to see if the `custom_data` value is a key in `local.dynamic_custom_data`. If it is, it will construct the value of `custom_data` using the map that has a key with the same value as `custom_data`. -- `var.palo_alto_connection_string`
4. If the key does not exist in `dynamic_custom_data`. It will attempt to search for a file by that name, or add the string as-is.

## Future Use Cases
In the future, if anyone wanted to add a dynamic string, they have to do the following:
1. Add the condition to `local.dynamic_custom_data`
2. Reference the key in `custom_data`
3.  Add any attributes needed in `var.dynamic_custom_data[custom_data]`

# Questions
I understand this might be a lot to follow. Please let me know if you guys want to jump on a call to review.
