### PR TITLE
add lifecycle

### DIFF
--- a/modules/compute/virtual_machine_scale_set/vmss_linux.tf
+++ b/modules/compute/virtual_machine_scale_set/vmss_linux.tf
@@ -222,7 +222,10 @@ resource "azurerm_linux_virtual_machine_scale_set" "vmss" {
     }
   }
 
-
+  lifecycle {
+    ignore_changes = try(each.value.ignore_changes, [])
+  }
+  
 }
 
 #


### PR DESCRIPTION
in some case we need update source_image_id or source_image_reference by Ansible in vmss. so terraform should ignore them.
for that reason we need to manage lifecycle.