### PR TITLE
Add support for adding virtual-network-links outside of private-dns-zone creation

### DIFF
--- a/examples/networking/private_dns_vnet_link/100_pvtdns_vnetlink/configuration.tfvars
+++ b/examples/networking/private_dns_vnet_link/100_pvtdns_vnetlink/configuration.tfvars
@@ -1,4 +1,4 @@
-private_dns_vnet_link = {
+private_dns_vnet_links = {
   vnet_pvtdns_link1 = {        
     vnet_key = "vnet_key1"
     #lz_key = "remote landing zone key for vnet"

--- a/examples/networking/private_dns_vnet_link/100_pvtdns_vnetlink/configuration.tfvars
+++ b/examples/networking/private_dns_vnet_link/100_pvtdns_vnetlink/configuration.tfvars
@@ -1,0 +1,26 @@
+private_dns_vnet_link = {
+  vnet_pvtdns_link1 = {        
+    vnet_key = "vnet_key1"
+    private_dns_zones = {            
+      dns_zone1 = {
+        name     = "vnet-pvtdns_link1"
+        key = "dnszone_southeastasia"
+        lz_key = "provide the landing zone key of private dns zone"
+      }
+      # dns_zone2 = {
+      #   name     = "pvtdnstest-vnet1-link2"
+      #   key = "dnszone_eastasia"
+      
+      # }
+    }
+  }  
+  # vnet_pvtdns_link2 = {        
+  #   vnet_key = "vnet_dev_test2"
+  #   private_dns_zones = {
+  #     dns_zone1 = {
+  #       name     = "pvtdnstest-vnet2-link1"
+  #       key = "aks_southeastasia"
+  #     }
+  #   }
+  # }
+}

--- a/examples/networking/private_dns_vnet_link/100_pvtdns_vnetlink/configuration.tfvars
+++ b/examples/networking/private_dns_vnet_link/100_pvtdns_vnetlink/configuration.tfvars
@@ -1,25 +1,25 @@
 private_dns_vnet_link = {
   vnet_pvtdns_link1 = {        
     vnet_key = "vnet_key1"
+    #lz_key = "remote landing zone key for vnet"
     private_dns_zones = {            
       dns_zone1 = {
-        name     = "vnet-pvtdns_link1"
-        key = "dnszone_southeastasia"
+        name     = "vnet1-link1"
+        key = "dnszone1_key"
         lz_key = "provide the landing zone key of private dns zone"
       }
       # dns_zone2 = {
-      #   name     = "pvtdnstest-vnet1-link2"
-      #   key = "dnszone_eastasia"
-      
+      #   name     = "vnet1-link2"
+      #   key = "dnszone2_key"
       # }
     }
   }  
   # vnet_pvtdns_link2 = {        
-  #   vnet_key = "vnet_dev_test2"
+  #   vnet_key = "vnet_key2"
   #   private_dns_zones = {
   #     dns_zone1 = {
-  #       name     = "pvtdnstest-vnet2-link1"
-  #       key = "aks_southeastasia"
+  #       name     = "vnet2-link1"
+  #       key = "dnszone1_key"
   #     }
   #   }
   # }

--- a/locals.tf
+++ b/locals.tf
@@ -210,7 +210,7 @@ locals {
     network_security_group_definition                       = try(var.networking.network_security_group_definition, {})
     network_watchers                                        = try(var.networking.network_watchers, {})
     private_dns                                             = try(var.networking.private_dns, {})
-    private_dns_vnet_link                                   = try(var.networking.private_dns_vnet_link, {})
+    private_dns_vnet_links                                  = try(var.networking.private_dns_vnet_links, {})
     public_ip_addresses                                     = try(var.networking.public_ip_addresses, {})
     route_tables                                            = try(var.networking.route_tables, {})
     vhub_peerings                                           = try(var.networking.vhub_peerings, {})

--- a/locals.tf
+++ b/locals.tf
@@ -210,6 +210,7 @@ locals {
     network_security_group_definition                       = try(var.networking.network_security_group_definition, {})
     network_watchers                                        = try(var.networking.network_watchers, {})
     private_dns                                             = try(var.networking.private_dns, {})
+    private_dns_vnet_link                                   = try(var.networking.private_dns_vnet_link, {})
     public_ip_addresses                                     = try(var.networking.public_ip_addresses, {})
     route_tables                                            = try(var.networking.route_tables, {})
     vhub_peerings                                           = try(var.networking.vhub_peerings, {})

--- a/modules/networking/private_dns_vnet_link/main.tf
+++ b/modules/networking/private_dns_vnet_link/main.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    azurecaf = {
+      source = "aztfmod/azurecaf"
+    }
+  }
+  required_version = ">= 0.13"
+}
+
+locals {
+  module_tag = {
+    "module" = basename(abspath(path.module))
+  }
+  tags = merge(var.base_tags, local.module_tag, var.tags)
+}

--- a/modules/networking/private_dns_vnet_link/module.tf
+++ b/modules/networking/private_dns_vnet_link/module.tf
@@ -13,16 +13,16 @@ resource "azurecaf_name" "pnetlk" {
 resource "azurerm_private_dns_zone_virtual_network_link" "vnet_links" {
   for_each = var.settings.private_dns_zones
 
-  name                  = azurecaf_name.pnetlk[each.key].result
-  resource_group_name   = coalesce(
-      try(var.private_dns[each.value.lz_key][each.value.key].resource_group_name, null),
-      try(var.private_dns[var.client_config.landingzone_key][each.value.key].resource_group_name, null)
-    )
+  name = azurecaf_name.pnetlk[each.key].result
+  resource_group_name = coalesce(
+    try(var.private_dns[each.value.lz_key][each.value.key].resource_group_name, null),
+    try(var.private_dns[var.client_config.landingzone_key][each.value.key].resource_group_name, null)
+  )
   private_dns_zone_name = coalesce(
-      try(var.private_dns[each.value.lz_key][each.value.key].name, null),
-      try(var.private_dns[var.client_config.landingzone_key][each.value.key].name, null)
-    )
-  virtual_network_id    = var.virtual_network_id
-  registration_enabled  = try(each.value.registration_enabled, false)
-  tags                  = merge(var.base_tags, local.module_tag, try(each.value.tags, null))
+    try(var.private_dns[each.value.lz_key][each.value.key].name, null),
+    try(var.private_dns[var.client_config.landingzone_key][each.value.key].name, null)
+  )
+  virtual_network_id   = var.virtual_network_id
+  registration_enabled = try(each.value.registration_enabled, false)
+  tags                 = merge(var.base_tags, local.module_tag, try(each.value.tags, null))
 }

--- a/modules/networking/private_dns_vnet_link/module.tf
+++ b/modules/networking/private_dns_vnet_link/module.tf
@@ -1,0 +1,28 @@
+resource "azurecaf_name" "pnetlk" {
+  for_each = var.settings.private_dns_zones
+
+  name          = each.value.name
+  resource_type = "azurerm_private_dns_zone_virtual_network_link"
+  prefixes      = var.global_settings.prefixes
+  random_length = var.global_settings.random_length
+  clean_input   = true
+  passthrough   = var.global_settings.passthrough
+  use_slug      = var.global_settings.use_slug
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "vnet_links" {
+  for_each = var.settings.private_dns_zones
+
+  name                  = azurecaf_name.pnetlk[each.key].result
+  resource_group_name   = coalesce(
+      try(var.private_dns[each.value.lz_key][each.value.key].resource_group_name, null),
+      try(var.private_dns[var.client_config.landingzone_key][each.value.key].resource_group_name, null)
+    )
+  private_dns_zone_name = coalesce(
+      try(var.private_dns[each.value.lz_key][each.value.key].name, null),
+      try(var.private_dns[var.client_config.landingzone_key][each.value.key].name, null)
+    )
+  virtual_network_id    = var.virtual_network_id
+  registration_enabled  = try(each.value.registration_enabled, false)
+  tags                  = merge(var.base_tags, local.module_tag, try(each.value.tags, null))
+}

--- a/modules/networking/private_dns_vnet_link/output.tf
+++ b/modules/networking/private_dns_vnet_link/output.tf
@@ -1,0 +1,3 @@
+output "ids" {
+  value = azurerm_private_dns_zone_virtual_network_link.vnet_links.*
+}

--- a/modules/networking/private_dns_vnet_link/variables.tf
+++ b/modules/networking/private_dns_vnet_link/variables.tf
@@ -4,30 +4,20 @@ variable "global_settings" {
 variable "client_config" {
   description = "Client configuration object (see module README.md)."
 }
-variable "name" {
-  description = "Name of the Virtual Network Link"
+
+variable "virtual_network_id" {
 }
 
-variable "resource_group_name" {
-  description = "Resource Group Name"
+variable "private_dns" {
 }
 
-variable "records" {
-}
-
-variable "vnet_links" {
-  default = {}
-}
-
-variable "vnets" {
-  default = {}
+variable "settings" {
 }
 
 variable "base_tags" {
   description = "Base tags for the resource to be inherited from the resource group."
   type        = map(any)
 }
-
 variable "tags" {
   default = {}
 }

--- a/modules/networking/private_dns_vnet_link/variables.tf
+++ b/modules/networking/private_dns_vnet_link/variables.tf
@@ -1,0 +1,30 @@
+variable "global_settings" {
+  description = "Global settings object (see module README.md)"
+}
+variable "client_config" {
+  description = "Client configuration object (see module README.md)."
+}
+variable "name" {
+  description = "Name of the Virtual Network Link"
+}
+
+variable "resource_group_name" {
+  description = "Resource Group Name"
+}
+
+variable "vnet_links" {
+  default = {}
+}
+
+variable "vnets" {
+  default = {}
+}
+
+variable "base_tags" {
+  description = "Base tags for the resource to be inherited from the resource group."
+  type        = map(any)
+}
+
+variable "tags" {
+  default = {}
+}

--- a/modules/networking/private_dns_vnet_link/variables.tf
+++ b/modules/networking/private_dns_vnet_link/variables.tf
@@ -12,6 +12,9 @@ variable "resource_group_name" {
   description = "Resource Group Name"
 }
 
+variable "records" {
+}
+
 variable "vnet_links" {
   default = {}
 }

--- a/networking_private_dns.tf
+++ b/networking_private_dns.tf
@@ -18,3 +18,24 @@ module "private_dns" {
 output "private_dns" {
   value = module.private_dns
 }
+
+#
+# Create vnet links on remote DNS zones
+#
+
+module "private_dns_vnet_link" {
+  source   = "./modules/networking/private_dns_vnet_link"
+  for_each = try(local.networking.private_dns_vnet_link, {})
+  depends  = [module.private_dns]
+
+  base_tags          = {}
+  global_settings    = local.global_settings
+  client_config      = local.client_config
+  virtual_network_id = local.combined_objects_networking[local.client_config.landingzone_key][each.value.vnet_key].id
+  private_dns        = local.combined_objects_private_dns
+  settings           = each.value
+}
+
+output "private_dns_vnet_link" {
+  value = module.private_dns_vnet_link
+}

--- a/networking_private_dns.tf
+++ b/networking_private_dns.tf
@@ -23,9 +23,9 @@ output "private_dns" {
 # Create vnet links on remote DNS zones
 #
 
-module "private_dns_vnet_link" {
+module "private_dns_vnet_links" {
   source   = "./modules/networking/private_dns_vnet_link"
-  for_each = try(local.networking.private_dns_vnet_link, {})
+  for_each = try(local.networking.private_dns_vnet_links, {})
   depends  = [module.private_dns]
 
   base_tags       = {}
@@ -39,6 +39,6 @@ module "private_dns_vnet_link" {
   settings    = each.value
 }
 
-output "private_dns_vnet_link" {
-  value = module.private_dns_vnet_link
+output "private_dns_vnet_links" {
+  value = module.private_dns_vnet_links
 }

--- a/networking_private_dns.tf
+++ b/networking_private_dns.tf
@@ -28,12 +28,15 @@ module "private_dns_vnet_link" {
   for_each = try(local.networking.private_dns_vnet_link, {})
   depends  = [module.private_dns]
 
-  base_tags          = {}
-  global_settings    = local.global_settings
-  client_config      = local.client_config
-  virtual_network_id = local.combined_objects_networking[local.client_config.landingzone_key][each.value.vnet_key].id
-  private_dns        = local.combined_objects_private_dns
-  settings           = each.value
+  base_tags       = {}
+  global_settings = local.global_settings
+  client_config   = local.client_config
+  virtual_network_id = coalesce(
+    try(local.combined_objects_networking[each.value.lz_key][each.value.vnet_key].id, null),
+    try(local.combined_objects_networking[local.client_config.landingzone_key][each.value.vnet_key].id, null)
+  )
+  private_dns = local.combined_objects_private_dns
+  settings    = each.value
 }
 
 output "private_dns_vnet_link" {

--- a/networking_private_dns.tf
+++ b/networking_private_dns.tf
@@ -26,7 +26,7 @@ output "private_dns" {
 module "private_dns_vnet_links" {
   source   = "./modules/networking/private_dns_vnet_link"
   for_each = try(local.networking.private_dns_vnet_links, {})
-  depends  = [module.private_dns]
+  depends_on  = [module.private_dns]
 
   base_tags       = {}
   global_settings = local.global_settings


### PR DESCRIPTION
### Description
- Add a sub-module for creating virtual-network-links in a separate landing zone and not as part of private-dns-zone creation
- Sometime private-dns-zones and vnets are not created together in the same even landing zone or even same level. Separating the vnet-link module would enable users to create vnet-links in a separate lz linking the dependencies


### Dependencies
- This requires changes in https://github.com/Azure/caf-terraform-landingzones repository. PR to merged for these changes to work: https://github.com/Azure/caf-terraform-landingzones/pull/251

### Testing
- Added a sample config tfvars file to  showcase the usage

<img width="1072" alt="Screenshot 2021-09-06 at 4 09 08 PM" src="https://user-images.githubusercontent.com/42051002/132183771-ec5768cc-2913-481b-83b2-00a24768c3f1.png">


