### PR TITLE
add fix for remote vnet reference in network fule

### DIFF
--- a/modules/databases/mssql_server/server.tf
+++ b/modules/databases/mssql_server/server.tf
@@ -44,7 +44,11 @@ resource "azurerm_mssql_virtual_network_rule" "network_rules" {
 
   name      = each.value.name
   server_id = azurerm_mssql_server.mssql.id
-  subnet_id = try(each.value.subnet_id, var.vnets[try(var.client_config.landingzone_key, each.value.lz_key)][each.value.vnet_key].subnets[each.value.subnet_key].id)
+  subnet_id = coalesce(
+    try(each.value.subnet_id, null),
+    try(var.vnets[each.value.lz_key][each.value.vnet_key].subnets[each.value.subnet_key].id, null),
+    try(var.vnets[var.client_config.landingzone_key][each.value.vnet_key].subnets[each.value.subnet_key].id, null)
+  )
 }
 
 resource "azurecaf_name" "mssql" {


### PR DESCRIPTION
mssql_server module for network rule subnet remote referencing sequence was wrong,
evaluation is considering var.client_config.landingzone_key before each.value.lz_key, thus rendering each.value.lz_key not evaluated.
Fix to reverse the sequence.