### PR TITLE
remove inherited tags into winrm self-signed cert

### DIFF
--- a/modules/compute/virtual_machine/vm_windows_winrm_self.tf
+++ b/modules/compute/virtual_machine/vm_windows_winrm_self.tf
@@ -7,7 +7,7 @@ resource "azurerm_key_vault_certificate" "self_signed_winrm" {
 
   name         = try(format("%s-winrm-cert", azurecaf_name.windows[each.key].result), format("%s-winrm-cert", azurecaf_name.legacy[each.key].result))
   key_vault_id = local.keyvault.id
-  tags         = try(merge(var.base_tags, try(each.value.tags, null)), null)
+  tags         = try(each.value.cert_tags, null)
 
   certificate_policy {
     issuer_parameters {

--- a/modules/compute/virtual_machine/vm_windows_winrm_self.tf
+++ b/modules/compute/virtual_machine/vm_windows_winrm_self.tf
@@ -7,6 +7,7 @@ resource "azurerm_key_vault_certificate" "self_signed_winrm" {
 
   name         = try(format("%s-winrm-cert", azurecaf_name.windows[each.key].result), format("%s-winrm-cert", azurecaf_name.legacy[each.key].result))
   key_vault_id = local.keyvault.id
+  # Disabled inherited tags as it may have exceed limit of 15 tags on cert that gives badparameter error
   tags         = try(each.value.cert_tags, null)
 
   certificate_policy {


### PR DESCRIPTION
there is limit of 15 tags in kv cert and when there's more than 15 tags, error below shows up 
│ Error: keyvault.BaseClient#CreateCertificate: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="BadParameter" Message="Property has invalid value\r\n"