### PR TITLE
Added support for image_registry_credentials to container groups

### DIFF
--- a/container_groups.tf
+++ b/container_groups.tf
@@ -12,6 +12,7 @@ module "container_groups" {
   location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
   resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
   settings            = each.value
+  dynamic_keyvault_secrets = local.security.dynamic_keyvault_secrets #module.dynamic_keyvault_secrets
 
   combined_resources = {
     keyvaults          = local.combined_objects_keyvaults

--- a/container_groups.tf
+++ b/container_groups.tf
@@ -1,18 +1,19 @@
 module "container_groups" {
   source   = "./modules/compute/container_group"
   for_each = local.compute.container_groups
+  depends_on = [module.dynamic_keyvault_secrets]
 
-  base_tags            = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
-  client_config        = local.client_config
-  combined_diagnostics = local.combined_diagnostics
+  base_tags                = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
+  client_config            = local.client_config
+  combined_diagnostics     = local.combined_diagnostics
   # combined_managed_identities  = local.combined_objects_managed_identities
   # combined_vnets               = local.combined_objects_networking
-  diagnostic_profiles = try(each.value.diagnostic_profiles, {})
-  global_settings     = local.global_settings
-  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
-  resource_group_name = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
-  settings            = each.value
-  dynamic_keyvault_secrets = local.security.dynamic_keyvault_secrets #module.dynamic_keyvault_secrets
+  diagnostic_profiles      = try(each.value.diagnostic_profiles, {})
+  global_settings          = local.global_settings
+  location                 = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  resource_group_name      = local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].name
+  settings                 = each.value
+  dynamic_keyvault_secrets = try(local.security.dynamic_keyvault_secrets, {})
 
   combined_resources = {
     keyvaults          = local.combined_objects_keyvaults

--- a/examples/compute/container_groups/102-aci-private-registry/container_groups.tfvars
+++ b/examples/compute/container_groups/102-aci-private-registry/container_groups.tfvars
@@ -1,0 +1,78 @@
+# This configuration demonstrates multiple implementations
+# 1- OS Windows and Linux
+# 2- instantiate container based on for_each, count or both
+#
+
+container_groups = {
+  github_private_image = {
+    name               = "github-private-image"
+    region             = "region1"
+    resource_group_key = "rg1"
+    ip_address_type    = "Public"
+    os_type            = "Linux"
+    restart_policy     = "Always" // Possible values are 'Always'(default) 'Never' 'OnFailure'
+
+    containers = {
+      github_private_image = {
+        name   = "github-private-image"
+        image  = "ghcr.io/my_org/github-private-image:latest"
+        cpu    = "0.5"
+        memory = "1.5"
+
+        ports = {
+          80 = {
+            port     = 80
+            protocol = "TCP"
+          }
+        }
+
+        # for demo purposes
+        environment_variables = {
+          URL = "https://www.microsoft.com"
+        }
+        secure_environment_variables = {
+          TOKEN = "token from tfvars"
+        }
+        environment_variables_from_resources = {
+          AGENT_KEYVAULT_NAME = {
+            output_key    = "keyvaults"
+            resource_key  = "secrets"
+            attribute_key = "name"
+          }
+          MSI_ID = {
+            output_key    = "managed_identities"
+            resource_key  = "github_private_image"
+            attribute_key = "id"
+          }
+        }
+      }
+
+    } //containers
+
+    tags = {
+      environment = "testing"
+    }
+
+    identity = {
+      type = "UserAssigned" // Possible options are 'SystemAssigned, UserAssigned' 'SystemAssigned' or 'UserAssigned'
+      managed_identity_keys = [
+        "github_private_image"
+      ]
+    } // identity
+
+    image_registry_credentials = { # Max 1 image registry credential per container
+      ghcr = { # To be able to pull container from private repo
+        keyvault_key = "secrets" # keyvault key used in dynamic secrets
+        username_secret_key = "ghcr_username" # dynamic secret for github username
+        password_secret_key = "ghcr_password" # dynamic secret for github PAT-token
+        server = "ghcr.io"
+      }
+#      docker_hub = {
+#        username = "my_username"
+#        password = "HUB_PAT"
+#        server = "index.docker.io"
+#      }
+    } //image_registry_credentials
+  } //github_private_image
+}
+

--- a/examples/compute/container_groups/102-aci-private-registry/global_settings.tfvars
+++ b/examples/compute/container_groups/102-aci-private-registry/global_settings.tfvars
@@ -1,0 +1,6 @@
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "westeurope"
+  }
+}

--- a/examples/compute/container_groups/102-aci-private-registry/keyvaults.tfvars
+++ b/examples/compute/container_groups/102-aci-private-registry/keyvaults.tfvars
@@ -1,0 +1,34 @@
+keyvaults = {
+  secrets = {
+    name               = "secrets"
+    resource_group_key = "rg1"
+    sku_name           = "standard"
+
+    enabled_for_deployment = true
+
+    creation_policies = {
+      logged_in_user = {
+        certificate_permissions = ["Get", "List", "Update", "Create", "Import", "Delete", "Purge", "Recover"]
+        secret_permissions      = ["Set", "Get", "List", "Delete", "Purge", "Recover"]
+      }
+      github_private_image = {
+        managed_identity_key = "github_private_image"
+        secret_permissions   = ["Get"]
+      }
+    }
+  }
+}
+
+# Store output attributes into keyvault secret
+dynamic_keyvault_secrets = {
+  secrets = { # Key of the keyvault
+    ghcr_username = {
+      secret_name = "image-registry-username"
+      value       = "my_username"
+    }
+    ghcr_password = {
+      secret_name = "image-registry-password"
+      value       = "replace with GitHub PAT"
+    }
+  }
+}

--- a/examples/compute/container_groups/102-aci-private-registry/managed_identities.tfvars
+++ b/examples/compute/container_groups/102-aci-private-registry/managed_identities.tfvars
@@ -1,0 +1,7 @@
+# User assigned identities
+managed_identities = {
+  github_private_image = {
+    name               = "github-private-image"
+    resource_group_key = "rg1"
+  }
+}

--- a/examples/compute/container_groups/102-aci-private-registry/resource_groups.tfvars
+++ b/examples/compute/container_groups/102-aci-private-registry/resource_groups.tfvars
@@ -1,0 +1,6 @@
+resource_groups = {
+  rg1 = {
+    name   = "container-groups"
+    region = "region1"
+  }
+}

--- a/modules/compute/container_group/container_group.tf
+++ b/modules/compute/container_group/container_group.tf
@@ -13,7 +13,7 @@ data "azurerm_key_vault_secret" "image_registry_credential_password" {
     for irc_key, irc in try(var.settings.image_registry_credentials,{}) : irc_key => irc if try(irc.keyvault_key, null) != null
   }
   key_vault_id = try(var.combined_resources.keyvaults[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.keyvault_key].id, null)
-  name         = try(try(var.dynamic_keyvault_secrets[each.value.keyvault_key][each.value.password_secret_key].secret_name, each.value.password_secret_name), null)
+  name         = try(var.dynamic_keyvault_secrets[each.value.keyvault_key][each.value.password_secret_key].secret_name, each.value.password_secret_name, null)
 }
 
 data "azurerm_key_vault_secret" "image_registry_credential_username" {
@@ -21,7 +21,7 @@ data "azurerm_key_vault_secret" "image_registry_credential_username" {
     for irc_key, irc in try(var.settings.image_registry_credentials, {}) : irc_key => irc if try(irc.keyvault_key, null) != null
   }
   key_vault_id = try(var.combined_resources.keyvaults[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.keyvault_key].id, null)
-  name         = try(try(var.dynamic_keyvault_secrets[each.value.keyvault_key][each.value.username_secret_key].secret_name, each.value.username_secret_name), null)
+  name         = try(var.dynamic_keyvault_secrets[each.value.keyvault_key][each.value.username_secret_key].secret_name, each.value.username_secret_name, null)
 }
 
 resource "azurerm_container_group" "acg" {
@@ -161,8 +161,8 @@ resource "azurerm_container_group" "acg" {
     for_each = try(var.settings.image_registry_credentials, {})
     content {
       server = image_registry_credential.value.server
-      username = try(image_registry_credential.value.username,data.azurerm_key_vault_secret.image_registry_credential_username[image_registry_credential.key].value)
-      password = try(image_registry_credential.value.password,data.azurerm_key_vault_secret.image_registry_credential_password[image_registry_credential.key].value)
+      username = try(data.azurerm_key_vault_secret.image_registry_credential_username[image_registry_credential.key].value, image_registry_credential.value.username)
+      password = try(data.azurerm_key_vault_secret.image_registry_credential_password[image_registry_credential.key].value, image_registry_credential.value.password)
     }
   }
 

--- a/modules/compute/container_group/container_group.tf
+++ b/modules/compute/container_group/container_group.tf
@@ -8,6 +8,22 @@ resource "azurecaf_name" "acg" {
   use_slug      = var.global_settings.use_slug
 }
 
+data "azurerm_key_vault_secret" "image_registry_credential_password" {
+  for_each = {
+    for irc_key, irc in try(var.settings.image_registry_credentials,{}) : irc_key => irc if try(irc.keyvault_key, null) != null
+  }
+  key_vault_id = try(var.combined_resources.keyvaults[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.keyvault_key].id, null)
+  name         = try(try(var.dynamic_keyvault_secrets[each.value.keyvault_key][each.value.password_secret_key].secret_name, each.value.password_secret_name), null)
+}
+
+data "azurerm_key_vault_secret" "image_registry_credential_username" {
+  for_each = {
+    for irc_key, irc in try(var.settings.image_registry_credentials, {}) : irc_key => irc if try(irc.keyvault_key, null) != null
+  }
+  key_vault_id = try(var.combined_resources.keyvaults[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.keyvault_key].id, null)
+  name         = try(try(var.dynamic_keyvault_secrets[each.value.keyvault_key][each.value.username_secret_key].secret_name, each.value.username_secret_name), null)
+}
+
 resource "azurerm_container_group" "acg" {
   name                = azurecaf_name.acg.result
   location            = var.location
@@ -138,6 +154,15 @@ resource "azurerm_container_group" "acg" {
       nameservers    = var.settings.dns_config.nameservers
       search_domains = var.settings.dns_config.search_domains
       options        = var.settings.dns_config.options
+    }
+  }
+
+  dynamic "image_registry_credential" {
+    for_each = try(var.settings.image_registry_credentials, {})
+    content {
+      server = image_registry_credential.value.server
+      username = try(image_registry_credential.value.username,data.azurerm_key_vault_secret.image_registry_credential_username[image_registry_credential.key].value)
+      password = try(image_registry_credential.value.password,data.azurerm_key_vault_secret.image_registry_credential_password[image_registry_credential.key].value)
     }
   }
 

--- a/modules/compute/container_group/variables.tf
+++ b/modules/compute/container_group/variables.tf
@@ -10,3 +10,7 @@ variable "global_settings" {}
 variable "location" {}
 variable "resource_group_name" {}
 variable "settings" {}
+variable "dynamic_keyvault_secrets" {
+  description = "Provide credenrials for private image registries"
+  default = {}
+}


### PR DESCRIPTION
 Updated container groups to now support image_registry_credentials.
 A example is provided using dynamic_keyvault_secrets as as credential source.