### PR TITLE
Add packer_build module

### DIFF
--- a/examples/module.tf
+++ b/examples/module.tf
@@ -204,7 +204,7 @@ module "example" {
     monitor_action_groups      = var.monitor_action_groups
     monitor_autoscale_settings = var.monitor_autoscale_settings
     monitoring                 = var.monitoring
-    packer_managed_identity    = var.packer_managed_identity
+    packer_build               = var.packer_build
     packer_service_principal   = var.packer_service_principal
     recovery_vaults            = var.recovery_vaults
     shared_image_galleries     = var.shared_image_galleries

--- a/examples/shared_image_gallery/102-packer_build_linux/image_gallery.tfvars
+++ b/examples/shared_image_gallery/102-packer_build_linux/image_gallery.tfvars
@@ -1,0 +1,62 @@
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "southeastasia"
+  }
+}
+
+resource_groups = {
+  sig = {
+    name = "sig"
+  }
+  packer = {
+    name = "packer"
+  }
+  build = {
+    name = "build"
+  }
+}
+
+shared_image_galleries = {
+  gallery1 = {
+    name               = "test1"
+    resource_group_key = "sig"
+    description        = " "
+  }
+
+}
+
+image_definitions = {
+  image1 = {
+    name               = "image1"
+    gallery_key        = "gallery1"
+    resource_group_key = "sig"
+    os_type            = "Linux"
+    publisher          = "MyCompany"
+    offer              = "WebServer"
+    sku                = "2020.1"
+  }
+}
+
+managed_identities = {
+  example_mi = {
+    name               = "example_mi"
+    resource_group_key = "sig"
+  }
+}
+
+vnets = {
+  vnet_region1 = {
+    resource_group_key = "sig"
+    vnet = {
+      name          = "buildvnet"
+      address_space = ["10.100.100.0/24"]
+    }
+    subnets = {
+      buildsubnet = {
+        name = "buildsubnet"
+        cidr = ["10.100.100.0/29"]
+      }
+    }
+  }
+}

--- a/examples/shared_image_gallery/102-packer_build_linux/keyvaults.tfvars
+++ b/examples/shared_image_gallery/102-packer_build_linux/keyvaults.tfvars
@@ -1,0 +1,27 @@
+keyvaults = {
+  packer_client = {
+    name                = "packerakv"
+    resource_group_key  = "sig"
+    sku_name            = "standard"
+    soft_delete_enabled = true
+    tags = {
+      tfstate = "level2"
+    }
+    creation_policies = {
+      logged_in_user = {
+        # if the key is set to "logged_in_user" add the user running terraform in the keyvault policy
+        # More examples in /examples/keyvault
+        secret_permissions = ["Set", "Get", "List", "Delete", "Purge", "Recover"]
+      }
+    }
+  }
+}
+
+keyvault_access_policies_azuread_apps = {
+  packer_client = {
+    packer_client = {
+      azuread_app_key    = "packer_client"
+      secret_permissions = ["Set", "Get", "List", "Delete"]
+    }
+  }
+}

--- a/examples/shared_image_gallery/102-packer_build_linux/packer.tfvars
+++ b/examples/shared_image_gallery/102-packer_build_linux/packer.tfvars
@@ -1,0 +1,38 @@
+packer_build = {
+  build1 = {
+    packer_working_dir                               = "./shared_image_gallery/102-packer_build_linux/packer_files/"
+    packer_template_file                             = "build.pkr.hcl"
+    packer_var_file                                  = "packer.vars.json"
+    secret_prefix                                    = "packer-client"
+    keyvault_key                                     = "packer_client"
+    managed_image_name                               = "myImage1"
+    build_resource_group_key                         = "build" #build in existing resource group instead of temporary rg created by packer
+    resource_group_key                               = "sig"   #for managed_image_resource_group_name
+    os_type                                          = "Linux"
+    image_publisher                                  = "Canonical"
+    image_offer                                      = "UbuntuServer"
+    image_sku                                        = "18.04-LTS"
+    location                                         = "southeastasia"
+    vm_size                                          = "Standard_A2_v2"
+    build_script                                     = "ansible-ping.yml"
+    managed_identity_key                             = "example_mi"   #managed identity configured on build VM for permissions to Azure resources during build
+    vnet_key                                         = "vnet_region1" #build in existing vnet/subnet if preferred or for internal builds
+    subnet_key                                       = "buildsubnet"  #build in existing vnet/subnet if preferred or for internal builds
+    private_virtual_network_with_public_ip           = true           #false for internal builds, needed for example
+    managed_image_storage_account_type               = "Standard_LRS" #storage type used during build. Premium_LRS for faster builds, note chosen vm_size needs to support the storage type
+    storage_account_type                             = "Standard_LRS" #storage type in shared image gallery
+    tag_packer_resources                             = true           #apply tags to the Azure resources created by Packer
+    keep_image                                       = false          #source Azure managed image can be deleted once imported into shared image gallery
+    shared_gallery_image_version_exclude_from_latest = false
+    keep_versions                                    = 2 # number of image versions to keep
+    tags = {
+      mybuild = "linux"
+    }
+    shared_image_gallery_destination = {
+      gallery_key         = "gallery1"
+      image_key           = "image1"
+      resource_group_key  = "sig"
+      replication_regions = ["southeastasia", "eastasia"]
+    }
+  }
+}

--- a/examples/shared_image_gallery/102-packer_build_linux/packer_files/ansible-ping.yml
+++ b/examples/shared_image_gallery/102-packer_build_linux/packer_files/ansible-ping.yml
@@ -1,0 +1,6 @@
+---
+
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - ping:

--- a/examples/shared_image_gallery/102-packer_build_linux/packer_files/build.pkr.hcl
+++ b/examples/shared_image_gallery/102-packer_build_linux/packer_files/build.pkr.hcl
@@ -1,0 +1,111 @@
+source "azure-arm" "mybuild" {
+  build_resource_group_name                        = var.build_resource_group_name
+  client_id                                        = var.client_id
+  client_secret                                    = var.client_secret
+  image_offer                                      = var.image_offer
+  image_publisher                                  = var.image_publisher
+  image_sku                                        = var.image_sku
+  managed_image_name                               = var.managed_image_name
+  managed_image_resource_group_name                = var.managed_image_resource_group_name
+  managed_image_storage_account_type               = var.managed_image_storage_account_type
+  os_type                                          = var.os_type
+  private_virtual_network_with_public_ip           = var.private_virtual_network_with_public_ip
+  subscription_id                                  = var.subscription_id
+  tenant_id                                        = var.tenant_id
+  user_assigned_managed_identities                 = var.managed_identity
+  virtual_network_name                             = var.virtual_network_name
+  virtual_network_subnet_name                      = var.virtual_network_subnet_name
+  vm_size                                          = var.vm_size
+  azure_tags                                       = local.azure_tags
+  shared_gallery_image_version_exclude_from_latest = var.shared_gallery_image_version_exclude_from_latest
+  shared_image_gallery_destination {
+    gallery_name         = var.gallery_name
+    image_name           = var.image_name
+    image_version        = var.image_version
+    replication_regions  = var.replication_regions
+    resource_group       = var.resource_group
+    subscription         = var.subscription
+    storage_account_type = var.storage_account_type
+  }
+}
+
+build {
+  sources = ["source.azure-arm.mybuild"]
+
+  provisioner "ansible" {
+    playbook_file = "${var.packer_working_dir}${var.build_script}"
+  }
+}
+
+locals {
+  azure_tags = try(convert(var.azure_tags, map(string)), null)
+}
+
+variable "subscription_id" {}
+variable "tenant_id" {}
+variable "client_id" {}
+variable "client_secret" {}
+variable "managed_image_name" {}
+variable "managed_image_resource_group_name" {}
+variable "managed_image_storage_account_type" {}
+variable "os_type" {}
+variable "packer_working_dir" {}
+variable "azure_tags" {
+  default = null
+}
+variable "location" {}
+variable "build_resource_group_name" {
+  default = null
+}
+variable "image_offer" {
+  default = null
+}
+variable "image_publisher" {
+  default = null
+}
+variable "image_sku" {
+  default = null
+}
+variable "build_script" {
+  default = null
+}
+variable "private_virtual_network_with_public_ip" {
+  default = null
+}
+variable "managed_identity" {
+  default = null
+}
+variable "virtual_network_name" {
+  default = null
+}
+variable "virtual_network_subnet_name" {
+  default = null
+}
+variable "vm_size" {}
+#destination sig
+variable "gallery_name" {}
+variable "image_name" {}
+variable "image_version" {}
+variable "replication_regions" {}
+variable "resource_group" {}
+variable "subscription" {}
+variable "storage_account_type" {}
+variable "shared_gallery_image_version_exclude_from_latest" {
+  default = null
+}
+#source sig
+variable "source_subscription" {
+  default = null
+}
+variable "source_resource_group" {
+  default = null
+}
+variable "source_gallery_name" {
+  default = null
+}
+variable "source_image_version" {
+  default = null
+}
+variable "source_image_name" {
+  default = null
+}

--- a/examples/shared_image_gallery/102-packer_build_linux/role_mapping.tfvars
+++ b/examples/shared_image_gallery/102-packer_build_linux/role_mapping.tfvars
@@ -1,0 +1,22 @@
+azuread_roles = {
+  packer_client = {
+    roles = [
+      "Contributor"
+    ]
+  }
+}
+
+role_mapping = {
+  built_in_role_mapping = {
+    subscriptions = {
+      logged_in_subscription = {
+        "Contributor" = {
+          azuread_apps = {
+            keys   = ["packer_client"]
+            lz_key = "examples"
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/shared_image_gallery/102-packer_build_linux/service_principal.tfvars
+++ b/examples/shared_image_gallery/102-packer_build_linux/service_principal.tfvars
@@ -1,0 +1,15 @@
+azuread_apps = {
+  packer_client = {
+    useprefix                    = true
+    application_name             = "packer-client"
+    password_expire_in_days      = 1
+    app_role_assignment_required = true
+    keyvaults = {
+      packer_client = {
+        secret_prefix = "packer-client"
+      }
+    }
+    # Store the ${secret_prefix}-client-id, ${secret_prefix}-client-secret...
+    # Set the policy during the creation process of the launchpad
+  }
+}

--- a/examples/shared_image_gallery/103-packer_build_source_sig/image_gallery.tfvars
+++ b/examples/shared_image_gallery/103-packer_build_source_sig/image_gallery.tfvars
@@ -1,0 +1,76 @@
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "southeastasia"
+  }
+}
+
+resource_groups = {
+  sig = {
+    name = "sig"
+  }
+  packer = {
+    name = "packer"
+  }
+  build = {
+    name = "build"
+  }
+}
+
+shared_image_galleries = {
+  gallery1 = {
+    name               = "source"
+    resource_group_key = "sig"
+    description        = " "
+  }
+  gallery2 = {
+    name               = "test"
+    resource_group_key = "sig"
+    description        = " "
+  }
+}
+
+
+image_definitions = {
+  image1 = {
+    name               = "image1"
+    gallery_key        = "gallery1"
+    resource_group_key = "sig"
+    os_type            = "Linux"
+    publisher          = "MyCompany"
+    offer              = "WebServer"
+    sku                = "2020.1"
+  }
+  image2 = {
+    name               = "image2"
+    gallery_key        = "gallery2"
+    resource_group_key = "sig"
+    os_type            = "Linux"
+    publisher          = "MyCompany"
+    offer              = "AdvancedWebServer"
+    sku                = "2020.2"
+  }
+}
+
+managed_identities = {
+  example_mi = {
+    name               = "example_mi"
+    resource_group_key = "sig"
+  }
+}
+
+vnets = {
+  vnet_region1 = {
+    resource_group_key = "sig"
+    vnet = {
+      name          = "buildvnet"
+      address_space = ["10.100.100.0/24"]
+    }
+    subnets = {
+      buildsubnet = {
+        name = "buildsubnet"
+        cidr = ["10.100.100.0/29"]
+      }
+    }
+  }
+}

--- a/examples/shared_image_gallery/103-packer_build_source_sig/keyvaults.tfvars
+++ b/examples/shared_image_gallery/103-packer_build_source_sig/keyvaults.tfvars
@@ -1,0 +1,27 @@
+keyvaults = {
+  packer_client = {
+    name                = "packerakv"
+    resource_group_key  = "sig"
+    sku_name            = "standard"
+    soft_delete_enabled = true
+    tags = {
+      tfstate = "level2"
+    }
+    creation_policies = {
+      logged_in_user = {
+        # if the key is set to "logged_in_user" add the user running terraform in the keyvault policy
+        # More examples in /examples/keyvault
+        secret_permissions = ["Set", "Get", "List", "Delete", "Purge", "Recover"]
+      }
+    }
+  }
+}
+
+keyvault_access_policies_azuread_apps = {
+  packer_client = {
+    packer_client = {
+      azuread_app_key    = "packer_client"
+      secret_permissions = ["Set", "Get", "List", "Delete"]
+    }
+  }
+}

--- a/examples/shared_image_gallery/103-packer_build_source_sig/packer.tfvars
+++ b/examples/shared_image_gallery/103-packer_build_source_sig/packer.tfvars
@@ -1,0 +1,42 @@
+packer_build = {
+  build1 = {
+    packer_working_dir   = "./shared_image_gallery/103-packer_build_source_sig/packer_files/"
+    packer_template_file = "build.pkr.hcl"
+    packer_var_file      = "packer.vars.json"
+    secret_prefix        = "packer-client"
+    keyvault_key         = "packer_client"
+    managed_image_name   = "myImage2"
+    #build_resource_group_key                         = "build" #build in existing resource group instead of temporary rg created by packer
+    resource_group_key = "sig" #for managed_image_resource_group_name
+    os_type            = "Linux"
+    location           = "southeastasia"
+    vm_size            = "Standard_A2_v2"
+    build_script       = "ansible-ping.yml"
+    #managed_identity_key                             = "example_mi"   #managed identity configured on build VM for permissions to Azure resources during build
+    #vnet_key                                         = "vnet_region1" #build in existing vnet/subnet if preferred or for internal builds
+    #subnet_key                                       = "buildsubnet"  #build in existing vnet/subnet if preferred or for internal builds
+    #private_virtual_network_with_public_ip           = true           #false for internal builds, needed for example
+    managed_image_storage_account_type               = "Standard_LRS" #storage type used during build. Premium_LRS for faster builds, note chosen vm_size needs to support the storage type
+    storage_account_type                             = "Standard_LRS" #storage type in shared image gallery
+    tag_packer_resources                             = true           #apply tags to the Azure resources created by Packer
+    keep_image                                       = false          #source Azure managed image can be deleted once imported into shared image gallery
+    shared_gallery_image_version_exclude_from_latest = false
+    keep_versions                                    = 3 # number of image versions to keep
+    tags = {
+      mybuild = "advancedlinux"
+    }
+    shared_image_gallery = {
+      gallery_name   = "<source image gallery name>"
+      image_name     = "<image name>"
+      resource_group = "<resource group name>"
+      image_version  = "latest"
+      subscription   = "<subscription id>"
+    }
+    shared_image_gallery_destination = {
+      gallery_key         = "gallery2"
+      image_key           = "image2"
+      resource_group_key  = "sig"
+      replication_regions = "southeastasia"
+    }
+  }
+}

--- a/examples/shared_image_gallery/103-packer_build_source_sig/packer_files/ansible-ping.yml
+++ b/examples/shared_image_gallery/103-packer_build_source_sig/packer_files/ansible-ping.yml
@@ -1,0 +1,6 @@
+---
+
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - ping:

--- a/examples/shared_image_gallery/103-packer_build_source_sig/packer_files/build.pkr.hcl
+++ b/examples/shared_image_gallery/103-packer_build_source_sig/packer_files/build.pkr.hcl
@@ -1,0 +1,119 @@
+source "azure-arm" "mybuild" {
+  build_resource_group_name                        = var.build_resource_group_name
+  client_id                                        = var.client_id
+  client_secret                                    = var.client_secret
+  # image_offer                                      = var.image_offer
+  # image_publisher                                  = var.image_publisher
+  # image_sku                                        = var.image_sku
+  managed_image_name                               = var.managed_image_name
+  managed_image_resource_group_name                = var.managed_image_resource_group_name
+  managed_image_storage_account_type               = var.managed_image_storage_account_type
+  os_type                                          = var.os_type
+  private_virtual_network_with_public_ip           = var.private_virtual_network_with_public_ip
+  subscription_id                                  = var.subscription_id
+  tenant_id                                        = var.tenant_id
+  user_assigned_managed_identities                 = var.managed_identity
+  virtual_network_name                             = var.virtual_network_name
+  virtual_network_subnet_name                      = var.virtual_network_subnet_name
+  vm_size                                          = var.vm_size
+  azure_tags                                       = local.azure_tags
+  shared_gallery_image_version_exclude_from_latest = var.shared_gallery_image_version_exclude_from_latest
+  shared_image_gallery_destination {
+    gallery_name         = var.gallery_name
+    image_name           = var.image_name
+    image_version        = var.image_version
+    replication_regions  = [var.replication_regions]
+    resource_group       = var.resource_group
+    subscription         = var.subscription
+    storage_account_type = var.storage_account_type
+  }
+  shared_image_gallery {
+    subscription = var.source_subscription
+    resource_group = var.source_resource_group
+    gallery_name = var.source_gallery_name
+    image_version = var.source_image_version
+    image_name = var.source_image_name
+  }
+}
+
+build {
+  sources = ["source.azure-arm.mybuild"]
+
+  provisioner "ansible" {
+    playbook_file = "${var.packer_working_dir}${var.build_script}"
+  }
+
+}
+
+locals {
+  azure_tags = try(convert(var.azure_tags, map(string)), null)
+}
+
+variable "subscription_id" {}
+variable "tenant_id" {}
+variable "client_id" {}
+variable "client_secret" {}
+variable "managed_image_name" {}
+variable "managed_image_resource_group_name" {}
+variable "managed_image_storage_account_type" {}
+variable "os_type" {}
+variable "packer_working_dir" {}
+variable "azure_tags" {
+  default = null
+}
+variable "location" {}
+variable "build_resource_group_name" {
+  default = null
+}
+variable "image_offer" {
+  default = null
+}
+variable "image_publisher" {
+  default = null
+}
+variable "image_sku" {
+  default = null
+}
+variable "build_script" {
+  default = null
+}
+variable "private_virtual_network_with_public_ip" {
+  default = null
+}
+variable "managed_identity" {
+  default = null
+}
+variable "virtual_network_name" {
+  default = null
+}
+variable "virtual_network_subnet_name" {
+  default = null
+}
+variable "vm_size" {}
+#destination sig
+variable "gallery_name" {}
+variable "image_name" {}
+variable "image_version" {}
+variable "replication_regions" {}
+variable "resource_group" {}
+variable "subscription" {}
+variable "storage_account_type" {}
+variable "shared_gallery_image_version_exclude_from_latest" {
+  default = null
+}
+#source sig
+variable "source_subscription" {
+  default = null
+}
+variable "source_resource_group" {
+  default = null
+}
+variable "source_gallery_name" {
+  default = null
+}
+variable "source_image_version" {
+  default = null
+}
+variable "source_image_name" {
+  default = null
+}

--- a/examples/shared_image_gallery/103-packer_build_source_sig/role_mapping.tfvars
+++ b/examples/shared_image_gallery/103-packer_build_source_sig/role_mapping.tfvars
@@ -1,0 +1,22 @@
+azuread_roles = {
+  packer_client = {
+    roles = [
+      "Contributor"
+    ]
+  }
+}
+
+role_mapping = {
+  built_in_role_mapping = {
+    subscriptions = {
+      logged_in_subscription = {
+        "Contributor" = {
+          azuread_apps = {
+            keys   = ["packer_client"]
+            lz_key = "examples"
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/shared_image_gallery/103-packer_build_source_sig/service_principal.tfvars
+++ b/examples/shared_image_gallery/103-packer_build_source_sig/service_principal.tfvars
@@ -1,0 +1,15 @@
+azuread_apps = {
+  packer_client = {
+    useprefix                    = true
+    application_name             = "packer-client"
+    password_expire_in_days      = 1
+    app_role_assignment_required = true
+    keyvaults = {
+      packer_client = {
+        secret_prefix = "packer-client"
+      }
+    }
+    # Store the ${secret_prefix}-client-id, ${secret_prefix}-client-secret...
+    # Set the policy during the creation process of the launchpad
+  }
+}

--- a/examples/shared_image_gallery/104-packer_build_windows/image_gallery.tfvars
+++ b/examples/shared_image_gallery/104-packer_build_windows/image_gallery.tfvars
@@ -1,0 +1,36 @@
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "southeastasia"
+  }
+}
+
+resource_groups = {
+  sig = {
+    name = "sig"
+  }
+  packer = {
+    name = "packer"
+  }
+}
+
+shared_image_galleries = {
+  gallery1 = {
+    name               = "example104"
+    resource_group_key = "sig"
+    description        = " "
+  }
+
+}
+
+image_definitions = {
+  image1 = {
+    name               = "image1"
+    gallery_key        = "gallery1"
+    resource_group_key = "sig"
+    os_type            = "Windows"
+    publisher          = "MyCompany"
+    offer              = "WebServer"
+    sku                = "2020.1"
+  }
+}

--- a/examples/shared_image_gallery/104-packer_build_windows/keyvaults.tfvars
+++ b/examples/shared_image_gallery/104-packer_build_windows/keyvaults.tfvars
@@ -1,0 +1,27 @@
+keyvaults = {
+  packer_client = {
+    name                = "packerakv"
+    resource_group_key  = "sig"
+    sku_name            = "standard"
+    soft_delete_enabled = true
+    tags = {
+      tfstate = "level2"
+    }
+    creation_policies = {
+      logged_in_user = {
+        # if the key is set to "logged_in_user" add the user running terraform in the keyvault policy
+        # More examples in /examples/keyvault
+        secret_permissions = ["Set", "Get", "List", "Delete", "Purge", "Recover"]
+      }
+    }
+  }
+}
+
+keyvault_access_policies_azuread_apps = {
+  packer_client = {
+    packer_client = {
+      azuread_app_key    = "packer_client"
+      secret_permissions = ["Set", "Get", "List", "Delete"]
+    }
+  }
+}

--- a/examples/shared_image_gallery/104-packer_build_windows/packer.tfvars
+++ b/examples/shared_image_gallery/104-packer_build_windows/packer.tfvars
@@ -1,0 +1,38 @@
+packer_build = {
+  build1 = {
+    packer_working_dir   = "./shared_image_gallery/104-packer_build_windows/packer_files/"
+    packer_template_file = "build.pkr.hcl"
+    packer_var_file      = "packer.vars.json"
+    secret_prefix        = "packer-client"
+    keyvault_key         = "packer_client"
+    managed_image_name   = "104-packer_build_windows"
+    #build_resource_group_key                         = "build" #build in existing resource group instead of temporary rg created by packer
+    resource_group_key = "sig" #for managed_image_resource_group_name
+    os_type            = "Windows"
+    image_publisher    = "MicrosoftWindowsServer"
+    image_offer        = "WindowsServer"
+    image_sku          = "2019-Datacenter-smalldisk"
+    location           = "southeastasia"
+    vm_size            = "Standard_D2s_v3"
+    #build_script                            = "./shared_image_gallery/102-packer_build_linux/packer_files/ansible-ping.yml"
+    #managed_identity_key                             = "example_mi"   #managed identity configured on build VM for permissions to Azure resources during build
+    #vnet_key                                         = "vnet_region1" #build in existing vnet/subnet if preferred or for internal builds
+    #subnet_key                                       = "buildsubnet"  #build in existing vnet/subnet if preferred or for internal builds
+    #private_virtual_network_with_public_ip           = true           #false for internal builds, needed for example
+    managed_image_storage_account_type = "Premium_LRS" #storage type used during build. Premium_LRS for faster builds, note chosen vm_size needs to support the storage type
+    storage_account_type               = "Premium_LRS" #storage type in shared image gallery
+    #tag_packer_resources                             = true           #apply tags to the Azure resources created by Packer
+    keep_image                                       = false #source Azure managed image can be deleted once imported into shared image gallery
+    shared_gallery_image_version_exclude_from_latest = false
+    keep_versions                                    = 1 # number of image versions to keep
+    tags = {
+      mybuild = "Windows"
+    }
+    shared_image_gallery_destination = {
+      gallery_key         = "gallery1"
+      image_key           = "image1"
+      resource_group_key  = "sig"
+      replication_regions = "southeastasia"
+    }
+  }
+}

--- a/examples/shared_image_gallery/104-packer_build_windows/packer_files/build.pkr.hcl
+++ b/examples/shared_image_gallery/104-packer_build_windows/packer_files/build.pkr.hcl
@@ -1,0 +1,134 @@
+packer {
+  required_plugins {
+    windows-update = {
+      version = "0.14.0"
+      source = "github.com/rgl/windows-update"
+    }
+  }
+}
+
+source "azure-arm" "mybuild" {
+  build_resource_group_name                        = var.build_resource_group_name
+  client_id                                        = var.client_id
+  client_secret                                    = var.client_secret
+  image_offer                                      = var.image_offer
+  image_publisher                                  = var.image_publisher
+  image_sku                                        = var.image_sku
+  managed_image_name                               = var.managed_image_name
+  managed_image_resource_group_name                = var.managed_image_resource_group_name
+  managed_image_storage_account_type               = var.managed_image_storage_account_type
+  os_type                                          = var.os_type
+  private_virtual_network_with_public_ip           = var.private_virtual_network_with_public_ip
+  subscription_id                                  = var.subscription_id
+  tenant_id                                        = var.tenant_id
+  user_assigned_managed_identities                 = var.managed_identity
+  virtual_network_name                             = var.virtual_network_name
+  virtual_network_subnet_name                      = var.virtual_network_subnet_name
+  vm_size                                          = var.vm_size
+  azure_tags                                       = local.azure_tags
+  shared_gallery_image_version_exclude_from_latest = var.shared_gallery_image_version_exclude_from_latest
+  shared_image_gallery_destination {
+    gallery_name         = var.gallery_name
+    image_name           = var.image_name
+    image_version        = var.image_version
+    replication_regions  = [var.replication_regions]
+    resource_group       = var.resource_group
+    subscription         = var.subscription
+    storage_account_type = var.storage_account_type
+  }
+  communicator = "winrm"
+  winrm_use_ssl = true
+  winrm_insecure= true
+  winrm_timeout= "5m"
+  winrm_username= "packer"
+  #async_resourcegroup_delete": "true",
+}
+
+build {
+  sources = ["source.azure-arm.mybuild"]
+
+  provisioner "powershell" {
+    inline = [
+      "Install-WindowsFeature -name Web-Server -IncludeManagementTools"
+    ]
+  }
+  provisioner "windows-update" {
+    search_criteria = "IsInstalled=0"
+  }
+  provisioner "powershell" {
+    script = "${var.packer_working_dir}finalize.ps1"
+  }
+}
+
+locals {
+  azure_tags = try(convert(var.azure_tags, map(string)), null)
+}
+
+variable "subscription_id" {}
+variable "tenant_id" {}
+variable "client_id" {}
+variable "client_secret" {}
+variable "managed_image_name" {}
+variable "managed_image_resource_group_name" {}
+variable "managed_image_storage_account_type" {}
+variable "os_type" {}
+variable "packer_working_dir" {}
+variable "build_script" {
+  default = null
+}
+variable "azure_tags" {
+  default = null
+}
+variable "location" {}
+variable "build_resource_group_name" {
+  default = null
+}
+variable "image_offer" {
+  default = null
+}
+variable "image_publisher" {
+  default = null
+}
+variable "image_sku" {
+  default = null
+}
+variable "ansible_playbook_path" {
+  default = null
+}
+variable "private_virtual_network_with_public_ip" {
+  default = null
+}
+variable "managed_identity" {
+  default = null
+}
+variable "virtual_network_name" {
+  default = null
+}
+variable "virtual_network_subnet_name" {
+  default = null
+}
+variable "vm_size" {}
+#destination sig
+variable "gallery_name" {}
+variable "image_name" {}
+variable "image_version" {}
+variable "replication_regions" {}
+variable "resource_group" {}
+variable "subscription" {}
+variable "storage_account_type" {}
+variable "shared_gallery_image_version_exclude_from_latest" {
+  default = null
+}
+#source sig
+variable "source_subscription" {
+  default = null
+}
+variable "source_resource_group" {
+  default = null
+}
+variable "source_gallery_name" {
+  default = null
+}
+variable "source_image_version" {
+  default = null
+}

--- a/examples/shared_image_gallery/104-packer_build_windows/packer_files/finalize.ps1
+++ b/examples/shared_image_gallery/104-packer_build_windows/packer_files/finalize.ps1
@@ -1,0 +1,4 @@
+while ((Get-Service RdAgent).Status -ne 'Running') { Start-Sleep -s 5 }
+while ((Get-Service WindowsAzureGuestAgent).Status -ne 'Running') { Start-Sleep -s 5 }
+& $env:SystemRoot/System32/Sysprep/Sysprep.exe /oobe /generalize /quiet /quit
+while($true) { $imageState = Get-ItemProperty HKLM:/SOFTWARE/Microsoft/Windows/CurrentVersion/Setup/State | Select ImageState; if($imageState.ImageState -ne 'IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE') { Write-Output $imageState.ImageState; Start-Sleep -s 10  } else { break } }

--- a/examples/shared_image_gallery/104-packer_build_windows/role_mapping.tfvars
+++ b/examples/shared_image_gallery/104-packer_build_windows/role_mapping.tfvars
@@ -1,0 +1,22 @@
+azuread_roles = {
+  packer_client = {
+    roles = [
+      "Contributor"
+    ]
+  }
+}
+
+role_mapping = {
+  built_in_role_mapping = {
+    subscriptions = {
+      logged_in_subscription = {
+        "Contributor" = {
+          azuread_apps = {
+            keys   = ["packer_client"]
+            lz_key = "examples"
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/shared_image_gallery/104-packer_build_windows/service_principal.tfvars
+++ b/examples/shared_image_gallery/104-packer_build_windows/service_principal.tfvars
@@ -1,0 +1,15 @@
+azuread_apps = {
+  packer_client = {
+    useprefix                    = true
+    application_name             = "packer-client"
+    password_expire_in_days      = 1
+    app_role_assignment_required = true
+    keyvaults = {
+      packer_client = {
+        secret_prefix = "packer-client"
+      }
+    }
+    # Store the ${secret_prefix}-client-id, ${secret_prefix}-client-secret...
+    # Set the policy during the creation process of the launchpad
+  }
+}

--- a/examples/shared_image_gallery/104-packer_build_windows/vm.tfvars
+++ b/examples/shared_image_gallery/104-packer_build_windows/vm.tfvars
@@ -1,0 +1,124 @@
+# Virtual machines
+virtual_machines = {
+
+  # Configuration to deploy a bastion host linux virtual machine
+  example_vm1 = {
+    resource_group_key = "sig"
+    provision_vm_agent = true
+    # when boot_diagnostics_storage_account_key is empty string "", boot diagnostics will be put on azure managed storage
+    # when boot_diagnostics_storage_account_key is a non-empty string, it needs to point to the key of a user managed storage defined in diagnostic_storage_accounts
+    # if boot_diagnostics_storage_account_key is not defined, but global_settings.resource_defaults.virtual_machines.use_azmanaged_storage_for_boot_diagnostics is true, boot diagnostics will be put on azure managed storage
+    boot_diagnostics_storage_account_key = "bootdiag_region1"
+
+    os_type = "windows"
+
+    # the auto-generated ssh key in keyvault secret. Secret name being {VM name}-ssh-public and {VM name}-ssh-private
+    keyvault_key = "packer_client"
+
+    # Define the number of networking cards to attach the virtual machine
+    networking_interfaces = {
+      nic0 = {
+        # Value of the keys from networking.tfvars
+        vnet_key                = "vnet_region1"
+        subnet_key              = "example"
+        name                    = "0"
+        enable_ip_forwarding    = false
+        internal_dns_name_label = "nic0"
+        public_ip_address_key   = "example_vm_pip1_rg1"
+      }
+    }
+
+    virtual_machine_settings = {
+      windows = {
+        name           = "example_vm2"
+        size           = "Standard_F2"
+        admin_username = "adminuser"
+
+        # Spot VM to save money
+        #priority        = "Spot"
+        #eviction_policy = "Deallocate"
+
+        # Value of the nic keys to attach the VM. The first one in the list is the default nic
+        network_interface_keys = ["nic0"]
+
+        os_disk = {
+          name                 = "example_vm1-os"
+          caching              = "ReadWrite"
+          storage_account_type = "Standard_LRS"
+        }
+
+        # source_image_reference = {
+        #   publisher = "MicrosoftWindowsServer"
+        #   offer     = "WindowsServer"
+        #   sku       = "2019-Datacenter"
+        #   version   = "latest"
+        # }
+        custom_image_key = "image1"
+        #lz_key = "examples"
+      }
+    }
+
+  }
+}
+
+
+diagnostic_storage_accounts = {
+  # Stores boot diagnostic for region1
+  bootdiag_region1 = {
+    name                     = "bootrg1"
+    resource_group_key       = "sig"
+    account_kind             = "StorageV2"
+    account_tier             = "Standard"
+    account_replication_type = "LRS"
+    access_tier              = "Cool"
+  }
+}
+
+vnets = {
+  vnet_region1 = {
+    resource_group_key = "sig"
+    vnet = {
+      name          = "virtual_machines"
+      address_space = ["10.100.100.0/24"]
+    }
+    specialsubnets = {}
+    subnets = {
+      example = {
+        name    = "examples"
+        cidr    = ["10.100.100.0/29"]
+        nsg_key = "example"
+      }
+    }
+
+  }
+}
+
+public_ip_addresses = {
+  example_vm_pip1_rg1 = {
+    name                    = "example_vm_pip1"
+    resource_group_key      = "sig"
+    sku                     = "Standard"
+    allocation_method       = "Static"
+    ip_version              = "IPv4"
+    idle_timeout_in_minutes = "4"
+
+  }
+}
+
+network_security_group_definition = {
+  example = {
+    nsg = [
+      {
+        name                       = "rdp-inbound",
+        priority                   = "100"
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_range     = "3389"
+        source_address_prefix      = "Internet"
+        destination_address_prefix = "VirtualNetwork"
+      }
+    ]
+  }
+}

--- a/examples/variables.tf
+++ b/examples/variables.tf
@@ -416,7 +416,7 @@ variable "packer_service_principal" {
   default = {}
 }
 
-variable "packer_managed_identity" {
+variable "packer_build" {
   default = {}
 }
 

--- a/locals.tf
+++ b/locals.tf
@@ -279,8 +279,8 @@ locals {
     monitor_autoscale_settings = try(var.shared_services.monitor_autoscale_settings, {})
     monitor_action_groups      = try(var.shared_services.monitor_action_groups, {})
     monitoring                 = try(var.shared_services.monitoring, {})
-    packer_managed_identity    = try(var.shared_services.packer_managed_identity, {})
     packer_service_principal   = try(var.shared_services.packer_service_principal, {})
+    packer_build               = try(var.shared_services.packer_build, {})
     recovery_vaults            = try(var.shared_services.recovery_vaults, {})
     shared_image_galleries     = try(var.shared_services.shared_image_galleries, {})
   }

--- a/modules/shared_image_gallery/packer_build/main.tf
+++ b/modules/shared_image_gallery/packer_build/main.tf
@@ -1,0 +1,14 @@
+locals {
+  module_tag = {
+    "module" = basename(abspath(path.module))
+  }
+  tags = merge(var.base_tags, local.module_tag, try(var.settings.tags, null))
+}
+
+terraform {
+  required_providers {
+    azurecaf = {
+      source = "aztfmod/azurecaf"
+    }
+  }
+}

--- a/modules/shared_image_gallery/packer_build/packer.tf
+++ b/modules/shared_image_gallery/packer_build/packer.tf
@@ -103,6 +103,25 @@ resource "null_resource" "clean_old_versions" {
   ]
 }
 
+resource "null_resource" "remove_all_versions" {
+  triggers = {
+    resource_group_name = var.resource_group_name
+    gallery_name = var.gallery_name
+    image_name = var.image_name
+  }
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash"]
+    when    = destroy
+    command = format("%s/remove_all_versions.sh", path.module)
+    environment = {
+      RESOURCE_GROUP_NAME = self.triggers.resource_group_name 
+      GALLERY_NAME = self.triggers.gallery_name
+      IMAGE_NAME = self.triggers.image_name
+    }
+  }
+}
+
+
 data "azurerm_platform_image" "source" {
   count     = try(var.settings.image_publisher, "") == "" ? 0 : 1
   publisher = var.settings.image_publisher

--- a/modules/shared_image_gallery/packer_build/packer.tf
+++ b/modules/shared_image_gallery/packer_build/packer.tf
@@ -1,0 +1,136 @@
+data "azurerm_key_vault_secret" "packer_client_id" {
+  name         = format("%s-client-id", var.settings.secret_prefix)
+  key_vault_id = var.key_vault_id
+}
+
+data "azurerm_key_vault_secret" "packer_secret" {
+  name         = format("%s-client-secret", var.settings.secret_prefix)
+  key_vault_id = var.key_vault_id
+}
+
+resource "local_file" "packer_var_file" {
+  content = jsonencode(
+    {
+      client_id                              = data.azurerm_key_vault_secret.packer_client_id.value
+      client_secret                          = data.azurerm_key_vault_secret.packer_secret.value
+      tenant_id                              = var.tenant_id
+      subscription_id                        = var.subscription
+      os_type                                = var.settings.os_type
+      image_publisher                        = try(var.settings.image_publisher, null)
+      image_offer                            = try(var.settings.image_offer, null)
+      image_sku                              = try(var.settings.image_sku, null)
+      location                               = var.location
+      vm_size                                = var.settings.vm_size
+      managed_image_resource_group_name      = var.resource_group_name
+      build_resource_group_name              = var.build_resource_group_name
+      virtual_network_name                   = try(var.vnet_name, null)
+      virtual_network_subnet_name            = try(var.subnet_name, null)
+      private_virtual_network_with_public_ip = try(var.settings.private_virtual_network_with_public_ip, null)
+      managed_image_storage_account_type     = try(var.settings.managed_image_storage_account_type, null)
+      storage_account_type                   = try(var.settings.storage_account_type, null)
+      managed_image_name                     = local.managed_image_name
+      build_script                           = try(var.settings.build_script, null)
+      managed_identity                       = local.managed_identity
+      azure_tags                             = try(var.settings.tag_packer_resources, false) == true ? local.tags : null
+      shared_gallery_image_version_exclude_from_latest = try(var.settings.shared_gallery_image_version_exclude_from_latest, null)
+      packer_working_dir                               = var.settings.packer_working_dir
+      //shared_image_gallery destination values. If publishing to a different Subscription, change the following arguments and supply the values as variables
+      subscription                                     = var.subscription
+      resource_group                                   = var.resource_group_name
+      gallery_name                                     = var.gallery_name
+      image_name                                       = var.image_name
+      image_version                                    = local.image_version
+      replication_regions                              = var.settings.shared_image_gallery_destination.replication_regions
+      //source shared_image_gallery values
+      source_subscription   = try(var.settings.shared_image_gallery.subscription, null)
+      source_resource_group = try(var.settings.shared_image_gallery.resource_group, null)
+      source_gallery_name   = try(var.settings.shared_image_gallery.gallery_name, null)
+      source_image_version  = try(var.settings.shared_image_gallery.image_version, null)
+      source_image_name     = try(var.settings.shared_image_gallery.image_name, null)
+    }
+  )
+  filename             = local.packer_var_filepath
+  file_permission      = "0640"
+  directory_permission = "0755"
+}
+
+resource "null_resource" "create_image" {
+  triggers = {
+    build_trigger = local.build_trigger
+  }
+  provisioner "local-exec" {
+    command = "packer init ${local.packer_template_filepath} && packer build -force -var-file ${local.packer_var_filepath} ${local.packer_template_filepath}"
+  }
+  depends_on = [
+    local_file.packer_var_file
+  ]
+}
+
+data "external" "image_versions" { # data source errors if no versions exist
+  program = [
+    "bash", "-c",
+    format(
+      "a=$(az sig image-version list --resource-group %s --gallery-name %s --gallery-image-definition %s -o json --query 'max_by([].{name:name},&name)'); if [[ $a == *name* ]]; then echo $a; else echo '{ \"name\":\"0.0.0\" }'; fi",
+      var.resource_group_name, var.gallery_name, var.image_name
+    )
+  ]
+}
+
+resource "null_resource" "delete_image" {
+  count = try(var.settings.keep_image, false) == true ? 0 : 1
+  triggers = {
+    build_trigger = local.build_trigger
+  }
+  provisioner "local-exec" {
+    command = format("az resource delete --ids %s", local.managed_image_version_id)
+  }
+  depends_on = [
+    null_resource.create_image
+  ]
+}
+
+resource "null_resource" "clean_old_versions" {
+  triggers = {
+    build_trigger = local.build_trigger
+  }
+  provisioner "local-exec" {
+    command = format("az sig image-version list --resource-group %s --gallery-name %s --gallery-image-definition %s --query 'sort_by([].{name:name},&name) | [:-%d]' -o tsv | xargs -I '{}' az sig image-version delete --resource-group %s --gallery-name %s --gallery-image-definition %s --gallery-image-version '{}'",
+      var.resource_group_name, var.gallery_name, var.image_name, var.settings.keep_versions, var.resource_group_name, var.gallery_name, var.image_name
+    )
+  }
+  depends_on = [
+    null_resource.delete_image
+  ]
+}
+
+data "azurerm_platform_image" "source" {
+  count     = try(var.settings.image_publisher, "") == "" ? 0 : 1
+  publisher = var.settings.image_publisher
+  offer     = var.settings.image_offer
+  sku       = var.settings.image_sku
+  location  = var.settings.location
+}
+
+data "azurerm_shared_image_version" "source" {
+  count               = try(var.settings.shared_image_gallery.gallery_name, "") == "" ? 0 : 1
+  name                = var.settings.shared_image_gallery.image_version
+  image_name          = var.settings.shared_image_gallery.image_name
+  gallery_name        = var.settings.shared_image_gallery.gallery_name
+  resource_group_name = var.settings.shared_image_gallery.resource_group
+}
+
+locals {
+  packer_template_filepath = "${var.settings.packer_working_dir}${var.settings.packer_template_file}"
+  packer_var_filepath      = "${var.settings.packer_working_dir}${var.settings.packer_var_file}"
+  build_trigger            = md5("${filemd5(local.packer_template_filepath)}${var.settings.managed_image_name}${try(data.azurerm_platform_image.source[0].id, "")}${var.settings.keep_versions}${var.settings.image_sku}${try(data.azurerm_shared_image_version.source[0].id, "")}")
+  managed_image_name       = format("%s-%s", var.settings.managed_image_name, local.image_version)
+  managed_image_version_id = try("/subscriptions/${var.subscription}/resourceGroups/${var.resource_group_name}/providers/Microsoft.Compute/images/${local.managed_image_name}", "")
+  highest_version_number   = data.external.image_versions.result.name
+  next_version_number      = tonumber(element(split(".", local.highest_version_number), 2)) + 1
+  image_version            = format("%s.%s.%s", "0", "0", tostring(local.next_version_number))
+  # managed identity
+  managed_local_identity  = try(var.managed_identities[var.client_config.landingzone_key][var.settings.managed_identity_key].id, "")
+  managed_remote_identity = try(var.managed_identities[var.settings.lz_key][var.settings.managed_identity_key].id, "")
+  provided_identity       = try(var.settings.managed_identity_id, "")
+  managed_identity        = try(merge(local.managed_local_identity, local.managed_remote_identity, local.provided_identity), [])
+}

--- a/modules/shared_image_gallery/packer_build/remove_all_versions.sh
+++ b/modules/shared_image_gallery/packer_build/remove_all_versions.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo "removing all versions of image-definition ${IMAGE_NAME} in gallery ${GALLERY_NAME} in resource group ${RESOURCE_GROUP_NAME}"
+az sig image-version list --resource-group ${RESOURCE_GROUP_NAME} --gallery-name ${GALLERY_NAME} --gallery-image-definition ${IMAGE_NAME} -o tsv --query 'sort_by([].{name:name},&name)' | xargs -I '{}' az sig image-version delete --resource-group ${RESOURCE_GROUP_NAME} --gallery-name ${GALLERY_NAME} --gallery-image-definition ${IMAGE_NAME} --gallery-image-version '{}' ||true
+echo "sleeping a minute to propagate"
+sleep 60

--- a/modules/shared_image_gallery/packer_build/variables.tf
+++ b/modules/shared_image_gallery/packer_build/variables.tf
@@ -1,0 +1,25 @@
+variable "resource_group_name" {}
+variable "build_resource_group_name" {
+  default = {}
+}
+variable "location" {}
+variable "client_config" {}
+variable "global_settings" {}
+variable "settings" {}
+variable "base_tags" {}
+variable "gallery_name" {}
+variable "image_name" {}
+variable "key_vault_id" {}
+variable "tenant_id" {}
+variable "subscription" {}
+variable "managed_identities" {
+  default = {}
+}
+variable "vnet_name" {
+  default = {}
+}
+variable "subnet_name" {
+  default = {}
+}
+
+

--- a/shared_image_gallery.tf
+++ b/shared_image_gallery.tf
@@ -50,3 +50,29 @@ module "packer_service_principal" {
     azurerm_role_assignment.for,
   ]
 }
+
+module "packer_build" {
+  source   = "./modules/shared_image_gallery/packer_build"
+  for_each = try(local.shared_services.packer_build, {})
+
+  resource_group_name       = local.resource_groups[each.value.resource_group_key].name
+  build_resource_group_name = try(local.resource_groups[each.value.build_resource_group_key].name, local.resource_groups[each.value.resource_group_key].name) #build in separate or same rg
+  location                  = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  client_config             = local.client_config
+  global_settings           = local.global_settings
+  subscription              = data.azurerm_subscription.primary.subscription_id
+  tenant_id                 = data.azurerm_client_config.current.tenant_id
+  gallery_name              = module.shared_image_galleries[each.value.shared_image_gallery_destination.gallery_key].name
+  image_name                = module.image_definitions[each.value.shared_image_gallery_destination.image_key].name
+  key_vault_id              = lookup(each.value, "keyvault_key") == null ? null : module.keyvaults[each.value.keyvault_key].id
+  managed_identities        = local.combined_objects_managed_identities
+  vnet_name                 = try(try(local.combined_objects_networking[each.value.lz_key][each.value.vnet_key].name, local.combined_objects_networking[local.client_config.landingzone_key][each.value.vnet_key].name), "")
+  subnet_name               = try(lookup(each.value, "lz_key", null) == null ? local.combined_objects_networking[local.client_config.landingzone_key][each.value.vnet_key].subnets[each.value.subnet_key].name : local.combined_objects_networking[each.value.lz_key][each.value.vnet_key].subnets[each.value.subnet_key].name, "")
+  settings                  = each.value
+  base_tags                 = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  depends_on = [
+    module.shared_image_galleries,
+    module.image_definitions,
+    azurerm_role_assignment.for,
+  ]
+}

--- a/virtual_machines.tf
+++ b/virtual_machines.tf
@@ -9,7 +9,9 @@ module "virtual_machines" {
     module.keyvault_access_policies_azuread_apps,
     module.proximity_placement_groups,
     module.network_security_groups,
-    module.storage_account_blobs
+    module.storage_account_blobs,
+    module.packer_service_principal,
+    module.packer_build
   ]
   for_each = local.compute.virtual_machines
 

--- a/virtual_machines_scale_sets.tf
+++ b/virtual_machines_scale_sets.tf
@@ -10,7 +10,9 @@ module "virtual_machine_scale_sets" {
     module.proximity_placement_groups,
     module.load_balancers,
     module.application_gateways,
-    module.application_security_groups
+    module.application_security_groups,
+    module.packer_service_principal,
+    module.packer_build
   ]
   for_each = local.compute.virtual_machine_scale_sets
 


### PR DESCRIPTION
I wanted to add some features we needed to the existing packer_service_principal module but this was hard to do without breaking changes so I've implemented it as a new module packer_build. This module adds the following features:

- Ability to specify a managed identity for access to resources during the Packer build
- Ability to tag resources created by Packer with the base or additional tags to conform with Azure Policy
- Ability to specify existing virtual network and subnet for Packer builds to enable internal builds
- Ability to specify existing resource group for Packer builds
- Ability to build from a shared image gallery source
- Improved stability on rebuild or failed builds
- Use of Packer HCL2 templates instead of the legacy JSON templates
- New image builds will trigger on the following changes:
  - packer build template file
  - image name
  - id of the source platform or shared image gallery image
  - number of versions to keep

If downstream resources such as virtual machine scale sets are using the images the default terraform behaviour can cause issues so the module always creates a new image version with the option to clean up a configurable amount of older versions.

Added examples, example 104 depends on https://github.com/aztfmod/terraform-azurerm-caf/pull/852