### PR TITLE
remove inherited tags on kv cert

### DIFF
--- a/modules/security/keyvault_certificate/certificate.tf
+++ b/modules/security/keyvault_certificate/certificate.tf
@@ -3,7 +3,8 @@ resource "azurerm_key_vault_certificate" "cert" {
 
   name         = var.settings.name
   key_vault_id = var.keyvault.id
-  tags         = merge(var.settings.tags, var.keyvault.base_tags)
+  # Disabled inherited tags as it may have exceed limit of 15 tags on cert that gives badparameter error
+  tags         = try(each.value.cert_tags, null)
 
   certificate_policy {
     issuer_parameters {


### PR DESCRIPTION
kv cert only support up to 15 tags, beyond that will gives badparameter 400 error