### PR TITLE
Correct order for lz_key and landingzone_key

### DIFF
--- a/modules/databases/mssql_server/server.tf
+++ b/modules/databases/mssql_server/server.tf
@@ -44,7 +44,7 @@ resource "azurerm_mssql_virtual_network_rule" "network_rules" {
 
   name      = each.value.name
   server_id = azurerm_mssql_server.mssql.id
-  subnet_id = try(each.value.subnet_id, var.vnets[try(var.client_config.landingzone_key, each.value.lz_key)][each.value.vnet_key].subnets[each.value.subnet_key].id)
+  subnet_id = try(each.value.subnet_id, var.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id)
 }
 
 resource "azurecaf_name" "mssql" {


### PR DESCRIPTION
If you want to use a subnet in a different lz then the current code doesn't let you as it checks `var.client_config.landingzone_key` first instead of `each.value.lz_key`

Signed-off-by: Rob Long <Robert.Long@lv.com>