### PR TITLE
Add support for vmss custom script and domain join extensions

### DIFF
--- a/.github/workflows/standalone-scenarios.json
+++ b/.github/workflows/standalone-scenarios.json
@@ -41,6 +41,7 @@
     "compute/virtual_machine/211-vm-bastion-winrm-agents",
     "compute/virtual_machine_scale_set/100-linux-win-vmss-lb",
     "compute/virtual_machine_scale_set/101-linux-win-vmss-agw",
+    "compute/virtual_machine_scale_set/102-linux-win-vmss-custom-script-extension",
     "compute/windows_virtual_desktop/wvd_resources",
     "cosmos_db/100-simple-cosmos-db-cassandra",
     "cosmos_db/100-simple-cosmos-db-gremlin",

--- a/examples/compute/virtual_machine_scale_set/102-linux-win-vmss-custom-script-extension/configuration.tfvars
+++ b/examples/compute/virtual_machine_scale_set/102-linux-win-vmss-custom-script-extension/configuration.tfvars
@@ -183,16 +183,70 @@ load_balancers = {
         public_ip_address_key = "lb_pip1"
       }
     }
+    probes = {
+      probe1 = {
+        resource_group_key  = "example_vmss_rg1"
+        load_balancer_key   = "lb1"
+        probe_name          = "probe1"
+        port                = "22"
+        interval_in_seconds = "20"
+        number_of_probes    = "3"
+      }
+    }
+    lb_rules = {
+      rule1 = {
+        resource_group_key             = "example_vmss_rg1"
+        load_balancer_key              = "lb1"
+        lb_rule_name                   = "rule1"
+        protocol                       = "tcp"
+        probe_id_key                   = "probe1"
+        frontend_port                  = "22"
+        backend_port                   = "22"
+        enable_floating_ip             = "false"
+        idle_timeout_in_minutes        = "4"
+        load_distribution              = "SourceIPProtocol"
+        disable_outbound_snat          = "false"
+        enable_tcp_rest                = "false"
+        frontend_ip_configuration_name = "config1" # name must match the configuration that's defined in the load_balancers block.
+      }
+    }
   }
   lb2 = {
     name                      = "lb-vmss2"
     sku                       = "basic"
     resource_group_key        = "example_vmss_rg1"
-    backend_address_pool_name = "vmss1"
+    backend_address_pool_name = "vmss2"
     frontend_ip_configurations = {
       config1 = {
         name                  = "config1"
         public_ip_address_key = "lb_pip2"
+      }
+    }
+    probes = {
+      probe1 = {
+        resource_group_key  = "example_vmss_rg1"
+        load_balancer_key   = "lb2"
+        probe_name          = "probe1"
+        port                = "3389"
+        interval_in_seconds = "20"
+        number_of_probes    = "3"
+      }
+    }
+    lb_rules = {
+      rule1 = {
+        resource_group_key             = "example_vmss_rg1"
+        load_balancer_key              = "lb2"
+        lb_rule_name                   = "rule1"
+        protocol                       = "tcp"
+        probe_id_key                   = "probe1"
+        frontend_port                  = "3389"
+        backend_port                   = "3389"
+        enable_floating_ip             = "false"
+        idle_timeout_in_minutes        = "4"
+        load_distribution              = "SourceIPProtocol"
+        disable_outbound_snat          = "false"
+        enable_tcp_rest                = "false"
+        frontend_ip_configuration_name = "config1" # name must match the configuration that's defined in the load_balancers block.
       }
     }
   }

--- a/examples/compute/virtual_machine_scale_set/102-linux-win-vmss-custom-script-extension/configuration.tfvars
+++ b/examples/compute/virtual_machine_scale_set/102-linux-win-vmss-custom-script-extension/configuration.tfvars
@@ -41,15 +41,22 @@ storage_accounts = {
   }
 }
 
-# Upload helloworld script
+# Upload helloworld scripts
 storage_account_blobs = {
-  script = {
+  script1 = {
+    name                   = "helloworld.sh"
+    storage_account_key    = "sa1"
+    storage_container_name = "files"
+    source                 = "./compute/virtual_machine_scale_set/102-linux-win-vmss-custom-script-extension/scripts/helloworld.sh"
+    parallelism            = 1
+  }
+  script2 = {
     name                   = "helloworld.ps1"
     storage_account_key    = "sa1"
     storage_container_name = "files"
-    source                 = "./compute/virtual_machine_scale_set/102-linux-win-vmss-custom-script-extension/helloworld.ps1"
+    source                 = "./compute/virtual_machine_scale_set/102-linux-win-vmss-custom-script-extension/scripts/helloworld.ps1"
     parallelism            = 1
-  }
+  },
 }
 
 # Give managed identity Storage Blob Data reader and executing user Storage Blob Data Contributor permissions on storage account
@@ -304,12 +311,12 @@ virtual_machine_scale_sets = {
 
     virtual_machine_scale_set_extensions = {
       custom_script = {
-        # can define fileuris directly or use fileuri_sa_reference keys and lz_key:
+        # can define fileuris directly or use fileuri_sa reference keys and lz_key:
         # fileuris             = ["https://somelocation/container/script.ps1"]
         fileuri_sa_key       = "sa1"
-        fileuri_sa_path      = "helloworld.sh"
-        commandtoexecute     = "bash ./helloworld.sh"
-        identity_type        = "UserAssigned" #optional to use managed_identity for download from location specified in fileuri, UserAssigned or SystemAssigned.
+        fileuri_sa_path      = "files/helloworld.sh"
+        commandtoexecute     = "bash ./files/helloworld.sh"
+        identity_type        = "UserAssigned" # optional to use managed_identity for download from location specified in fileuri, UserAssigned or SystemAssigned.
         managed_identity_key = "example_vmss_mi"
         # managed_identity_id  = "id" optional to define managed identity principal_id directly
         # lz_key               = "other_lz" optional for managed identity defined in other lz
@@ -417,12 +424,12 @@ virtual_machine_scale_sets = {
 
     virtual_machine_scale_set_extensions = {
       custom_script = {
-        # can define fileuris directly or use fileuri_sa_reference keys and lz_key:
+        # can define fileuris directly or use fileuri_sa reference keys and lz_key:
         # fileuris             = ["https://somelocation/container/script.ps1"]
         fileuri_sa_key       = "sa1"
         fileuri_sa_path      = "files/helloworld.ps1"
         commandtoexecute     = "PowerShell -file helloworld.ps1"
-        identity_type        = "UserAssigned" #optional to use managed_identity for download from location specified in fileuri, UserAssigned or SystemAssigned.
+        identity_type        = "UserAssigned" # optional to use managed_identity for download from location specified in fileuri, UserAssigned or SystemAssigned.
         managed_identity_key = "example_vmss_mi"
         # managed_identity_id  = "id" optional to define managed identity principal_id directly
         # lz_key               = "other_lz" optional for managed identity defined in other lz

--- a/examples/compute/virtual_machine_scale_set/102-linux-win-vmss-custom-script-extension/configuration.tfvars
+++ b/examples/compute/virtual_machine_scale_set/102-linux-win-vmss-custom-script-extension/configuration.tfvars
@@ -15,10 +15,10 @@ resource_groups = {
   }
 }
 
-# managed identity to attach to vm to download from the storage account
+# Managed identity to attach to vm to download from the storage account
 managed_identities = {
-  example_mi = {
-    name               = "example_mi"
+  example_vmss_mi = {
+    name               = "example_vmss_mi"
     resource_group_key = "example_vmss_rg1"
   }
 }
@@ -59,7 +59,7 @@ role_mapping = {
       sa1 = {
         "Storage Blob Data Reader" = {
           managed_identities = {
-            keys = ["user_mi"]
+            keys = ["example_vmss_mi"]
           }
         }
         "Storage Blob Data Contributor" = {
@@ -237,7 +237,7 @@ virtual_machine_scale_sets = {
         identity = {
           # type = "SystemAssigned"
           type                  = "UserAssigned"
-          managed_identity_keys = ["example_mi"]
+          managed_identity_keys = ["example_vmss_mi"]
 
           remote = {
             lz_key_name = {

--- a/examples/compute/virtual_machine_scale_set/102-linux-win-vmss-custom-script-extension/configuration.tfvars
+++ b/examples/compute/virtual_machine_scale_set/102-linux-win-vmss-custom-script-extension/configuration.tfvars
@@ -56,7 +56,7 @@ storage_account_blobs = {
     storage_container_name = "files"
     source                 = "./compute/virtual_machine_scale_set/102-linux-win-vmss-custom-script-extension/scripts/helloworld.ps1"
     parallelism            = 1
-  },
+  }
 }
 
 # Give managed identity Storage Blob Data reader and executing user Storage Blob Data Contributor permissions on storage account
@@ -173,7 +173,7 @@ public_ip_addresses = {
 # Public Load Balancer will be created. For Internal/Private Load Balancer config, please refer 102-internal-load-balancer example.
 load_balancers = {
   lb1 = {
-    name                      = "lb-vmss"
+    name                      = "lb-vmss1"
     sku                       = "basic"
     resource_group_key        = "example_vmss_rg1"
     backend_address_pool_name = "vmss1"

--- a/examples/compute/virtual_machine_scale_set/102-linux-win-vmss-custom-script-extension/configuration.tfvars
+++ b/examples/compute/virtual_machine_scale_set/102-linux-win-vmss-custom-script-extension/configuration.tfvars
@@ -304,15 +304,15 @@ virtual_machine_scale_sets = {
 
     virtual_machine_scale_set_extensions = {
       custom_script = {
-        #fileuris            = ["https://somelocation/container/script.ps1"]
-        # can define fileuris directly or use fileuri_sa_ reference keys and lz_key:
-        fileuri_sa_key   = "sa1"
-        fileuri_sa_path  = "files/helloworld.ps1"
-        commandtoexecute = "PowerShell -file helloworld.ps1"
-        # managed_identity_id = optional to define managed identity principal_id directly
+        # can define fileuris directly or use fileuri_sa_reference keys and lz_key:
+        # fileuris             = ["https://somelocation/container/script.ps1"]
+        fileuri_sa_key       = "sa1"
+        fileuri_sa_path      = "helloworld.sh"
+        commandtoexecute     = "bash ./helloworld.sh"
         identity_type        = "UserAssigned" #optional to use managed_identity for download from location specified in fileuri, UserAssigned or SystemAssigned.
-        managed_identity_key = "example_mi"
-        #lz_key               = "other_lz" optional for managed identity defined in other lz
+        managed_identity_key = "example_vmss_mi"
+        # managed_identity_id  = "id" optional to define managed identity principal_id directly
+        # lz_key               = "other_lz" optional for managed identity defined in other lz
       }
     }
   }
@@ -417,15 +417,15 @@ virtual_machine_scale_sets = {
 
     virtual_machine_scale_set_extensions = {
       custom_script = {
-        #fileuris            = ["https://somelocation/container/script.ps1"]
-        # can define fileuris directly or use fileuri_sa_ reference keys and lz_key:
-        fileuri_sa_key   = "sa1"
-        fileuri_sa_path  = "files/helloworld.ps1"
-        commandtoexecute = "PowerShell -file helloworld.ps1"
-        # managed_identity_id = optional to define managed identity principal_id directly
+        # can define fileuris directly or use fileuri_sa_reference keys and lz_key:
+        # fileuris             = ["https://somelocation/container/script.ps1"]
+        fileuri_sa_key       = "sa1"
+        fileuri_sa_path      = "files/helloworld.ps1"
+        commandtoexecute     = "PowerShell -file helloworld.ps1"
         identity_type        = "UserAssigned" #optional to use managed_identity for download from location specified in fileuri, UserAssigned or SystemAssigned.
-        managed_identity_key = "example_mi"
-        #lz_key               = "other_lz" optional for managed identity defined in other lz
+        managed_identity_key = "example_vmss_mi"
+        # managed_identity_id  = "id" optional to define managed identity principal_id directly
+        # lz_key               = "other_lz" optional for managed identity defined in other lz
       }
     }
   }

--- a/examples/compute/virtual_machine_scale_set/102-linux-win-vmss-custom-script-extension/configuration.tfvars
+++ b/examples/compute/virtual_machine_scale_set/102-linux-win-vmss-custom-script-extension/configuration.tfvars
@@ -295,14 +295,18 @@ virtual_machine_scale_sets = {
           # lz_key = ""
         }
 
-        identity = {
-          # type = "SystemAssigned"
-          type                  = "UserAssigned"
-          managed_identity_keys = ["example_vmss_mi"]
+        # Uncomment in case the managed_identity_keys are generated locally
+        # identity = {
+        #   type                  = "UserAssigned"
+        #   managed_identity_keys = ["example_vmss_id"]
+        # }
 
+        # Uncomment in case the managed_identity_keys are generated in a different landingzone
+        identity = {
+          type = "UserAssigned"
           remote = {
-            lz_key_name = {
-              managed_identity_keys = []
+            examples = {
+              managed_identity_keys = ["example_vmss_mi"]
             }
           }
         }
@@ -371,6 +375,7 @@ virtual_machine_scale_sets = {
         fileuri_sa_path      = "files/helloworld.sh"
         commandtoexecute     = "bash ./files/helloworld.sh"
         identity_type        = "UserAssigned" # optional to use managed_identity for download from location specified in fileuri, UserAssigned or SystemAssigned.
+        lz_key               = "examples"
         managed_identity_key = "example_vmss_mi"
         # managed_identity_id  = "id" optional to define managed identity principal_id directly
         # lz_key               = "other_lz" optional for managed identity defined in other lz
@@ -417,9 +422,20 @@ virtual_machine_scale_sets = {
           disk_size_gb         = 128
         }
 
+        # Uncomment in case the managed_identity_keys are generated locally
+        # identity = {
+        #   type                  = "UserAssigned"
+        #   managed_identity_keys = ["example_vmss_id"]
+        # }
+
+        # Uncomment in case the managed_identity_keys are generated in a different landingzone
         identity = {
-          type                  = "SystemAssigned"
-          managed_identity_keys = []
+          type = "UserAssigned"
+          remote = {
+            examples = {
+              managed_identity_keys = ["example_vmss_mi"]
+            }
+          }
         }
 
         source_image_reference = {
@@ -484,6 +500,7 @@ virtual_machine_scale_sets = {
         fileuri_sa_path      = "files/helloworld.ps1"
         commandtoexecute     = "PowerShell -file helloworld.ps1"
         identity_type        = "UserAssigned" # optional to use managed_identity for download from location specified in fileuri, UserAssigned or SystemAssigned.
+        lz_key               = "examples"
         managed_identity_key = "example_vmss_mi"
         # managed_identity_id  = "id" optional to define managed identity principal_id directly
         # lz_key               = "other_lz" optional for managed identity defined in other lz

--- a/examples/compute/virtual_machine_scale_set/102-linux-win-vmss-custom-script-extension/configuration.tfvars
+++ b/examples/compute/virtual_machine_scale_set/102-linux-win-vmss-custom-script-extension/configuration.tfvars
@@ -90,7 +90,7 @@ vnets = {
 }
 
 keyvaults = {
-  example_vm_rg1 = {
+  example_vmss_kv1 = {
     name               = "vmsecretskv"
     resource_group_key = "example_vmss_rg1"
     sku_name           = "standard"
@@ -107,7 +107,7 @@ keyvaults = {
 
 # Store output attributes into keyvault secret
 dynamic_keyvault_secrets = {
-  example_vm_rg1 = { # Key of the keyvault
+  example_vmss_kv1 = { # Key of the keyvault
     vmadmin-username = {
       secret_name = "vmadmin-username"
       value       = "vmadmin"
@@ -196,7 +196,7 @@ virtual_machine_scale_sets = {
     resource_group_key                   = "example_vmss_rg1"
     boot_diagnostics_storage_account_key = "bootdiag1"
     os_type                              = "linux"
-    keyvault_key                         = "kv1"
+    keyvault_key                         = "example_vmss_kv1"
 
     vmss_settings = {
       linux = {
@@ -322,7 +322,7 @@ virtual_machine_scale_sets = {
     provision_vm_agent                   = true
     boot_diagnostics_storage_account_key = "bootdiag1"
     os_type                              = "windows"
-    keyvault_key                         = "kv1"
+    keyvault_key                         = "example_vmss_kv1"
 
     vmss_settings = {
       windows = {

--- a/examples/compute/virtual_machine_scale_set/102-linux-win-vmss-custom-script-extension/configuration.tfvars
+++ b/examples/compute/virtual_machine_scale_set/102-linux-win-vmss-custom-script-extension/configuration.tfvars
@@ -10,7 +10,7 @@ tags = {
 }
 
 resource_groups = {
-  rg1 = {
+  example_vm_rg1 = {
     name = "vmss-lb-cse-rg"
   }
 }
@@ -19,14 +19,14 @@ resource_groups = {
 managed_identities = {
   example_mi = {
     name               = "example_mi"
-    resource_group_key = "rg1"
+    resource_group_key = "example_vm_rg1"
   }
 }
 
 storage_accounts = {
   sa1 = {
     name               = "sa1"
-    resource_group_key = "rg1"
+    resource_group_key = "example_vm_rg1"
     # Account types are BlobStorage, BlockBlobStorage, FileStorage, Storage and StorageV2. Defaults to StorageV2
     #account_kind = "BlobStorage"
     # Account Tier options are Standard and Premium. For BlockBlobStorage and FileStorage accounts only Premium is valid.
@@ -74,7 +74,7 @@ role_mapping = {
 
 vnets = {
   vnet1 = {
-    resource_group_key = "rg1"
+    resource_group_key = "example_vm_rg1"
     vnet = {
       name          = "vmss"
       address_space = ["10.100.0.0/16"]
@@ -92,7 +92,7 @@ vnets = {
 keyvaults = {
   example_vm_rg1 = {
     name               = "vmsecretskv"
-    resource_group_key = "rg1"
+    resource_group_key = "example_vm_rg1"
     sku_name           = "standard"
     tags = {
       env = "Standalone"
@@ -123,7 +123,7 @@ diagnostic_storage_accounts = {
   # Stores boot diagnostic for region1
   bootdiag1 = {
     name                     = "lebootdiag1"
-    resource_group_key       = "rg1"
+    resource_group_key       = "example_vm_rg1"
     account_kind             = "StorageV2"
     account_tier             = "Standard"
     account_replication_type = "LRS"
@@ -134,7 +134,7 @@ diagnostic_storage_accounts = {
 # Application security groups
 application_security_groups = {
   app_sg1 = {
-    resource_group_key = "rg1"
+    resource_group_key = "example_vm_rg1"
     name               = "app_sg1"
   }
 }
@@ -143,7 +143,7 @@ application_security_groups = {
 public_ip_addresses = {
   lb_pip1 = {
     name               = "lb_pip1"
-    resource_group_key = "rg1"
+    resource_group_key = "example_vm_rg1"
     sku                = "Basic"
     # Note: For UltraPerformance ExpressRoute Virtual Network gateway, the associated Public IP needs to be sku "Basic" not "Standard"
     allocation_method = "Dynamic"
@@ -153,7 +153,7 @@ public_ip_addresses = {
   }
   lb_pip2 = {
     name               = "lb_pip2"
-    resource_group_key = "rg1"
+    resource_group_key = "example_vm_rg1"
     sku                = "Basic"
     # Note: For UltraPerformance ExpressRoute Virtual Network gateway, the associated Public IP needs to be sku "Basic" not "Standard"
     allocation_method = "Dynamic"
@@ -168,7 +168,7 @@ load_balancers = {
   lb1 = {
     name                      = "lb-vmss"
     sku                       = "basic"
-    resource_group_key        = "rg1"
+    resource_group_key        = "example_vm_rg1"
     backend_address_pool_name = "vmss1"
     frontend_ip_configurations = {
       config1 = {
@@ -180,7 +180,7 @@ load_balancers = {
   lb2 = {
     name                      = "lb-vmss2"
     sku                       = "basic"
-    resource_group_key        = "rg1"
+    resource_group_key        = "example_vm_rg1"
     backend_address_pool_name = "vmss1"
     frontend_ip_configurations = {
       config1 = {
@@ -193,7 +193,7 @@ load_balancers = {
 
 virtual_machine_scale_sets = {
   vmss1 = {
-    resource_group_key                   = "rg1"
+    resource_group_key                   = "example_vm_rg1"
     boot_diagnostics_storage_account_key = "bootdiag1"
     os_type                              = "linux"
     keyvault_key                         = "kv1"
@@ -318,7 +318,7 @@ virtual_machine_scale_sets = {
   }
 
   vmss2 = {
-    resource_group_key                   = "rg1"
+    resource_group_key                   = "example_vm_rg1"
     provision_vm_agent                   = true
     boot_diagnostics_storage_account_key = "bootdiag1"
     os_type                              = "windows"

--- a/examples/compute/virtual_machine_scale_set/102-linux-win-vmss-custom-script-extension/configuration.tfvars
+++ b/examples/compute/virtual_machine_scale_set/102-linux-win-vmss-custom-script-extension/configuration.tfvars
@@ -1,0 +1,432 @@
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "southeastasia"
+  }
+}
+
+tags = {
+  level = "100"
+}
+
+resource_groups = {
+  rg1 = {
+    name = "vmss-lb-cse-rg"
+  }
+}
+
+# managed identity to attach to vm to download from the storage account
+managed_identities = {
+  example_mi = {
+    name               = "example_mi"
+    resource_group_key = "rg1"
+  }
+}
+
+storage_accounts = {
+  sa1 = {
+    name               = "sa1"
+    resource_group_key = "rg1"
+    # Account types are BlobStorage, BlockBlobStorage, FileStorage, Storage and StorageV2. Defaults to StorageV2
+    #account_kind = "BlobStorage"
+    # Account Tier options are Standard and Premium. For BlockBlobStorage and FileStorage accounts only Premium is valid.
+    account_tier = "Standard"
+    #  Valid options are LRS, GRS, RAGRS, ZRS, GZRS and RAGZRS
+    account_replication_type = "LRS" # https://docs.microsoft.com/en-us/azure/storage/common/storage-redundancy
+    containers = {
+      files = {
+        name = "files"
+      }
+    }
+  }
+}
+
+# Upload helloworld script
+storage_account_blobs = {
+  script = {
+    name                   = "helloworld.ps1"
+    storage_account_key    = "sa1"
+    storage_container_name = "files"
+    source                 = "./compute/virtual_machine_scale_set/102-linux-win-vmss-custom-script-extension/helloworld.ps1"
+    parallelism            = 1
+  }
+}
+
+# Give managed identity Storage Blob Data reader and executing user Storage Blob Data Contributor permissions on storage account
+role_mapping = {
+  built_in_role_mapping = {
+    storage_accounts = {
+      sa1 = {
+        "Storage Blob Data Reader" = {
+          managed_identities = {
+            keys = ["user_mi"]
+          }
+        }
+        "Storage Blob Data Contributor" = {
+          logged_in = {
+            keys = ["user"]
+          }
+        }
+      }
+    }
+  }
+}
+
+vnets = {
+  vnet1 = {
+    resource_group_key = "rg1"
+    vnet = {
+      name          = "vmss"
+      address_space = ["10.100.0.0/16"]
+    }
+    specialsubnets = {}
+    subnets = {
+      subnet1 = {
+        name = "compute"
+        cidr = ["10.100.1.0/24"]
+      }
+    }
+  }
+}
+
+keyvaults = {
+  example_vm_rg1 = {
+    name               = "vmsecretskv"
+    resource_group_key = "rg1"
+    sku_name           = "standard"
+    tags = {
+      env = "Standalone"
+    }
+    creation_policies = {
+      logged_in_user = {
+        secret_permissions = ["Set", "Get", "List", "Delete", "Purge", "Recover"]
+      }
+    }
+  }
+}
+
+# Store output attributes into keyvault secret
+dynamic_keyvault_secrets = {
+  example_vm_rg1 = { # Key of the keyvault
+    vmadmin-username = {
+      secret_name = "vmadmin-username"
+      value       = "vmadmin"
+    }
+    vmadmin-password = {
+      secret_name = "vmadmin-password"
+      value       = "Very@Str5ngP!44w0rdToChaNge#"
+    }
+  }
+}
+
+diagnostic_storage_accounts = {
+  # Stores boot diagnostic for region1
+  bootdiag1 = {
+    name                     = "lebootdiag1"
+    resource_group_key       = "rg1"
+    account_kind             = "StorageV2"
+    account_tier             = "Standard"
+    account_replication_type = "LRS"
+    access_tier              = "Cool"
+  }
+}
+
+# Application security groups
+application_security_groups = {
+  app_sg1 = {
+    resource_group_key = "rg1"
+    name               = "app_sg1"
+  }
+}
+
+# Load Balancer
+public_ip_addresses = {
+  lb_pip1 = {
+    name               = "lb_pip1"
+    resource_group_key = "rg1"
+    sku                = "Basic"
+    # Note: For UltraPerformance ExpressRoute Virtual Network gateway, the associated Public IP needs to be sku "Basic" not "Standard"
+    allocation_method = "Dynamic"
+    # allocation method needs to be Dynamic
+    ip_version              = "IPv4"
+    idle_timeout_in_minutes = "4"
+  }
+  lb_pip2 = {
+    name               = "lb_pip2"
+    resource_group_key = "rg1"
+    sku                = "Basic"
+    # Note: For UltraPerformance ExpressRoute Virtual Network gateway, the associated Public IP needs to be sku "Basic" not "Standard"
+    allocation_method = "Dynamic"
+    # allocation method needs to be Dynamic
+    ip_version              = "IPv4"
+    idle_timeout_in_minutes = "4"
+  }
+}
+
+# Public Load Balancer will be created. For Internal/Private Load Balancer config, please refer 102-internal-load-balancer example.
+load_balancers = {
+  lb1 = {
+    name                      = "lb-vmss"
+    sku                       = "basic"
+    resource_group_key        = "rg1"
+    backend_address_pool_name = "vmss1"
+    frontend_ip_configurations = {
+      config1 = {
+        name                  = "config1"
+        public_ip_address_key = "lb_pip1"
+      }
+    }
+  }
+  lb2 = {
+    name                      = "lb-vmss2"
+    sku                       = "basic"
+    resource_group_key        = "rg1"
+    backend_address_pool_name = "vmss1"
+    frontend_ip_configurations = {
+      config1 = {
+        name                  = "config1"
+        public_ip_address_key = "lb_pip2"
+      }
+    }
+  }
+}
+
+virtual_machine_scale_sets = {
+  vmss1 = {
+    resource_group_key                   = "rg1"
+    boot_diagnostics_storage_account_key = "bootdiag1"
+    os_type                              = "linux"
+    keyvault_key                         = "kv1"
+
+    vmss_settings = {
+      linux = {
+        name                            = "linux_vmss1"
+        computer_name_prefix            = "lnx"
+        sku                             = "Standard_F2"
+        instances                       = 1
+        admin_username                  = "adminuser"
+        disable_password_authentication = true
+        provision_vm_agent              = true
+        priority                        = "Spot"
+        eviction_policy                 = "Deallocate"
+        ultra_ssd_enabled               = false # required if planning to use UltraSSD_LRS
+
+        upgrade_mode = "Manual" # Automatic / Rolling / Manual
+
+        # rolling_upgrade_policy = {
+        #   # Only for upgrade mode = "Automatic / Rolling "
+        #   max_batch_instance_percent = 20
+        #   max_unhealthy_instance_percent = 20
+        #   max_unhealthy_upgraded_instance_percent = 20
+        #   pause_time_between_batches = ""
+        # }
+        # automatic_os_upgrade_policy = {
+        #   # Only for upgrade mode = "Automatic"
+        #   disable_automatic_rollback = false
+        #   enable_automatic_os_upgrade = true
+        # }
+
+        os_disk = {
+          caching              = "ReadWrite"
+          storage_account_type = "Standard_LRS"
+          disk_size_gb         = 128
+          # disk_encryption_set_key = ""
+          # lz_key = ""
+        }
+
+        identity = {
+          # type = "SystemAssigned"
+          type                  = "UserAssigned"
+          managed_identity_keys = ["example_mi"]
+
+          remote = {
+            lz_key_name = {
+              managed_identity_keys = []
+            }
+          }
+        }
+
+        # custom_image_id = ""
+
+        source_image_reference = {
+          publisher = "Canonical"
+          offer     = "UbuntuServer"
+          sku       = "18.04-LTS"
+          version   = "latest"
+        }
+
+      }
+    }
+
+    network_interfaces = {
+      # option to assign each nic to different LB/ App GW
+
+      nic0 = {
+
+        name       = "0"
+        primary    = true
+        vnet_key   = "vnet1"
+        subnet_key = "subnet1"
+        load_balancers = {
+          lb1 = {
+            lb_key = "lb1"
+            # lz_key = ""
+          }
+        }
+
+        application_security_groups = {
+          asg1 = {
+            asg_key = "app_sg1"
+            # lz_key = ""
+          }
+        }
+
+        enable_accelerated_networking = false
+        enable_ip_forwarding          = false
+        internal_dns_name_label       = "nic0"
+      }
+    }
+
+    data_disks = {
+      data1 = {
+        caching                   = "None"  # None / ReadOnly / ReadWrite
+        create_option             = "Empty" # Empty / FromImage (only if source image includes data disks)
+        disk_size_gb              = "10"
+        lun                       = 1
+        storage_account_type      = "Standard_LRS" # UltraSSD_LRS only possible when > additional_capabilities { ultra_ssd_enabled = true }
+        disk_iops_read_write      = 100            # only for UltraSSD Disks
+        disk_mbps_read_write      = 100            # only for UltraSSD Disks
+        write_accelerator_enabled = false          # true requires Premium_LRS and caching = "None"
+        # disk_encryption_set_key = "set1"
+        # lz_key = "" # lz_key for disk_encryption_set_key if remote
+      }
+    }
+
+    virtual_machine_scale_set_extensions = {
+      custom_script = {
+        #fileuris            = ["https://somelocation/container/script.ps1"]
+        # can define fileuris directly or use fileuri_sa_ reference keys and lz_key:
+        fileuri_sa_key   = "sa1"
+        fileuri_sa_path  = "files/helloworld.ps1"
+        commandtoexecute = "PowerShell -file helloworld.ps1"
+        # managed_identity_id = optional to define managed identity principal_id directly
+        identity_type        = "UserAssigned" #optional to use managed_identity for download from location specified in fileuri, UserAssigned or SystemAssigned.
+        managed_identity_key = "example_mi"
+        #lz_key               = "other_lz" optional for managed identity defined in other lz
+      }
+    }
+  }
+
+  vmss2 = {
+    resource_group_key                   = "rg1"
+    provision_vm_agent                   = true
+    boot_diagnostics_storage_account_key = "bootdiag1"
+    os_type                              = "windows"
+    keyvault_key                         = "kv1"
+
+    vmss_settings = {
+      windows = {
+        name                            = "win"
+        computer_name_prefix            = "win"
+        sku                             = "Standard_F2"
+        instances                       = 1
+        admin_username                  = "adminuser"
+        disable_password_authentication = true
+        priority                        = "Spot"
+        eviction_policy                 = "Deallocate"
+
+        upgrade_mode = "Manual" # Automatic / Rolling / Manual
+
+        # rolling_upgrade_policy = {
+        #   # Only for upgrade mode = "Automatic / Rolling "
+        #   max_batch_instance_percent = 20
+        #   max_unhealthy_instance_percent = 20
+        #   max_unhealthy_upgraded_instance_percent = 20
+        #   pause_time_between_batches = ""
+        # }
+        # automatic_os_upgrade_policy = {
+        #   # Only for upgrade mode = "Automatic"
+        #   disable_automatic_rollback = false
+        #   enable_automatic_os_upgrade = true
+        # }
+
+        os_disk = {
+          caching              = "ReadWrite"
+          storage_account_type = "Standard_LRS"
+          disk_size_gb         = 128
+        }
+
+        identity = {
+          type                  = "SystemAssigned"
+          managed_identity_keys = []
+        }
+
+        source_image_reference = {
+          publisher = "MicrosoftWindowsServer"
+          offer     = "WindowsServer"
+          sku       = "2016-Datacenter"
+          version   = "latest"
+        }
+
+      }
+    }
+
+    network_interfaces = {
+      nic0 = {
+        # Value of the keys from networking.tfvars
+        name       = "0"
+        primary    = true
+        vnet_key   = "vnet1"
+        subnet_key = "subnet1"
+
+        load_balancers = {
+          lb2 = {
+            lb_key = "lb2"
+            # lz_key = ""
+          }
+        }
+
+        application_security_groups = {
+          asg1 = {
+            asg_key = "app_sg1"
+            # lz_key = ""
+          }
+        }
+
+        enable_accelerated_networking = false
+        enable_ip_forwarding          = false
+        internal_dns_name_label       = "nic0"
+      }
+    }
+    ultra_ssd_enabled = false # required if planning to use UltraSSD_LRS
+
+    data_disks = {
+      data1 = {
+        caching                   = "None"  # None / ReadOnly / ReadWrite
+        create_option             = "Empty" # Empty / FromImage (only if source image includes data disks)
+        disk_size_gb              = "10"
+        lun                       = 1
+        storage_account_type      = "Standard_LRS" # UltraSSD_LRS only possible when > additional_capabilities { ultra_ssd_enabled = true }
+        disk_iops_read_write      = 100            # only for UltraSSD Disks
+        disk_mbps_read_write      = 100            # only for UltraSSD Disks
+        write_accelerator_enabled = false          # true requires Premium_LRS and caching = "None"
+        # disk_encryption_set_key = "set1"
+        # lz_key = "" # lz_key for disk_encryption_set_key if remote
+      }
+    }
+
+    virtual_machine_scale_set_extensions = {
+      custom_script = {
+        #fileuris            = ["https://somelocation/container/script.ps1"]
+        # can define fileuris directly or use fileuri_sa_ reference keys and lz_key:
+        fileuri_sa_key   = "sa1"
+        fileuri_sa_path  = "files/helloworld.ps1"
+        commandtoexecute = "PowerShell -file helloworld.ps1"
+        # managed_identity_id = optional to define managed identity principal_id directly
+        identity_type        = "UserAssigned" #optional to use managed_identity for download from location specified in fileuri, UserAssigned or SystemAssigned.
+        managed_identity_key = "example_mi"
+        #lz_key               = "other_lz" optional for managed identity defined in other lz
+      }
+    }
+  }
+}

--- a/examples/compute/virtual_machine_scale_set/102-linux-win-vmss-custom-script-extension/configuration.tfvars
+++ b/examples/compute/virtual_machine_scale_set/102-linux-win-vmss-custom-script-extension/configuration.tfvars
@@ -10,7 +10,7 @@ tags = {
 }
 
 resource_groups = {
-  example_vm_rg1 = {
+  example_vmss_rg1 = {
     name = "vmss-lb-cse-rg"
   }
 }
@@ -19,14 +19,14 @@ resource_groups = {
 managed_identities = {
   example_mi = {
     name               = "example_mi"
-    resource_group_key = "example_vm_rg1"
+    resource_group_key = "example_vmss_rg1"
   }
 }
 
 storage_accounts = {
   sa1 = {
     name               = "sa1"
-    resource_group_key = "example_vm_rg1"
+    resource_group_key = "example_vmss_rg1"
     # Account types are BlobStorage, BlockBlobStorage, FileStorage, Storage and StorageV2. Defaults to StorageV2
     #account_kind = "BlobStorage"
     # Account Tier options are Standard and Premium. For BlockBlobStorage and FileStorage accounts only Premium is valid.
@@ -74,7 +74,7 @@ role_mapping = {
 
 vnets = {
   vnet1 = {
-    resource_group_key = "example_vm_rg1"
+    resource_group_key = "example_vmss_rg1"
     vnet = {
       name          = "vmss"
       address_space = ["10.100.0.0/16"]
@@ -92,7 +92,7 @@ vnets = {
 keyvaults = {
   example_vm_rg1 = {
     name               = "vmsecretskv"
-    resource_group_key = "example_vm_rg1"
+    resource_group_key = "example_vmss_rg1"
     sku_name           = "standard"
     tags = {
       env = "Standalone"
@@ -123,7 +123,7 @@ diagnostic_storage_accounts = {
   # Stores boot diagnostic for region1
   bootdiag1 = {
     name                     = "lebootdiag1"
-    resource_group_key       = "example_vm_rg1"
+    resource_group_key       = "example_vmss_rg1"
     account_kind             = "StorageV2"
     account_tier             = "Standard"
     account_replication_type = "LRS"
@@ -134,7 +134,7 @@ diagnostic_storage_accounts = {
 # Application security groups
 application_security_groups = {
   app_sg1 = {
-    resource_group_key = "example_vm_rg1"
+    resource_group_key = "example_vmss_rg1"
     name               = "app_sg1"
   }
 }
@@ -143,7 +143,7 @@ application_security_groups = {
 public_ip_addresses = {
   lb_pip1 = {
     name               = "lb_pip1"
-    resource_group_key = "example_vm_rg1"
+    resource_group_key = "example_vmss_rg1"
     sku                = "Basic"
     # Note: For UltraPerformance ExpressRoute Virtual Network gateway, the associated Public IP needs to be sku "Basic" not "Standard"
     allocation_method = "Dynamic"
@@ -153,7 +153,7 @@ public_ip_addresses = {
   }
   lb_pip2 = {
     name               = "lb_pip2"
-    resource_group_key = "example_vm_rg1"
+    resource_group_key = "example_vmss_rg1"
     sku                = "Basic"
     # Note: For UltraPerformance ExpressRoute Virtual Network gateway, the associated Public IP needs to be sku "Basic" not "Standard"
     allocation_method = "Dynamic"
@@ -168,7 +168,7 @@ load_balancers = {
   lb1 = {
     name                      = "lb-vmss"
     sku                       = "basic"
-    resource_group_key        = "example_vm_rg1"
+    resource_group_key        = "example_vmss_rg1"
     backend_address_pool_name = "vmss1"
     frontend_ip_configurations = {
       config1 = {
@@ -180,7 +180,7 @@ load_balancers = {
   lb2 = {
     name                      = "lb-vmss2"
     sku                       = "basic"
-    resource_group_key        = "example_vm_rg1"
+    resource_group_key        = "example_vmss_rg1"
     backend_address_pool_name = "vmss1"
     frontend_ip_configurations = {
       config1 = {
@@ -193,7 +193,7 @@ load_balancers = {
 
 virtual_machine_scale_sets = {
   vmss1 = {
-    resource_group_key                   = "example_vm_rg1"
+    resource_group_key                   = "example_vmss_rg1"
     boot_diagnostics_storage_account_key = "bootdiag1"
     os_type                              = "linux"
     keyvault_key                         = "kv1"
@@ -318,7 +318,7 @@ virtual_machine_scale_sets = {
   }
 
   vmss2 = {
-    resource_group_key                   = "example_vm_rg1"
+    resource_group_key                   = "example_vmss_rg1"
     provision_vm_agent                   = true
     boot_diagnostics_storage_account_key = "bootdiag1"
     os_type                              = "windows"

--- a/examples/compute/virtual_machine_scale_set/102-linux-win-vmss-custom-script-extension/scripts/helloworld.ps1
+++ b/examples/compute/virtual_machine_scale_set/102-linux-win-vmss-custom-script-extension/scripts/helloworld.ps1
@@ -1,0 +1,1 @@
+Write-Host "Hello, World!"

--- a/examples/compute/virtual_machine_scale_set/102-linux-win-vmss-custom-script-extension/scripts/helloworld.ps1
+++ b/examples/compute/virtual_machine_scale_set/102-linux-win-vmss-custom-script-extension/scripts/helloworld.ps1
@@ -1,1 +1,3 @@
-Write-Host "Hello, World!"
+Start-Transcript -Path c:\helloworld.txt
+write-output "Hello, World!"
+stop-transcript

--- a/examples/compute/virtual_machine_scale_set/102-linux-win-vmss-custom-script-extension/scripts/helloworld.sh
+++ b/examples/compute/virtual_machine_scale_set/102-linux-win-vmss-custom-script-extension/scripts/helloworld.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "Hello, World!"

--- a/examples/compute/virtual_machine_scale_set/102-linux-win-vmss-custom-script-extension/scripts/helloworld.sh
+++ b/examples/compute/virtual_machine_scale_set/102-linux-win-vmss-custom-script-extension/scripts/helloworld.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-echo "Hello, World!"
+echo "Hello, World!" > hello.log

--- a/examples/compute/virtual_machine_scale_set/103-linux-win-vmss-domain-join-extension/configuration.tfvars
+++ b/examples/compute/virtual_machine_scale_set/103-linux-win-vmss-domain-join-extension/configuration.tfvars
@@ -1,0 +1,429 @@
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "southeastasia"
+  }
+}
+
+tags = {
+  level = "100"
+}
+
+resource_groups = {
+  rg1 = {
+    name = "vmss-lb-cse-rg"
+  }
+}
+
+storage_accounts = {
+  sa1 = {
+    name               = "sa1"
+    resource_group_key = "rg1"
+    # Account types are BlobStorage, BlockBlobStorage, FileStorage, Storage and StorageV2. Defaults to StorageV2
+    #account_kind = "BlobStorage"
+    # Account Tier options are Standard and Premium. For BlockBlobStorage and FileStorage accounts only Premium is valid.
+    account_tier = "Standard"
+    #  Valid options are LRS, GRS, RAGRS, ZRS, GZRS and RAGZRS
+    account_replication_type = "LRS" # https://docs.microsoft.com/en-us/azure/storage/common/storage-redundancy
+    containers = {
+      files = {
+        name = "files"
+      }
+    }
+  }
+}
+
+# Give managed identity Storage Blob Data reader and executing user Storage Blob Data Contributor permissions on storage account
+role_mapping = {
+  built_in_role_mapping = {
+    storage_accounts = {
+      sa1 = {
+        "Storage Blob Data Reader" = {
+          managed_identities = {
+            keys = ["user_mi"]
+          }
+        }
+        "Storage Blob Data Contributor" = {
+          logged_in = {
+            keys = ["user"]
+          }
+        }
+      }
+    }
+  }
+}
+
+vnets = {
+  vnet1 = {
+    resource_group_key = "rg1"
+    vnet = {
+      name          = "vmss"
+      address_space = ["10.100.0.0/16"]
+    }
+    specialsubnets = {}
+    subnets = {
+      subnet1 = {
+        name = "compute"
+        cidr = ["10.100.1.0/24"]
+      }
+    }
+  }
+}
+
+keyvaults = {
+  example_vm_rg1 = {
+    name               = "vmsecretskv"
+    resource_group_key = "rg1"
+    sku_name           = "standard"
+    tags = {
+      env = "Standalone"
+    }
+    creation_policies = {
+      logged_in_user = {
+        secret_permissions = ["Set", "Get", "List", "Delete", "Purge", "Recover"]
+      }
+    }
+  }
+}
+
+# Store output attributes into keyvault secret
+dynamic_keyvault_secrets = {
+  example_vm_rg1 = { # Key of the keyvault
+    vmadmin-username = {
+      secret_name = "vmadmin-username"
+      value       = "vmadmin"
+    }
+    vmadmin-password = {
+      secret_name = "vmadmin-password"
+      value       = "Very@Str5ngP!44w0rdToChaNge#"
+    }
+  }
+}
+
+diagnostic_storage_accounts = {
+  # Stores boot diagnostic for region1
+  bootdiag1 = {
+    name                     = "lebootdiag1"
+    resource_group_key       = "rg1"
+    account_kind             = "StorageV2"
+    account_tier             = "Standard"
+    account_replication_type = "LRS"
+    access_tier              = "Cool"
+  }
+}
+
+# Application security groups
+application_security_groups = {
+  app_sg1 = {
+    resource_group_key = "rg1"
+    name               = "app_sg1"
+  }
+}
+
+# Load Balancer
+public_ip_addresses = {
+  lb_pip1 = {
+    name               = "lb_pip1"
+    resource_group_key = "rg1"
+    sku                = "Basic"
+    # Note: For UltraPerformance ExpressRoute Virtual Network gateway, the associated Public IP needs to be sku "Basic" not "Standard"
+    allocation_method = "Dynamic"
+    # allocation method needs to be Dynamic
+    ip_version              = "IPv4"
+    idle_timeout_in_minutes = "4"
+  }
+  lb_pip2 = {
+    name               = "lb_pip2"
+    resource_group_key = "rg1"
+    sku                = "Basic"
+    # Note: For UltraPerformance ExpressRoute Virtual Network gateway, the associated Public IP needs to be sku "Basic" not "Standard"
+    allocation_method = "Dynamic"
+    # allocation method needs to be Dynamic
+    ip_version              = "IPv4"
+    idle_timeout_in_minutes = "4"
+  }
+}
+
+# Public Load Balancer will be created. For Internal/Private Load Balancer config, please refer 102-internal-load-balancer example.
+load_balancers = {
+  lb1 = {
+    name                      = "lb-vmss"
+    sku                       = "basic"
+    resource_group_key        = "rg1"
+    backend_address_pool_name = "vmss1"
+    frontend_ip_configurations = {
+      config1 = {
+        name                  = "config1"
+        public_ip_address_key = "lb_pip1"
+      }
+    }
+  }
+  lb2 = {
+    name                      = "lb-vmss2"
+    sku                       = "basic"
+    resource_group_key        = "rg1"
+    backend_address_pool_name = "vmss1"
+    frontend_ip_configurations = {
+      config1 = {
+        name                  = "config1"
+        public_ip_address_key = "lb_pip2"
+      }
+    }
+  }
+}
+
+virtual_machine_scale_sets = {
+  vmss1 = {
+    resource_group_key                   = "rg1"
+    boot_diagnostics_storage_account_key = "bootdiag1"
+    os_type                              = "linux"
+    keyvault_key                         = "kv1"
+
+    vmss_settings = {
+      linux = {
+        name                            = "linux_vmss1"
+        computer_name_prefix            = "lnx"
+        sku                             = "Standard_F2"
+        instances                       = 1
+        admin_username                  = "adminuser"
+        disable_password_authentication = true
+        provision_vm_agent              = true
+        priority                        = "Spot"
+        eviction_policy                 = "Deallocate"
+        ultra_ssd_enabled               = false # required if planning to use UltraSSD_LRS
+
+        upgrade_mode = "Manual" # Automatic / Rolling / Manual
+
+        # rolling_upgrade_policy = {
+        #   # Only for upgrade mode = "Automatic / Rolling "
+        #   max_batch_instance_percent = 20
+        #   max_unhealthy_instance_percent = 20
+        #   max_unhealthy_upgraded_instance_percent = 20
+        #   pause_time_between_batches = ""
+        # }
+        # automatic_os_upgrade_policy = {
+        #   # Only for upgrade mode = "Automatic"
+        #   disable_automatic_rollback = false
+        #   enable_automatic_os_upgrade = true
+        # }
+
+        os_disk = {
+          caching              = "ReadWrite"
+          storage_account_type = "Standard_LRS"
+          disk_size_gb         = 128
+          # disk_encryption_set_key = ""
+          # lz_key = ""
+        }
+
+        identity = {
+          # type = "SystemAssigned"
+          type                  = "UserAssigned"
+          managed_identity_keys = ["example_mi"]
+
+          remote = {
+            lz_key_name = {
+              managed_identity_keys = []
+            }
+          }
+        }
+
+        # custom_image_id = ""
+
+        source_image_reference = {
+          publisher = "Canonical"
+          offer     = "UbuntuServer"
+          sku       = "18.04-LTS"
+          version   = "latest"
+        }
+
+      }
+    }
+
+    network_interfaces = {
+      # option to assign each nic to different LB/ App GW
+
+      nic0 = {
+
+        name       = "0"
+        primary    = true
+        vnet_key   = "vnet1"
+        subnet_key = "subnet1"
+        load_balancers = {
+          lb1 = {
+            lb_key = "lb1"
+            # lz_key = ""
+          }
+        }
+
+        application_security_groups = {
+          asg1 = {
+            asg_key = "app_sg1"
+            # lz_key = ""
+          }
+        }
+
+        enable_accelerated_networking = false
+        enable_ip_forwarding          = false
+        internal_dns_name_label       = "nic0"
+      }
+    }
+
+    data_disks = {
+      data1 = {
+        caching                   = "None"  # None / ReadOnly / ReadWrite
+        create_option             = "Empty" # Empty / FromImage (only if source image includes data disks)
+        disk_size_gb              = "10"
+        lun                       = 1
+        storage_account_type      = "Standard_LRS" # UltraSSD_LRS only possible when > additional_capabilities { ultra_ssd_enabled = true }
+        disk_iops_read_write      = 100            # only for UltraSSD Disks
+        disk_mbps_read_write      = 100            # only for UltraSSD Disks
+        write_accelerator_enabled = false          # true requires Premium_LRS and caching = "None"
+        # disk_encryption_set_key = "set1"
+        # lz_key = "" # lz_key for disk_encryption_set_key if remote
+      }
+    }
+
+    virtual_machine_scale_set_extensions = {
+      microsoft_azure_domainjoin = {
+        domain_name = "test.local"
+        ou_path     = "OU=test,DC=test,DC=local"
+        restart     = "true"
+        # specify the AKV location of the password to retrieve for domain join operation
+        domain_join_username_keyvault = {
+          keyvault_key = "vmsecretskv"
+          #key_vault_id = ""
+          #lz_key       = ""
+          secret_name = "domjoinuser"
+        }
+        domain_join_password_keyvault = {
+          keyvault_key = "vmsecretskv"
+          #key_vault_id = ""
+          #lz_key       = ""
+          secret_name = "domjoinpassword"
+        }
+      }
+    }
+
+  }
+
+  vmss2 = {
+    resource_group_key                   = "rg1"
+    provision_vm_agent                   = true
+    boot_diagnostics_storage_account_key = "bootdiag1"
+    os_type                              = "windows"
+    keyvault_key                         = "kv1"
+
+    vmss_settings = {
+      windows = {
+        name                            = "win"
+        computer_name_prefix            = "win"
+        sku                             = "Standard_F2"
+        instances                       = 1
+        admin_username                  = "adminuser"
+        disable_password_authentication = true
+        priority                        = "Spot"
+        eviction_policy                 = "Deallocate"
+
+        upgrade_mode = "Manual" # Automatic / Rolling / Manual
+
+        # rolling_upgrade_policy = {
+        #   # Only for upgrade mode = "Automatic / Rolling "
+        #   max_batch_instance_percent = 20
+        #   max_unhealthy_instance_percent = 20
+        #   max_unhealthy_upgraded_instance_percent = 20
+        #   pause_time_between_batches = ""
+        # }
+        # automatic_os_upgrade_policy = {
+        #   # Only for upgrade mode = "Automatic"
+        #   disable_automatic_rollback = false
+        #   enable_automatic_os_upgrade = true
+        # }
+
+        os_disk = {
+          caching              = "ReadWrite"
+          storage_account_type = "Standard_LRS"
+          disk_size_gb         = 128
+        }
+
+        identity = {
+          type                  = "SystemAssigned"
+          managed_identity_keys = []
+        }
+
+        source_image_reference = {
+          publisher = "MicrosoftWindowsServer"
+          offer     = "WindowsServer"
+          sku       = "2016-Datacenter"
+          version   = "latest"
+        }
+
+      }
+    }
+
+    network_interfaces = {
+      nic0 = {
+        # Value of the keys from networking.tfvars
+        name       = "0"
+        primary    = true
+        vnet_key   = "vnet1"
+        subnet_key = "subnet1"
+
+        load_balancers = {
+          lb2 = {
+            lb_key = "lb2"
+            # lz_key = ""
+          }
+        }
+
+        application_security_groups = {
+          asg1 = {
+            asg_key = "app_sg1"
+            # lz_key = ""
+          }
+        }
+
+        enable_accelerated_networking = false
+        enable_ip_forwarding          = false
+        internal_dns_name_label       = "nic0"
+      }
+    }
+    ultra_ssd_enabled = false # required if planning to use UltraSSD_LRS
+
+    data_disks = {
+      data1 = {
+        caching                   = "None"  # None / ReadOnly / ReadWrite
+        create_option             = "Empty" # Empty / FromImage (only if source image includes data disks)
+        disk_size_gb              = "10"
+        lun                       = 1
+        storage_account_type      = "Standard_LRS" # UltraSSD_LRS only possible when > additional_capabilities { ultra_ssd_enabled = true }
+        disk_iops_read_write      = 100            # only for UltraSSD Disks
+        disk_mbps_read_write      = 100            # only for UltraSSD Disks
+        write_accelerator_enabled = false          # true requires Premium_LRS and caching = "None"
+        # disk_encryption_set_key = "set1"
+        # lz_key = "" # lz_key for disk_encryption_set_key if remote
+      }
+    }
+
+    virtual_machine_scale_set_extensions = {
+      microsoft_azure_domainjoin = {
+        domain_name = "test.local"
+        ou_path     = "OU=test,DC=test,DC=local"
+        restart     = "true"
+        # specify the AKV location of the password to retrieve for domain join operation
+        domain_join_username_keyvault = {
+          keyvault_key = "vmsecretskv"
+          #key_vault_id = ""
+          #lz_key       = ""
+          secret_name = "domjoinuser"
+        }
+        domain_join_password_keyvault = {
+          keyvault_key = "vmsecretskv"
+          #key_vault_id = ""
+          #lz_key       = ""
+          secret_name = "domjoinpassword"
+        }
+      }
+    }
+
+  }
+}

--- a/examples/vmss_extensions.tf
+++ b/examples/vmss_extensions.tf
@@ -24,10 +24,11 @@ module "vmss_extension_custom_scriptextension" {
     if try(value.virtual_machine_scale_set_extensions.custom_script, null) != null
   }
 
-  client_config                = module.example.client_config
-  virtual_machine_scale_set_id = module.example.virtual_machine_scale_sets[each.key].id
-  extension                    = each.value.virtual_machine_scale_set_extensions.custom_script
-  extension_name               = "custom_script"
-  managed_identities           = tomap({ (var.landingzone.key) = module.example.managed_identities })
-  storage_accounts             = tomap({ (var.landingzone.key) = module.example.storage_accounts })
+  client_config                     = module.example.client_config
+  virtual_machine_scale_set_id      = module.example.virtual_machine_scale_sets[each.key].id
+  extension                         = each.value.virtual_machine_scale_set_extensions.custom_script
+  extension_name                    = "custom_script"
+  managed_identities                = tomap({ (var.landingzone.key) = module.example.managed_identities })
+  storage_accounts                  = tomap({ (var.landingzone.key) = module.example.storage_accounts })
+  virtual_machine_scale_set_os_type = module.example.virtual_machine_scale_sets[each.key].os_type
 }

--- a/examples/vmss_extensions.tf
+++ b/examples/vmss_extensions.tf
@@ -1,0 +1,33 @@
+module "vmss_extension_microsoft_azure_domainjoin" {
+  source     = "../modules/compute/virtual_machine_scale_set_extensions"
+  depends_on = [module.example]
+
+  for_each = {
+    for key, value in try(var.virtual_machine_scale_sets, {}) : key => value
+    if try(value.virtual_machine_scale_set_extensions.microsoft_azure_domainjoin, null) != null
+  }
+
+  client_config                = module.example.client_config
+  virtual_machine_scale_set_id = module.example.virtual_machine_scale_sets[each.key].id
+  extension                    = each.value.virtual_machine_scale_set_extensions.microsoft_azure_domainjoin
+  extension_name               = "microsoft_azure_domainJoin"
+  keyvaults                    = tomap({ (var.landingzone.key) = module.example.keyvaults })
+}
+
+
+module "vmss_extension_custom_scriptextension" {
+  source     = "../modules/compute/virtual_machine_scale_set_extensions"
+  depends_on = [module.example]
+
+  for_each = {
+    for key, value in try(var.virtual_machine_scale_sets, {}) : key => value
+    if try(value.virtual_machine_scale_set_extensions.custom_script, null) != null
+  }
+
+  client_config                = module.example.client_config
+  virtual_machine_scale_set_id = module.example.virtual_machine_scale_sets[each.key].id
+  extension                    = each.value.virtual_machine_scale_set_extensions.custom_script
+  extension_name               = "custom_script"
+  managed_identities           = tomap({ (var.landingzone.key) = module.example.managed_identities })
+  storage_accounts             = tomap({ (var.landingzone.key) = module.example.storage_accounts })
+}

--- a/modules/compute/virtual_machine_scale_set_extensions/custom_script.tf
+++ b/modules/compute/virtual_machine_scale_set_extensions/custom_script.tf
@@ -1,0 +1,46 @@
+resource "azurerm_virtual_machine_scale_set_extension" "custom_script" {
+  for_each                     = var.extension_name == "custom_script" ? toset(["enabled"]) : toset([])
+  name                         = "custom_script"
+  virtual_machine_scale_set_id = var.virtual_machine_scale_set_id
+  publisher                    = "Microsoft.Compute"
+  type                         = "CustomScriptExtension"
+  type_handler_version         = "1.10"
+  auto_upgrade_minor_version   = true
+
+  #settings                   = jsonencode(local.settings)
+  settings = jsonencode(
+    {
+      "fileUris" : local.fileuris,
+      "timestamp" : try(var.extension.timestamp, "12345678")
+    }
+  )
+
+  protected_settings = jsonencode(local.protected_settings)
+}
+
+locals {
+  # managed identity
+  identity_type           = try(var.extension.identity_type, "") #userassigned, systemassigned or null
+  managed_local_identity  = try(var.managed_identities[var.client_config.landingzone_key][var.extension.managed_identity_key].principal_id, "")
+  managed_remote_identity = try(var.managed_identities[var.extension.lz_key][var.extension.managed_identity_key].principal_id, "")
+  provided_identity       = try(var.extension.managed_identity_id, "")
+  managed_identity        = try(coalesce(local.managed_local_identity, local.managed_remote_identity, local.provided_identity), "")
+
+  system_assigned_id = local.identity_type == "SystemAssigned" ? { "managedIdentity" : {} } : null
+  user_assigned_id   = local.identity_type == "UserAssigned" ? { "managedIdentity" : { "objectid" : "${local.managed_identity}" } } : null
+
+  command = { "commandtoexecute" : "${try(var.extension.commandtoexecute, "")}" }
+
+  protected_settings = merge(local.command, local.system_assigned_id, local.user_assigned_id)
+
+  # fileuris
+  fileuri_sa_key       = try(var.extension.fileuri_sa_key, "")
+  fileuri_sa_path      = try(var.extension.fileuri_sa_path, "")
+  fileuri_sa           = local.fileuri_sa_key != "" ? try(var.storage_accounts[var.client_config.landingzone_key][var.extension.fileuri_sa_key].primary_blob_endpoint, try(var.storage_accounts[var.extension.lz_key][var.extension.fileuri_sa_key].primary_blob_endpoint)) : ""
+  fileuri_sa_full_path = "${local.fileuri_sa}${local.fileuri_sa_path}"
+
+  #timestamp = {"timestamp" : try(var.extension.timestamp, "12345678")}
+  fileuri_sa_defined = try(var.extension.fileuris, "")
+  fileuris           = local.fileuri_sa_defined == "" ? [local.fileuri_sa_full_path] : var.extension.fileuris
+  #settings = merge(local.timestamp,local.fileuris)
+}

--- a/modules/compute/virtual_machine_scale_set_extensions/domain_join.tf
+++ b/modules/compute/virtual_machine_scale_set_extensions/domain_join.tf
@@ -1,0 +1,50 @@
+resource "azurerm_virtual_machine_scale_set_extension" "domainjoin" {
+  for_each                     = var.extension_name == "microsoft_azure_domainJoin" ? toset(["enabled"]) : toset([])
+  name                         = "microsoft_azure_domainJoin"
+  virtual_machine_scale_set_id = var.virtual_machine_scale_set_id
+  publisher                    = "Microsoft.Compute"
+  type                         = "JsonADDomainExtension"
+  type_handler_version         = try(var.extension.type_handler_version, "1.3")
+  auto_upgrade_minor_version   = try(var.extension.auto_upgrade_minor_version, true)
+
+  lifecycle {
+    ignore_changes = [
+      settings,
+      protected_settings
+    ]
+  }
+
+  settings = jsonencode(
+    {
+      "Name" : var.extension.domain_name,
+      "OUPath" : try(var.extension.ou_path, ""),
+      "User" : data.azurerm_key_vault_secret.domain_join_username["enabled"].value,
+      "Restart" : try(var.extension.restart, "false"),
+      "Options" : try(var.extension.options, "3")
+    }
+  )
+
+  protected_settings = jsonencode(
+    {
+      "Password" : data.azurerm_key_vault_secret.domain_join_password["enabled"].value
+    }
+  )
+}
+
+data "azurerm_key_vault_secret" "domain_join_password" {
+  for_each = var.extension_name == "microsoft_azure_domainJoin" ? toset(["enabled"]) : toset([])
+  name     = var.extension.domain_join_password_keyvault.secret_name
+  key_vault_id = try(
+    var.extension.domain_join_password_keyvault.key_vault_id,
+    try(var.keyvaults[var.extension.domain_join_password_keyvault.lz_key][var.extension.domain_join_password_keyvault.keyvault_key].id, var.keyvaults[var.client_config.landingzone_key][var.extension.domain_join_password_keyvault.keyvault_key].id)
+  )
+}
+
+data "azurerm_key_vault_secret" "domain_join_username" {
+  for_each = var.extension_name == "microsoft_azure_domainJoin" ? toset(["enabled"]) : toset([])
+  name     = var.extension.domain_join_username_keyvault.secret_name
+  key_vault_id = try(
+    var.extension.domain_join_username_keyvault.key_vault_id,
+    try(var.keyvaults[var.extension.domain_join_username_keyvault.lz_key][var.extension.domain_join_username_keyvault.keyvault_key].id, var.keyvaults[var.client_config.landingzone_key][var.extension.domain_join_username_keyvault.keyvault_key].id)
+  )
+}

--- a/modules/compute/virtual_machine_scale_set_extensions/variables.tf
+++ b/modules/compute/virtual_machine_scale_set_extensions/variables.tf
@@ -1,0 +1,18 @@
+variable "virtual_machine_scale_set_id" {}
+variable "extension" {}
+variable "extension_name" {}
+variable "client_config" {
+  description = "Client configuration object (see module README.md)."
+}
+variable "managed_identities" {
+  default = {}
+}
+variable "storage_accounts" {
+  default = {}
+}
+variable "keyvault_id" {
+  default = null
+}
+variable "keyvaults" {
+  default = {}
+}

--- a/modules/compute/virtual_machine_scale_set_extensions/variables.tf
+++ b/modules/compute/virtual_machine_scale_set_extensions/variables.tf
@@ -16,3 +16,6 @@ variable "keyvault_id" {
 variable "keyvaults" {
   default = {}
 }
+variable "virtual_machine_scale_set_os_type" {
+  default = {}
+}


### PR DESCRIPTION
Related to [PR 278](https://github.com/Azure/caf-terraform-landingzones/pull/278) in [caf-terraform-landingzones](https://github.com/Azure/caf-terraform-landingzones).

Local plan succeeded using the following commands:

```
cd examples/vmss_extensions.tf.
terraform plan -var-file compute/virtual_machine_scale_set/102-linux-win-vmss-custom-script-extension/configuration.tfvars
```

Custom script extension example included, but no domain join example yet.