### PR TITLE
Support remote KeyVault for MSSQL or MySQL

### DIFF
--- a/examples/mysql_server/102-private-endpoint-mysql/configuration.tfvars
+++ b/examples/mysql_server/102-private-endpoint-mysql/configuration.tfvars
@@ -30,6 +30,11 @@ mysql_servers = {
     #   Below password argument is used to set the DB password. If not passed, there will be a random password generated and stored in azure keyvault.
     #   administrator_login_password  = "ComplxP@ssw0rd!"
     keyvault_key                  = "mysql-re1"
+    # If your keyvault is on remote lz use this:
+    # keyvault = {
+    #   lz_key = "" #lz which the keyvault is located
+    #   key    = "" #keyvault resource key
+    # }
     system_msi                    = true
     public_network_access_enabled = true
     auto_grow_enabled             = true

--- a/mssql_servers.tf
+++ b/mssql_servers.tf
@@ -21,7 +21,12 @@ module "mssql_servers" {
   resource_groups     = try(each.value.private_endpoints, {}) == {} ? null : local.resource_groups
   base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
   private_dns         = local.combined_objects_private_dns
-  keyvault_id         = try(each.value.administrator_login_password, null) == null ? module.keyvaults[each.value.keyvault_key].id : null
+  keyvault_id         = coalesce(
+    try(each.value.administrator_login_password, null),
+    try(module.keyvaults[each.value.keyvault_key].id, null),
+    try(local.combined_objects_keyvaults[each.value.keyvault.lz_key][each.value.keyvault.key].id, null),
+    try(local.combined_objects_keyvaults[local.client_config.landingzone_key][each.value.keyvault.key].id, null)
+  )
 }
 
 data "azurerm_storage_account" "mssql_auditing" {

--- a/msssql_managed_instances.tf
+++ b/msssql_managed_instances.tf
@@ -18,7 +18,12 @@ module "mssql_managed_instances" {
   location            = try(local.global_settings.regions[each.value.region], local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location)
   subnet_id           = local.combined_objects_networking[try(each.value.networking.lz_key, local.client_config.landingzone_key)][each.value.networking.vnet_key].subnets[each.value.networking.subnet_key].id
   base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
-  keyvault_id         = try(each.value.administratorLoginPassword, null) == null ? module.keyvaults[each.value.keyvault_key].id : null
+  keyvault_id         = coalesce(
+    try(each.value.administrator_login_password, null),
+    try(module.keyvaults[each.value.keyvault_key].id, null),
+    try(local.combined_objects_keyvaults[each.value.keyvault.lz_key][each.value.keyvault.key].id, null),
+    try(local.combined_objects_keyvaults[local.client_config.landingzone_key][each.value.keyvault.key].id, null)
+  )
 }
 
 module "mssql_managed_instances_secondary" {

--- a/mysql_servers.tf
+++ b/mysql_servers.tf
@@ -14,7 +14,12 @@ module "mysql_servers" {
   client_config       = local.client_config
   resource_group_name = local.resource_groups[each.value.resource_group_key].name
   location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
-  keyvault_id         = try(each.value.administrator_login_password, null) == null ? module.keyvaults[each.value.keyvault_key].id : null
+  keyvault_id         = coalesce(
+    try(each.value.administrator_login_password, null),
+    try(module.keyvaults[each.value.keyvault_key].id, null),
+    try(local.combined_objects_keyvaults[each.value.keyvault.lz_key][each.value.keyvault.key].id, null),
+    try(local.combined_objects_keyvaults[local.client_config.landingzone_key][each.value.keyvault.key].id, null)
+  )
   storage_accounts    = module.storage_accounts
   azuread_groups      = module.azuread_groups
   vnets               = local.combined_objects_networking


### PR DESCRIPTION
Allow reference to remote lz to use the keyvault centrally or specifically outside out the creation of sql.