### PR TITLE
Added lifecycle ignore_changes to global_sign.tf

### DIFF
--- a/modules/security/keyvault_certificate_request/global_sign.tf
+++ b/modules/security/keyvault_certificate_request/global_sign.tf
@@ -43,4 +43,9 @@ resource "null_resource" "cancel_order_global_sign" {
       SOAP_CANCEL_ORDER_TPL = self.triggers.SOAP_CANCEL_ORDER
     }
   }
+  lifecycle {
+    ignore_changes = [
+      triggers
+    ]
+  }
 }


### PR DESCRIPTION
Added lifecycle ignore_changes to ignore triggers for preventing renewed SSL certificates from being reverted.