### PR TITLE
Adding virtual machine custom script extension 

### DIFF
--- a/examples/compute/virtual_machine/110-single-windows-vm-custom-script-extension/configuration.tfvars
+++ b/examples/compute/virtual_machine/110-single-windows-vm-custom-script-extension/configuration.tfvars
@@ -1,0 +1,153 @@
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "eastus"
+  }
+}
+
+tags = {
+  level = "100"
+}
+
+resource_groups = {
+  vm_region1 = {
+    name = "example-virtual-machine-rg1"
+    tags = {
+      env = "standalone"
+    }
+  }
+}
+
+# Virtual machines
+virtual_machines = {
+
+  # Configuration to deploy a bastion host linux virtual machine
+  example_vm1 = {
+    resource_group_key = "vm_region1"
+    provision_vm_agent = true
+    # when boot_diagnostics_storage_account_key is empty string "", boot diagnostics will be put on azure managed storage
+    # when boot_diagnostics_storage_account_key is a non-empty string, it needs to point to the key of a user managed storage defined in diagnostic_storage_accounts
+    # if boot_diagnostics_storage_account_key is not defined, but global_settings.resource_defaults.virtual_machines.use_azmanaged_storage_for_boot_diagnostics is true, boot diagnostics will be put on azure managed storage
+
+    os_type = "windows"
+
+    # the auto-generated ssh key in keyvault secret. Secret name being {VM name}-ssh-public and {VM name}-ssh-private
+    keyvault_key = "example_vm_rg1"
+
+    # Define the number of networking cards to attach the virtual machine
+    networking_interfaces = {
+      nic0 = {
+        # Value of the keys from networking.tfvars
+        net_key                 = "vnet_region1"
+        subnet_key              = "example"
+        name                    = "0"
+        enable_ip_forwarding    = false
+        internal_dns_name_label = "nic0"
+      }
+    }
+
+    virtual_machine_settings = {
+      windows = {
+        name = "example_vm3"
+        size = "Standard_F2"
+        zone = "1"
+
+        admin_username_key = "vmadmin-username"
+        admin_password_key = "vmadmin-password"
+
+        # Spot VM to save money
+        priority        = "Spot"
+        eviction_policy = "Deallocate"
+
+        # Value of the nic keys to attach the VM. The first one in the list is the default nic
+        network_interface_keys = ["nic0"]
+
+        os_disk = {
+          name                 = "example_vm1-os"
+          caching              = "ReadWrite"
+          storage_account_type = "Standard_LRS"
+          managed_disk_type    = "StandardSSD_LRS"
+          disk_size_gb         = "128"
+          create_option        = "FromImage"
+        }
+
+        source_image_reference = {
+          publisher = "MicrosoftWindowsServer"
+          offer     = "WindowsServer"
+          sku       = "2019-Datacenter"
+          version   = "latest"
+        }
+
+      }
+    }
+
+    virtual_machine_extensions = {
+     custom_script = {
+        #fileuris            = ["https://somelocation/container/script.ps1"]
+        # can define fileuris directly or use fileuri_sa_ reference keys and lz_key:
+        fileuri_sa_key       = "mystorageaccount"
+        fileuri_sa_path      = "container/script.ps1"
+        commandtoexecute     = "PowerShell -file script.ps1"
+        # managed_identity_id = optional to define managed identity principal_id directly
+        identity_type        = "UserAssigned" #optional to use managed_identity for download from location specified in fileuri, UserAssigned or SystemAssigned. 
+        managed_identity_key = "mymanagedidentity"
+        lz_key               = "shared_storage"
+      }
+    }
+  }
+}
+
+# Store output attributes into keyvault secret
+dynamic_keyvault_secrets = {
+  example_vm_rg1 = { # Key of the keyvault
+    vmadmin-username = {
+      secret_name = "vmadmin-username"
+      value       = "vmadmin"
+    }
+    vmadmin-password = {
+      secret_name = "vmadmin-password"
+      value       = "Very@Str5ngP!44w0rdToChaNge#"
+    }
+    domain-join-username = {
+      secret_name = "domain-join-username"
+      value       = "domainjoinuser@contoso.com"
+    }
+    domain-join-password = {
+      secret_name = "domain-join-password"
+      value       = "MyDoma1nVery@Str5ngP!44w0rdToChaNge#"
+    }
+  }
+}
+
+keyvaults = {
+  example_vm_rg1 = {
+    name               = "vmsecretskv"
+    resource_group_key = "vm_region1"
+    sku_name           = "standard"
+    tags = {
+      env = "Standalone"
+    }
+    creation_policies = {
+      logged_in_user = {
+        secret_permissions = ["Set", "Get", "List", "Delete", "Purge", "Recover"]
+      }
+    }
+  }
+}
+
+vnets = {
+  vnet_region1 = {
+    resource_group_key = "vm_region1"
+    vnet = {
+      name          = "virtual_machines"
+      address_space = ["10.100.100.0/24"]
+    }
+    subnets = {
+      example = {
+        name = "examples"
+        cidr = ["10.100.100.0/29"]
+      }
+    }
+
+  }
+}

--- a/examples/compute/virtual_machine/110-single-windows-vm-custom-script-extension/helloworld.ps1
+++ b/examples/compute/virtual_machine/110-single-windows-vm-custom-script-extension/helloworld.ps1
@@ -1,0 +1,3 @@
+Start-Transcript -Path c:\helloworld.txt
+write-output "hello world"
+stop-transcript

--- a/examples/vm_extensions.tf
+++ b/examples/vm_extensions.tf
@@ -73,3 +73,21 @@ module "vm_extension_session_host_dscextension" {
   keyvaults          = module.example.keyvaults
   wvd_host_pools     = module.example.wvd_host_pools
 }
+
+module "vm_extension_custom_scriptextension" {
+  source     = "../modules/compute/virtual_machine_extensions"
+
+  depends_on = [module.example, module.vm_extension_microsoft_azure_domainjoin]
+
+  for_each = {
+    for key, value in try(var.virtual_machines, {}) : key => value
+    if try(value.virtual_machine_extensions.custom_script, null) != null
+  }
+
+  client_config      = module.example.client_config
+  virtual_machine_id = module.example.virtual_machines[each.key].id
+  extension          = each.value.virtual_machine_extensions.custom_script
+  extension_name     = "custom_script"
+  managed_identities = module.example.managed_identities
+  storage_accounts   = module.example.storage_accounts
+}

--- a/modules/compute/virtual_machine_extensions/custom_script.tf
+++ b/modules/compute/virtual_machine_extensions/custom_script.tf
@@ -33,6 +33,7 @@ locals {
   fileuri_sa_full_path = "${local.fileuri_sa}${local.fileuri_sa_path}"
 
   timestamp = {"timestamp" : try(var.extension.timestamp, "12345678")}
-  fileuris = (try(var.extension.fileuris, "" == "")) ? [local.fileuri_sa_full_path] : var.extension.fileuris
+  fileuri_sa_defined   = try(var.extension.fileuris, "")
+  fileuris = fileuri_sa_defined == "" ? [local.fileuri_sa_full_path] : var.extension.fileuris
   settings = merge(local.timestamp,local.fileuris)
 }

--- a/modules/compute/virtual_machine_extensions/custom_script.tf
+++ b/modules/compute/virtual_machine_extensions/custom_script.tf
@@ -34,6 +34,6 @@ locals {
 
   timestamp = {"timestamp" : try(var.extension.timestamp, "12345678")}
   fileuri_sa_defined   = try(var.extension.fileuris, "")
-  fileuris = fileuri_sa_defined == "" ? [local.fileuri_sa_full_path] : var.extension.fileuris
+  fileuris = local.fileuri_sa_defined == "" ? [local.fileuri_sa_full_path] : var.extension.fileuris
   settings = merge(local.timestamp,local.fileuris)
 }

--- a/modules/compute/virtual_machine_extensions/custom_script.tf
+++ b/modules/compute/virtual_machine_extensions/custom_script.tf
@@ -35,7 +35,7 @@ locals {
   # fileuris
   fileuri_sa_key       = try(var.extension.fileuri_sa_key, "")
   fileuri_sa_path      = try(var.extension.fileuri_sa_path, "")
-  fileuri_sa           = local.fileuri_sa_key != "" ? try(var.storage_accounts[var.client_config.landingzone_key][var.extension.fileuri_sa_key].primary_blob_endpoint, try(var.storage_accounts[var.extension.lz_key][var.extension.fileuri_sa_key].primary_blob_endpoint)) : ""
+  fileuri_sa           = local.fileuri_sa_key != "" ? try(var.storage_accounts[var.extension.fileuri_sa_key].primary_blob_endpoint, try(var.storage_accounts[var.extension.lz_key][var.extension.fileuri_sa_key].primary_blob_endpoint)) : ""
   fileuri_sa_full_path = "${local.fileuri_sa}${local.fileuri_sa_path}"
   fileuri_sa_defined   = try(var.extension.fileuris, "")
   fileuris = local.fileuri_sa_defined == "" ? [local.fileuri_sa_full_path] : var.extension.fileuris

--- a/modules/compute/virtual_machine_extensions/custom_script.tf
+++ b/modules/compute/virtual_machine_extensions/custom_script.tf
@@ -23,12 +23,12 @@ locals {
   managed_local_identity = try(var.managed_identities[var.client_config.landingzone_key][var.extension.managed_identity_key].principal_id, "")
   managed_remote_identity = try(var.managed_identities[var.extension.lz_key][var.extension.managed_identity_key].principal_id, "")
   provided_identity = try(var.extension.managed_identity_id, "")
-  managed_identity = coalesce(local.managed_local_identity, local.managed_remote_identity, local.provided_identity)
+  managed_identity = try(coalesce(local.managed_local_identity, local.managed_remote_identity, local.provided_identity),"")
   
   system_assigned_id = local.identity_type == "SystemAssigned" ? {"managedIdentity" : {}} : null
   user_assigned_id = local.identity_type == "UserAssigned" ? {"managedIdentity" : {"objectid" : "${local.managed_identity}"}} : null
   
-  command = {"commandtoexecute" : "${var.extension.commandtoexecute}"}
+  command = {"commandtoexecute" : "${try(var.extension.commandtoexecute,"")}"}
 
   protected_settings = merge(local.command,local.system_assigned_id,local.user_assigned_id)
 

--- a/modules/compute/virtual_machine_extensions/custom_script.tf
+++ b/modules/compute/virtual_machine_extensions/custom_script.tf
@@ -7,7 +7,6 @@ resource "azurerm_virtual_machine_extension" "custom_script" {
   type_handler_version       = "1.10"
   auto_upgrade_minor_version = true
 
-  #settings                   = jsonencode(local.settings)
   settings = jsonencode(
     {
       "fileUris" : local.fileuris,
@@ -38,9 +37,6 @@ locals {
   fileuri_sa_path      = try(var.extension.fileuri_sa_path, "")
   fileuri_sa           = local.fileuri_sa_key != "" ? try(var.storage_accounts[var.client_config.landingzone_key][var.extension.fileuri_sa_key].primary_blob_endpoint, try(var.storage_accounts[var.extension.lz_key][var.extension.fileuri_sa_key].primary_blob_endpoint)) : ""
   fileuri_sa_full_path = "${local.fileuri_sa}${local.fileuri_sa_path}"
-
-  #timestamp = {"timestamp" : try(var.extension.timestamp, "12345678")}
   fileuri_sa_defined   = try(var.extension.fileuris, "")
   fileuris = local.fileuri_sa_defined == "" ? [local.fileuri_sa_full_path] : var.extension.fileuris
-  #settings = merge(local.timestamp,local.fileuris)
 }

--- a/modules/compute/virtual_machine_extensions/custom_script.tf
+++ b/modules/compute/virtual_machine_extensions/custom_script.tf
@@ -29,7 +29,7 @@ locals {
   # fileuris
   fileuri_sa_key       = try(var.extension.fileuri_sa_key, "")
   fileuri_sa_path      = try(var.extension.fileuri_sa_path, "")
-  fileuri_sa           = local.fileuri_sa_key != "" ? try(var.storage_accounts[var.client_config.landingzone_key][var.extension.fileuri_sa_key].primary_blob_endpoint, try(var.storage_accounts[var.extension.lz_key][var.extension.fileuri_sa_key].primary_blob_endpoint)) : null
+  fileuri_sa           = local.fileuri_sa_key != "" ? try(var.storage_accounts[var.client_config.landingzone_key][var.extension.fileuri_sa_key].primary_blob_endpoint, try(var.storage_accounts[var.extension.lz_key][var.extension.fileuri_sa_key].primary_blob_endpoint)) : ""
   fileuri_sa_full_path = "${local.fileuri_sa}${local.fileuri_sa_path}"
 
   timestamp = {"timestamp" : try(var.extension.timestamp, "12345678")}

--- a/modules/compute/virtual_machine_extensions/custom_script.tf
+++ b/modules/compute/virtual_machine_extensions/custom_script.tf
@@ -20,7 +20,7 @@ resource "azurerm_virtual_machine_extension" "custom_script" {
 locals {
   # managed identity
   identity_type = try(var.extension.identity_type, "") #userassigned, systemassigned or null
-  managed_local_identity = try(var.managed_identities[var.client_config.landingzone_key][var.extension.managed_identity_key].princpal_id, "")
+  managed_local_identity = try(var.managed_identities[var.client_config.landingzone_key][var.extension.managed_identity_key].principal_id, "")
   managed_remote_identity = try(var.managed_identities[var.extension.lz_key][var.extension.managed_identity_key].principal_id, "")
   provided_identity = try(var.extension.managed_identity_id, "")
   managed_identity = coalesce(local.managed_local_identity, local.managed_remote_identity, local.provided_identity)

--- a/modules/compute/virtual_machine_extensions/custom_script.tf
+++ b/modules/compute/virtual_machine_extensions/custom_script.tf
@@ -7,7 +7,14 @@ resource "azurerm_virtual_machine_extension" "custom_script" {
   type_handler_version       = "1.10"
   auto_upgrade_minor_version = true
 
-  settings                   = jsonencode(local.settings)
+  #settings                   = jsonencode(local.settings)
+  settings = jsonencode(
+    {
+      "fileUris" : local.fileuris,
+      "timestamp" : try(var.extension.timestamp, "12345678")
+    }
+  )
+
   protected_settings         = jsonencode(local.protected_settings)
 }
 
@@ -32,8 +39,8 @@ locals {
   fileuri_sa           = local.fileuri_sa_key != "" ? try(var.storage_accounts[var.client_config.landingzone_key][var.extension.fileuri_sa_key].primary_blob_endpoint, try(var.storage_accounts[var.extension.lz_key][var.extension.fileuri_sa_key].primary_blob_endpoint)) : ""
   fileuri_sa_full_path = "${local.fileuri_sa}${local.fileuri_sa_path}"
 
-  timestamp = {"timestamp" : try(var.extension.timestamp, "12345678")}
+  #timestamp = {"timestamp" : try(var.extension.timestamp, "12345678")}
   fileuri_sa_defined   = try(var.extension.fileuris, "")
   fileuris = local.fileuri_sa_defined == "" ? [local.fileuri_sa_full_path] : var.extension.fileuris
-  settings = merge(local.timestamp,local.fileuris)
+  #settings = merge(local.timestamp,local.fileuris)
 }

--- a/modules/compute/virtual_machine_extensions/custom_script.tf
+++ b/modules/compute/virtual_machine_extensions/custom_script.tf
@@ -1,0 +1,38 @@
+resource "azurerm_virtual_machine_extension" "custom_script" {
+  for_each                   = var.extension_name == "custom_script" ? toset(["enabled"]) : toset([])
+  name                       = "custom_script"
+  virtual_machine_id         = var.virtual_machine_id
+  publisher                  = "Microsoft.Compute"
+  type                       = "CustomScriptExtension"
+  type_handler_version       = "1.10"
+  auto_upgrade_minor_version = true
+
+  settings                   = jsonencode(local.settings)
+  protected_settings         = jsonencode(local.protected_settings)
+}
+
+locals {
+  # managed identity
+  identity_type = try(var.extension.identity_type, "") #userassigned, systemassigned or null
+  managed_local_identity = try(var.managed_identities[var.client_config.landingzone_key][var.extension.managed_identity_key].princpal_id, "")
+  managed_remote_identity = try(var.managed_identities[var.extension.lz_key][var.extension.managed_identity_key].principal_id, "")
+  provided_identity = try(var.extension.managed_identity_id, "")
+  managed_identity = coalesce(local.managed_local_identity, local.managed_remote_identity, local.provided_identity)
+  
+  system_assigned_id = local.identity_type == "SystemAssigned" ? {"managedIdentity" : {}} : null
+  user_assigned_id = local.identity_type == "UserAssigned" ? {"managedIdentity" : {"objectid" : "${local.managed_identity}"}} : null
+  
+  command = {"commandtoexecute" : "${var.extension.commandtoexecute}"}
+
+  protected_settings = merge(local.command,local.system_assigned_id,local.user_assigned_id)
+
+  # fileuris
+  fileuri_sa_key       = try(var.extension.fileuri_sa_key, "")
+  fileuri_sa_path      = try(var.extension.fileuri_sa_path, "")
+  fileuri_sa           = local.fileuri_sa_key != "" ? try(var.storage_accounts[var.client_config.landingzone_key][var.extension.fileuri_sa_key].primary_blob_endpoint, try(var.storage_accounts[var.extension.lz_key][var.extension.fileuri_sa_key].primary_blob_endpoint)) : null
+  fileuri_sa_full_path = "${local.filuri_sa}${local.fileuri_sa_path}"
+
+  timestamp = {"timestamp" : try(var.extension.timestamp, "12345678")}
+  fileuris = (try(var.extension.fileuris, "" == "")) ? [local.fileuri_sa_full_path] : var.extension.fileuris
+  settings = merge(local.timestamp,local.fileuris)
+}

--- a/modules/compute/virtual_machine_extensions/custom_script.tf
+++ b/modules/compute/virtual_machine_extensions/custom_script.tf
@@ -30,7 +30,7 @@ locals {
   fileuri_sa_key       = try(var.extension.fileuri_sa_key, "")
   fileuri_sa_path      = try(var.extension.fileuri_sa_path, "")
   fileuri_sa           = local.fileuri_sa_key != "" ? try(var.storage_accounts[var.client_config.landingzone_key][var.extension.fileuri_sa_key].primary_blob_endpoint, try(var.storage_accounts[var.extension.lz_key][var.extension.fileuri_sa_key].primary_blob_endpoint)) : null
-  fileuri_sa_full_path = "${local.filuri_sa}${local.fileuri_sa_path}"
+  fileuri_sa_full_path = "${local.fileuri_sa}${local.fileuri_sa_path}"
 
   timestamp = {"timestamp" : try(var.extension.timestamp, "12345678")}
   fileuris = (try(var.extension.fileuris, "" == "")) ? [local.fileuri_sa_full_path] : var.extension.fileuris

--- a/modules/compute/virtual_machine_extensions/variables.tf
+++ b/modules/compute/virtual_machine_extensions/variables.tf
@@ -16,3 +16,9 @@ variable "keyvaults" {
 variable "wvd_host_pools" {
   default = {}
 }
+variable "managed_identities" {
+  default = {}
+}
+variable "storage_accounts" {
+  default = {}
+}


### PR DESCRIPTION
Added virtual machine custom script extension according to #514

Module supports using managed or system identity for downloading files https://docs.microsoft.com/en-us/azure/virtual-machines/extensions/custom-script-windows

Follow up to https://github.com/aztfmod/terraform-azurerm-caf/pull/740:

- Added ability to reference storage account for fileuris by using key/landing zone key
- Added example

storageaccountname and storageaccountkey attributes are not implemented