### PR TITLE
Fix typo azurermfw vnet

### DIFF
--- a/examples/networking/virtual_network/100-simple-vnet-subnets-nsgs/configuration.tfvars
+++ b/examples/networking/virtual_network/100-simple-vnet-subnets-nsgs/configuration.tfvars
@@ -22,16 +22,16 @@ vnets = {
       #dns_servers   = ["10.2.0.5", "10.2.0.6"]
       # dns_servers_keys = {
       #   ip1 = {
-      #     lz_key          = "",
-      #     key             = "",
-      # .   resource_type   = "azurerm_firewall",
+      #     lz_key          = ""
+      #     key             = ""
+      # .   resource_type   = "azurerm_firewalls"
       #     interface_index = 0 #Optional it will take 0.
       #
       #   }
       #   ip2 = {
-      #     lz_key          = "",
-      #     key             = "",
-      #     resource_type   = "azurerm_firewall",
+      #     lz_key          = ""
+      #     key             = ""
+      #     resource_type   = "azurerm_firewalls"
       #   }
       # }
     }

--- a/examples/networking/virtual_network/100-simple-vnet-subnets-nsgs/configuration.tfvars
+++ b/examples/networking/virtual_network/100-simple-vnet-subnets-nsgs/configuration.tfvars
@@ -24,14 +24,14 @@ vnets = {
       #   ip1 = {
       #     lz_key          = ""
       #     key             = ""
-      # .   resource_type   = "azurerm_firewalls"
+      # .   resource_type   = "azurerm_firewall"
       #     interface_index = 0 #Optional it will take 0.
       #
       #   }
       #   ip2 = {
       #     lz_key          = ""
       #     key             = ""
-      #     resource_type   = "azurerm_firewalls"
+      #     resource_type   = "azurerm_firewall"
       #   }
       # }
     }

--- a/networking.tf
+++ b/networking.tf
@@ -41,7 +41,7 @@ module "networking" {
   base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].tags : {}
 
   remote_dns = {
-    azurerm_firewalls = try(var.remote_objects.azurerm_firewalls, null) #assumed from remote lz only
+    azurerm_firewall = try(var.remote_objects.azurerm_firewalls, null) #assumed from remote lz only
   }
 }
 

--- a/networking.tf
+++ b/networking.tf
@@ -41,7 +41,7 @@ module "networking" {
   base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].tags : {}
 
   remote_dns = {
-    azurerm_firewall = try(var.remote_objects.azurerm_firewall, null) #assumed from remote lz only
+    azurerm_firewalls = try(var.remote_objects.azurerm_firewalls, null) #assumed from remote lz only
   }
 }
 


### PR DESCRIPTION
should be using `var.remote_objects.azurerm_firewalls` instead of `var.remote_objects.azurerm_firewall`. updated and tested with example.