### PR TITLE
Use image_definitions output for vm/vmss configuration

### DIFF
--- a/examples/shared_image_gallery/101-packer_service_principal/vm.tfvars
+++ b/examples/shared_image_gallery/101-packer_service_principal/vm.tfvars
@@ -10,7 +10,7 @@ virtual_machines = {
     # if boot_diagnostics_storage_account_key is not defined, but global_settings.resource_defaults.virtual_machines.use_azmanaged_storage_for_boot_diagnostics is true, boot diagnostics will be put on azure managed storage
     boot_diagnostics_storage_account_key = "bootdiag_region1"
 
-    os_type = "windows"
+    os_type = "linux"
 
     # the auto-generated ssh key in keyvault secret. Secret name being {VM name}-ssh-public and {VM name}-ssh-private
     keyvault_key = "packer_client"
@@ -29,11 +29,11 @@ virtual_machines = {
     }
 
     virtual_machine_settings = {
-      windows = {
-        name           = "example_vm2"
-        size           = "Standard_F2"
-        admin_username = "adminuser"
-
+      linux = {
+        name                            = "example_vm2"
+        size                            = "Standard_F2"
+        admin_username                  = "adminuser"
+        disable_password_authentication = true
         # Spot VM to save money
         #priority        = "Spot"
         #eviction_policy = "Deallocate"
@@ -47,9 +47,9 @@ virtual_machines = {
           storage_account_type = "Standard_LRS"
         }
 
-       custom_image_key = "image1"
-       custom_image_version = "1.0.0"
-       #custom_image_lz_key # reference to image source landingzone 
+        custom_image_key     = "image1"
+        custom_image_version = "1.0.0"
+        #custom_image_lz_key # reference to image source landingzone 
       }
     }
 
@@ -79,8 +79,8 @@ vnets = {
     specialsubnets = {}
     subnets = {
       example = {
-        name = "examples"
-        cidr = ["10.100.100.0/29"]
+        name    = "examples"
+        cidr    = ["10.100.100.0/29"]
         nsg_key = "example"
       }
     }

--- a/examples/shared_image_gallery/101-packer_service_principal/vm.tfvars
+++ b/examples/shared_image_gallery/101-packer_service_principal/vm.tfvars
@@ -1,0 +1,119 @@
+# Virtual machines
+virtual_machines = {
+
+  # Configuration to deploy a bastion host linux virtual machine
+  example_vm1 = {
+    resource_group_key = "sig"
+    provision_vm_agent = true
+    # when boot_diagnostics_storage_account_key is empty string "", boot diagnostics will be put on azure managed storage
+    # when boot_diagnostics_storage_account_key is a non-empty string, it needs to point to the key of a user managed storage defined in diagnostic_storage_accounts
+    # if boot_diagnostics_storage_account_key is not defined, but global_settings.resource_defaults.virtual_machines.use_azmanaged_storage_for_boot_diagnostics is true, boot diagnostics will be put on azure managed storage
+    boot_diagnostics_storage_account_key = "bootdiag_region1"
+
+    os_type = "windows"
+
+    # the auto-generated ssh key in keyvault secret. Secret name being {VM name}-ssh-public and {VM name}-ssh-private
+    keyvault_key = "packer_client"
+
+    # Define the number of networking cards to attach the virtual machine
+    networking_interfaces = {
+      nic0 = {
+        # Value of the keys from networking.tfvars
+        vnet_key                = "vnet_region1"
+        subnet_key              = "example"
+        name                    = "0"
+        enable_ip_forwarding    = false
+        internal_dns_name_label = "nic0"
+        public_ip_address_key   = "example_vm_pip1_rg1"
+      }
+    }
+
+    virtual_machine_settings = {
+      windows = {
+        name           = "example_vm2"
+        size           = "Standard_F2"
+        admin_username = "adminuser"
+
+        # Spot VM to save money
+        #priority        = "Spot"
+        #eviction_policy = "Deallocate"
+
+        # Value of the nic keys to attach the VM. The first one in the list is the default nic
+        network_interface_keys = ["nic0"]
+
+        os_disk = {
+          name                 = "example_vm1-os"
+          caching              = "ReadWrite"
+          storage_account_type = "Standard_LRS"
+        }
+
+       custom_image_key = "image1"
+       custom_image_version = "1.0.0"
+       #custom_image_lz_key # reference to image source landingzone 
+      }
+    }
+
+  }
+}
+
+
+diagnostic_storage_accounts = {
+  # Stores boot diagnostic for region1
+  bootdiag_region1 = {
+    name                     = "bootrg1"
+    resource_group_key       = "sig"
+    account_kind             = "StorageV2"
+    account_tier             = "Standard"
+    account_replication_type = "LRS"
+    access_tier              = "Cool"
+  }
+}
+
+vnets = {
+  vnet_region1 = {
+    resource_group_key = "sig"
+    vnet = {
+      name          = "virtual_machines"
+      address_space = ["10.100.100.0/24"]
+    }
+    specialsubnets = {}
+    subnets = {
+      example = {
+        name = "examples"
+        cidr = ["10.100.100.0/29"]
+        nsg_key = "example"
+      }
+    }
+
+  }
+}
+
+public_ip_addresses = {
+  example_vm_pip1_rg1 = {
+    name                    = "example_vm_pip1"
+    resource_group_key      = "sig"
+    sku                     = "Standard"
+    allocation_method       = "Static"
+    ip_version              = "IPv4"
+    idle_timeout_in_minutes = "4"
+
+  }
+}
+
+network_security_group_definition = {
+  example = {
+    nsg = [
+      {
+        name                       = "ssh-inbound",
+        priority                   = "100"
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_range     = "22"
+        source_address_prefix      = "Internet"
+        destination_address_prefix = "VirtualNetwork"
+      }
+    ]
+  }
+}

--- a/locals.combined_objects.tf
+++ b/locals.combined_objects.tf
@@ -49,6 +49,7 @@ locals {
   combined_objects_express_route_circuits                         = merge(tomap({ (local.client_config.landingzone_key) = module.express_route_circuits }), try(var.remote_objects.express_route_circuits, {}))
   combined_objects_front_door                                     = merge(tomap({ (local.client_config.landingzone_key) = module.front_doors }), try(var.remote_objects.front_doors, {}))
   combined_objects_front_door_waf_policies                        = merge(tomap({ (local.client_config.landingzone_key) = module.front_door_waf_policies }), try(var.remote_objects.front_door_waf_policies, {}))
+  combined_objects_image_definitions                              = merge(tomap({ (local.client_config.landingzone_key) = module.image_definitions }), try(var.remote_objects.image_definitions, {}))
   combined_objects_integration_service_environment                = merge(tomap({ (local.client_config.landingzone_key) = module.integration_service_environment }), try(var.remote_objects.integration_service_environment, {}))
   combined_objects_keyvault_certificates                          = merge(tomap({ (local.client_config.landingzone_key) = module.keyvault_certificates }), try(var.remote_objects.keyvault_certificates, {}))
   combined_objects_keyvault_certificate_requests                  = merge(tomap({ (local.client_config.landingzone_key) = module.keyvault_certificate_requests }), try(var.remote_objects.keyvault_certificate_requests, {}))

--- a/modules/compute/virtual_machine/variables.tf
+++ b/modules/compute/virtual_machine/variables.tf
@@ -76,7 +76,7 @@ variable "application_security_groups" {
 variable "virtual_machines" {
   default = {}
 }
-variable "custom_image_ids" {
+variable "image_definitions" {
   default = {}
 }
 

--- a/modules/compute/virtual_machine/vm_linux.tf
+++ b/modules/compute/virtual_machine/vm_linux.tf
@@ -117,7 +117,7 @@ resource "azurerm_linux_virtual_machine" "vm" {
     }
   }
 
-  source_image_id = try(each.value.custom_image_id, var.custom_image_ids[each.value.lz_key][each.value.custom_image_key].id, null)
+  source_image_id = try(each.value.source_image_reference, null) == null ? "${try(each.value.custom_image_id, var.image_definitions[var.client_config.landingzone_key][each.value.custom_image_key].id, var.image_definitions[each.value.custom_image_lz_key][each.value.custom_image_key].id)}/versions/${try(each.value.custom_image_version, "latest")}" : null
 
   dynamic "identity" {
     for_each = try(each.value.identity, false) == false ? [] : [1]

--- a/modules/compute/virtual_machine/vm_windows.tf
+++ b/modules/compute/virtual_machine/vm_windows.tf
@@ -109,7 +109,7 @@ resource "azurerm_windows_virtual_machine" "vm" {
     }
   }
 
-  source_image_id = try(each.value.custom_image_id, var.custom_image_ids[each.value.lz_key][each.value.custom_image_key].id, null)
+  source_image_id = try(each.value.source_image_reference, null) == null ? "${try(each.value.custom_image_id, var.image_definitions[var.client_config.landingzone_key][each.value.custom_image_key].id, var.image_definitions[each.value.custom_image_lz_key][each.value.custom_image_key].id)}/versions/${try(each.value.custom_image_version, "latest")}" : null
 
   dynamic "additional_capabilities" {
     for_each = try(each.value.additional_capabilities, false) == false ? [] : [1]

--- a/modules/compute/virtual_machine_scale_set/variables.tf
+++ b/modules/compute/virtual_machine_scale_set/variables.tf
@@ -67,7 +67,7 @@ variable "network_security_groups" {
   description = "Require a version 1 NSG definition to be attached to a nic."
 }
 
-variable "custom_image_ids" {
+variable "image_definitions" {
   default = {}
 }
 variable "disk_encryption_sets" {}

--- a/modules/compute/virtual_machine_scale_set/vmss_linux.tf
+++ b/modules/compute/virtual_machine_scale_set/vmss_linux.tf
@@ -152,7 +152,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "vmss" {
     }
   }
 
-  source_image_id = try(each.value.custom_image_id, var.custom_image_ids[each.value.lz_key][each.value.custom_image_key].id, null)
+  source_image_id = try(each.value.source_image_reference, null) == null ? "${try(each.value.custom_image_id, var.image_definitions[var.client_config.landingzone_key][each.value.custom_image_key].id, var.image_definitions[each.value.custom_image_lz_key][each.value.custom_image_key].id)}/versions/${try(each.value.custom_image_version, "latest")}" : null
 
   dynamic "plan" {
     for_each = try(each.value.plan, null) != null ? [1] : []

--- a/modules/compute/virtual_machine_scale_set/vmss_windows.tf
+++ b/modules/compute/virtual_machine_scale_set/vmss_windows.tf
@@ -139,7 +139,7 @@ resource "azurerm_windows_virtual_machine_scale_set" "vmss" {
     }
   }
 
-  source_image_id = try(each.value.custom_image_id, var.custom_image_ids[each.value.lz_key][each.value.custom_image_key].id, null)
+  source_image_id = try(each.value.source_image_reference, null) == null ? "${try(each.value.custom_image_id, var.image_definitions[var.client_config.landingzone_key][each.value.custom_image_key].id, var.image_definitions[each.value.custom_image_lz_key][each.value.custom_image_key].id)}/versions/${try(each.value.custom_image_version, "latest")}" : null
 
   dynamic "plan" {
     for_each = try(each.value.plan, null) != null ? [1] : []

--- a/modules/shared_image_gallery/image_definitions/output.tf
+++ b/modules/shared_image_gallery/image_definitions/output.tf
@@ -1,3 +1,7 @@
 output "name" {
   value = azurerm_shared_image.image.name
 }
+
+output "id" {
+  value = azurerm_shared_image.image.id
+}

--- a/virtual_machines.tf
+++ b/virtual_machines.tf
@@ -20,6 +20,7 @@ module "virtual_machines" {
   diagnostics                 = local.combined_diagnostics
   disk_encryption_sets        = local.combined_objects_disk_encryption_sets
   global_settings             = local.global_settings
+  image_definitions           = local.combined_objects_image_definitions
   keyvaults                   = local.combined_objects_keyvaults
   managed_identities          = local.combined_objects_managed_identities
   network_security_groups     = local.combined_objects_network_security_groups

--- a/virtual_machines_scale_sets.tf
+++ b/virtual_machines_scale_sets.tf
@@ -23,6 +23,7 @@ module "virtual_machine_scale_sets" {
   diagnostics                      = local.combined_diagnostics
   disk_encryption_sets             = local.combined_objects_disk_encryption_sets
   global_settings                  = local.global_settings
+  image_definitions                = local.combined_objects_image_definitions
   keyvaults                        = local.combined_objects_keyvaults
   load_balancers                   = local.combined_objects_load_balancers
   managed_identities               = local.combined_objects_managed_identities


### PR DESCRIPTION
Allow use of images created with the shared_image_gallery modules as source images for vm/vmss configurations. See https://github.com/aztfmod/terraform-azurerm-caf/issues/825

Added VM build using the image to the [shared_image_gallery/101 example ](examples/shared_image_gallery/101-packer_service_principal/vm.tfvars)