### PR TITLE
Add cosmosdb_sql_databases module

### DIFF
--- a/cosmosdb_sql_databases.tf
+++ b/cosmosdb_sql_databases.tf
@@ -1,0 +1,23 @@
+output "cosmosdb_sql_databases" {
+  value = module.cosmosdb_sql_databases
+}
+
+module "cosmosdb_sql_databases" {
+  source   = "./modules/databases/cosmos_dbs/sql_database"
+  for_each = local.database.cosmosdb_sql_databases
+
+  global_settings       = local.global_settings
+  settings              = each.value
+  resource_group_name   = coalesce(
+    try(local.combined_objects_cosmos_dbs[each.value.lz_key][each.value.cosmosdb_account_key].resource_group_name, null),
+    try(local.combined_objects_cosmos_dbs[local.client_config.landingzone_key][each.value.cosmosdb_account_key].resource_group_name, null)
+  )
+  location              = coalesce(
+    try(local.combined_objects_cosmos_dbs[each.value.lz_key][each.value.cosmosdb_account_key].location, null),
+    try(local.combined_objects_cosmos_dbs[local.client_config.landingzone_key][each.value.cosmosdb_account_key].location, null)
+  )
+  cosmosdb_account_name = coalesce(
+    try(local.combined_objects_cosmos_dbs[each.value.lz_key][each.value.cosmosdb_account_key].name, null),
+    try(local.combined_objects_cosmos_dbs[local.client_config.landingzone_key][each.value.cosmosdb_account_key].name, null)
+  )
+}

--- a/locals.combined_objects.tf
+++ b/locals.combined_objects.tf
@@ -12,6 +12,8 @@ locals {
   combined_objects_application_security_groups                    = merge(tomap({ (local.client_config.landingzone_key) = module.application_security_groups }), try(var.remote_objects.application_security_groups, {}))
   combined_objects_availability_sets                              = merge(tomap({ (local.client_config.landingzone_key) = module.availability_sets }), try(var.remote_objects.availability_sets, {}))
   combined_objects_azure_container_registries                     = merge(tomap({ (local.client_config.landingzone_key) = module.container_registry }), try(var.remote_objects.container_registry, {}))
+  combined_objects_cosmos_dbs                                     = merge(tomap({ (local.client_config.landingzone_key) = module.cosmos_dbs }), try(var.remote_objects.cosmos_dbs, {}))
+  combined_objects_cosmosdb_sql_databases                         = merge(tomap({ (local.client_config.landingzone_key) = module.cosmosdb_sql_databases }), try(var.remote_objects.cosmosdb_sql_databases, {}))
   combined_objects_azuread_applications                           = merge(tomap({ (local.client_config.landingzone_key) = module.azuread_applications_v1 }), try(var.remote_objects.azuread_applications, {}))
   combined_objects_azuread_apps                                   = merge(tomap({ (local.client_config.landingzone_key) = module.azuread_applications }), try(var.remote_objects.azuread_apps, {}))
   combined_objects_azuread_groups                                 = merge(tomap({ (local.client_config.landingzone_key) = module.azuread_groups }), try(var.remote_objects.azuread_groups, {}))

--- a/locals.tf
+++ b/locals.tf
@@ -91,6 +91,7 @@ locals {
     app_config                         = try(var.database.app_config, {})
     azurerm_redis_caches               = try(var.database.azurerm_redis_caches, {})
     cosmos_dbs                         = try(var.database.cosmos_dbs, {})
+    cosmosdb_sql_databases             = try(var.database.cosmosdb_sql_databases, {})
     database_migration_services        = try(var.database.database_migration_services, {})
     database_migration_projects        = try(var.database.database_migration_projects, {})
     databricks_workspaces              = try(var.database.databricks_workspaces, {})

--- a/modules/databases/cosmos_dbs/output.tf
+++ b/modules/databases/cosmos_dbs/output.tf
@@ -13,3 +13,15 @@ output "primary_key" {
 output "endpoint" {
   value = azurerm_cosmosdb_account.cosmos_account.endpoint
 }
+
+output "name" {
+  value = azurecaf_name.cdb.result
+}
+
+output "resource_group_name" {
+  value = var.resource_group_name
+}
+
+output "location" {
+  value = var.location
+}

--- a/modules/databases/cosmos_dbs/sql_database/output.tf
+++ b/modules/databases/cosmos_dbs/sql_database/output.tf
@@ -1,0 +1,7 @@
+output "id" {
+  value = azurerm_cosmosdb_sql_database.database.id
+}
+
+output "name" {
+  value = azurerm_cosmosdb_sql_database.database.name
+}


### PR DESCRIPTION
A separate module allows the cosmos account to be defined in a different
landing zone to the database. For example you could define a shared cosmos
db account with a private endpoint in level 3 and project-specific sql
databases inside that account in level 4 landing zones. This allows you to
nicely separate shared and project components.