### PR TITLE
Fix value lookups for aks network_profile

### DIFF
--- a/modules/compute/aks/aks.tf
+++ b/modules/compute/aks/aks.tf
@@ -202,9 +202,9 @@ resource "azurerm_kubernetes_cluster" "aks" {
       dns_service_ip     = try(network_profile.value.dns_service_ip, null)
       docker_bridge_cidr = try(network_profile.value.docker_bridge_cidr, null)
       outbound_type      = try(network_profile.value.outbound_type, null)
-      pod_cidr           = try(network_profile.value.network_profile.pod_cidr, null)
-      service_cidr       = try(network_profile.value.network_profile.service_cidr, null)
-      load_balancer_sku  = try(network_profile.value.network_profile.load_balancer_sku, null)
+      pod_cidr           = try(network_profile.value.pod_cidr, null)
+      service_cidr       = try(network_profile.value.service_cidr, null)
+      load_balancer_sku  = try(network_profile.value.load_balancer_sku, null)
 
       dynamic "load_balancer_profile" {
         for_each = try(network_profile.value.load_balancer_profile[*], {})


### PR DESCRIPTION
Given the following config:

network_profile = {
  network_plugin     = "azure"
  load_balancer_sku  = "standard"
  network_policy     = "azure"
  service_cidr       = "172.20.0.0/16"
  dns_service_ip     = "172.20.255.254"
  docker_bridge_cidr = "172.21.0.1/16"
}

Terraform will throw the following error:

Error: `docker_bridge_cidr`, `dns_service_ip` and `service_cidr` should
all be empty or all should be set

This commit fixes this issue.