### PR TITLE
Make subnets attribute optional in AKS and to fix service_cidr error

### DIFF
--- a/aks_clusters.tf
+++ b/aks_clusters.tf
@@ -13,7 +13,7 @@ module "aks_clusters" {
   diagnostic_profiles = try(each.value.diagnostic_profiles, {})
   base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
   settings            = each.value
-  subnets             = lookup(each.value, "lz_key", null) == null ? local.combined_objects_networking[local.client_config.landingzone_key][each.value.vnet_key].subnets : local.combined_objects_networking[each.value.lz_key][each.value.vnet_key].subnets
+  subnets             = try(lookup(each.value, "lz_key", null) == null ? local.combined_objects_networking[local.client_config.landingzone_key][each.value.vnet_key].subnets : local.combined_objects_networking[each.value.lz_key][each.value.vnet_key].subnets, {})
   resource_group      = local.resource_groups[each.value.resource_group_key]
   private_dns_zone_id = try(local.combined_objects_private_dns[each.value.private_dns_zone.lz_key][each.value.private_dns_zone.key].id,
     local.combined_objects_private_dns[local.client_config.landingzone_key][each.value.private_dns_zone.key].id,

--- a/modules/compute/aks/aks.tf
+++ b/modules/compute/aks/aks.tf
@@ -211,9 +211,9 @@ resource "azurerm_kubernetes_cluster" "aks" {
       dns_service_ip     = try(network_profile.value.dns_service_ip, null)
       docker_bridge_cidr = try(network_profile.value.docker_bridge_cidr, null)
       outbound_type      = try(network_profile.value.outbound_type, null)
-      pod_cidr           = try(network_profile.value.network_profile.pod_cidr, null)
-      service_cidr       = try(network_profile.value.network_profile.service_cidr, null)
-      load_balancer_sku  = try(network_profile.value.network_profile.load_balancer_sku, null)
+      pod_cidr           = try(network_profile.value.pod_cidr, null)
+      service_cidr       = try(network_profile.value.service_cidr, null)
+      load_balancer_sku  = try(network_profile.value.load_balancer_sku, null)
 
       dynamic "load_balancer_profile" {
         for_each = try(network_profile.value.load_balancer_profile[*], {})


### PR DESCRIPTION
1.  When trying to provision an AKS cluster with an exisitng vnet/subnet through a resource id, I ran into the following error:
```
> │ Error: Unsupported attribute
> │ 
> │   on /aks_clusters.tf line 16, in module "aks_clusters":
> │   16:   subnets             = lookup(each.value, "lz_key", null) == null ? local.combined_objects_networking[local.client_config.landingzone_key][each.value.vnet_key].subnets : local.combined_objects_networking[each.value.lz_key][each.value.vnet_key].subnets
> │     ├────────────────
> │     │ each.value is object with 11 attributes
> │ 
> │ This object does not have an attribute named "vnet_key".
```
From what I understand, the current logic in aks_clusters.tf attempts to seek the `subnets` information through the `vnet_key`. 
In the case of an existing vnet where we reference the resource id in the configurations, this information (vnet_key) would be unavailable. I'm not sure if there are plans to support the seeking of subnets created through virtual_subnets, but I've added a change to make the subnets attribute optional for now and that worked for me.


2. The second issue that I've encountered was that the service_cidr attribute, part of network_profile in aks.tf, despite being specified in the config, was not being read in the terraform plan, and resulted in the error below. 
```
│ Error: `docker_bridge_cidr`, `dns_service_ip` and `service_cidr` should all be empty or all should be set
│ 
│   with module.solution.module.aks_clusters["cluster_re1"].azurerm_kubernetes_cluster.aks,
│   on ../../terraform-azurerm-caf/modules/compute/aks/aks.tf line 47, in resource "azurerm_kubernetes_cluster" "aks":
│   47: resource "azurerm_kubernetes_cluster" "aks" {
```
I realised that there is an additional "network_profile" object referenced, for service_cidr as well as pod_cidr and load_balancer_sku in aks.tf. I made the change to remove the additional network_profile and it worked as well.