### PR TITLE
Remote ASG in VMSS, added timezone, license_type to windows vmss

### DIFF
--- a/modules/compute/virtual_machine_scale_set/main.tf
+++ b/modules/compute/virtual_machine_scale_set/main.tf
@@ -38,7 +38,7 @@ locals {
   application_security_group_ids = flatten([
     for nic, nic_value in var.settings.network_interfaces : [
       for asg, asg_value in try(nic_value.application_security_groups, {}) : [
-        try(var.application_security_groups[try(var.client_config.landingzone_key, asg_value.lz_key)][asg_value.asg_key].id, null)
+        try(var.application_security_groups[var.client_config.landingzone_key][asg_value.asg_key].id, var.application_security_groups[asg_value.lz_key][asg_value.asg_key].id)
       ]
     ]
   ])

--- a/modules/compute/virtual_machine_scale_set/vmss_windows.tf
+++ b/modules/compute/virtual_machine_scale_set/vmss_windows.tf
@@ -75,6 +75,8 @@ resource "azurerm_windows_virtual_machine_scale_set" "vmss" {
   scale_in_policy              = try(each.value.scale_in_policy, null)
   zone_balance                 = try(each.value.zone_balance, null)
   zones                        = try(each.value.zones, null)
+  timezone                     = try(each.value.timezone, null)
+  license_type                 = try(each.value.license_type, null)
 
   dynamic "network_interface" {
     for_each = try(var.settings.network_interfaces, {})


### PR DESCRIPTION
Fixed bug: Making the virtual machine scale set nic member of an application security group defined in another landingzone always failed

Added timezone and license_type attributes to the windows vmss