### PR TITLE
Private dns vnet link - Added support to reference remote vnet

### DIFF
--- a/modules/networking/private-dns/virtual_network_link.tf
+++ b/modules/networking/private-dns/virtual_network_link.tf
@@ -17,7 +17,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "vnet_links" {
   name                  = azurecaf_name.pnetlk[each.key].result
   resource_group_name   = var.resource_group_name
   private_dns_zone_name = azurerm_private_dns_zone.private_dns.name
-  virtual_network_id    = try(var.vnets[var.client_config.landingzone_key][each.value.vnet_key].id, var.vnets[each.value.lz_key][each.value.vnet_key].id)
+  virtual_network_id    = try(var.vnets[var.client_config.landingzone_key][each.value.vnet_key].id, try(var.vnets[each.value.lz_key][each.value.vnet_key].id, each.value.virtual_network_id))
   registration_enabled  = try(each.value.registration_enabled, false)
   tags                  = merge(var.base_tags, local.module_tag, try(each.value.tags, null))
 }


### PR DESCRIPTION
Private dns vnet link has no option to specify a remote virtual network id.