### PR TITLE
Vm_scale_set output id not set correctly for windows VM

### DIFF
--- a/modules/compute/virtual_machine_scale_set/output.tf
+++ b/modules/compute/virtual_machine_scale_set/output.tf
@@ -1,5 +1,5 @@
 output "id" {
-  value = local.os_type == "linux" ? try(azurerm_linux_virtual_machine_scale_set.vmss["linux"].id, null) : try(azurerm_linux_virtual_machine_scale_set.vmss["windows"].id, null)
+  value = local.os_type == "linux" ? try(azurerm_linux_virtual_machine_scale_set.vmss["linux"].id, null) : try(azurerm_windows_virtual_machine_scale_set.vmss["windows"].id, null)
 }
 
 output "os_type" {


### PR DESCRIPTION
fix vm_scale_set output id for windows