### PR TITLE
AKS - Private DNS causes cluster to redeploy

### DIFF
--- a/marketplace.tf
+++ b/marketplace.tf
@@ -1,4 +1,0 @@
-module "marketplace_agreement" {
-  source              = "./modules/marketplace/agreement"
-  settings            = var.marketplace_agreement
-}

--- a/modules/compute/aks/aks.tf
+++ b/modules/compute/aks/aks.tf
@@ -233,7 +233,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
 
   lifecycle {
     ignore_changes = [
-      windows_profile,
+      windows_profile, private_dns_zone_id
     ]
   }
   tags = merge(local.tags, lookup(var.settings, "tags", {}))


### PR DESCRIPTION
Bug: 
If Private DNS zone ID is added, AKS is being destroyed and recreated. Private_dns_zone_id is an optional parameter and should not force the cluster to recreate as per [tf registry](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster#private_dns_zone_id)

```
 # module.solution.module.aks_clusters["cluster_re1"].azurerm_kubernetes_cluster.aks must be replaced
+/- resource "azurerm_kubernetes_cluster" "aks" {
      - api_server_authorized_ip_ranges     = [] -> null
      - enable_pod_security_policy          = false -> null
      + fqdn                                = (known after apply)
      ~ id                                  = "/subscriptions/*/resourcegroups/rg-**-001/providers/Microsoft.ContainerService/managedClusters/private-akscluster" -> (known after apply)
      ~ kube_admin_config                   = [] -> (known after apply)
      + kube_admin_config_raw               = (sensitive value)
      - local_account_disabled              = false -> null
        name                                = "private-akscluster"
      ~ private_dns_zone_id                 = "System" -> (known after apply) # forces replacement