### PR TITLE
Enable DDOS plan from other LZs

### DIFF
--- a/locals.combined_objects.tf
+++ b/locals.combined_objects.tf
@@ -37,6 +37,7 @@ locals {
   combined_objects_diagnostic_storage_accounts                    = merge(tomap({ (local.client_config.landingzone_key) = module.diagnostic_storage_accounts }), try(var.remote_objects.diagnostic_storage_accounts, {}))
   combined_objects_disk_encryption_sets                           = merge(tomap({ (local.client_config.landingzone_key) = module.disk_encryption_sets }), try(var.remote_objects.disk_encryption_sets, {}))
   combined_objects_dns_zones                                      = merge(tomap({ (local.client_config.landingzone_key) = module.dns_zones }), try(var.remote_objects.dns_zones, {}))
+  combined_objects_ddos_services                                  = merge(tomap({ (local.client_config.landingzone_key) = azurerm_network_ddos_protection_plan.ddos_protection_plan }), try(var.remote_objects.ddos_services, {}), try(var.remote_objects.ddos_services, {}))
   combined_objects_event_hub_namespaces                           = merge(tomap({ (local.client_config.landingzone_key) = module.event_hub_namespaces }), try(var.remote_objects.event_hub_namespaces, {}))
   combined_objects_front_door_waf_policies                        = merge(tomap({ (local.client_config.landingzone_key) = module.front_door_waf_policies }), try(var.remote_objects.front_door_waf_policies, {}))
   combined_objects_integration_service_environment                = merge(tomap({ (local.client_config.landingzone_key) = module.integration_service_environment }), try(var.remote_objects.integration_service_environment, {}))

--- a/networking.tf
+++ b/networking.tf
@@ -26,7 +26,7 @@ module "networking" {
 
   application_security_groups       = local.combined_objects_application_security_groups
   client_config                     = local.client_config
-  ddos_id                           = try(azurerm_network_ddos_protection_plan.ddos_protection_plan[each.value.ddos_services_key].id, "")
+  ddos_id                           = try(local.combined_objects_ddos_services[try(each.value.ddos_services_lz_key, local.client_config.landingzone_key)][try(each.value.ddos_services_key, each.value.ddos_services_key)].id, "")
   diagnostics                       = local.combined_diagnostics
   global_settings                   = local.global_settings
   network_security_groups           = module.network_security_groups
@@ -219,6 +219,10 @@ resource "azurerm_network_ddos_protection_plan" "ddos_protection_plan" {
   location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   tags                = try(local.global_settings.inherit_tags, false) ? merge(local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags, each.value.tags) : try(each.value.tags, null)
+}
+
+output "ddos_services" {
+  value = azurerm_network_ddos_protection_plan.ddos_protection_plan
 }
 
 #


### PR DESCRIPTION
Currently, you are unable to attach a DDoS protection plan to a vNet in a different LZ to that of the DDoS protection plan, this PR corrects that.

https://github.com/aztfmod/terraform-azurerm-caf/issues/775