### PR TITLE
Update private_endpoint.tf

### DIFF
--- a/modules/networking/private_endpoint/private_endpoint.tf
+++ b/modules/networking/private_endpoint/private_endpoint.tf
@@ -28,7 +28,7 @@ resource "azurerm_private_endpoint" "pep" {
     for_each = can(var.settings.private_dns) ? [var.settings.private_dns] : []
 
     content {
-      name = private_dns.zone_group_name
+      name = try(var.settings.private_dns.zone_group_name, private_dns_zone_group.zone_group_name)
       private_dns_zone_ids = concat(
         flatten([
           for key in try(private_dns_zone_group.keys, []) : [

--- a/modules/networking/private_endpoint/private_endpoint.tf
+++ b/modules/networking/private_endpoint/private_endpoint.tf
@@ -28,7 +28,7 @@ resource "azurerm_private_endpoint" "pep" {
     for_each = can(var.settings.private_dns) ? [var.settings.private_dns] : []
 
     content {
-      name = private_dns_zone_group.zone_group_name
+      name = private_dns.zone_group_name
       private_dns_zone_ids = concat(
         flatten([
           for key in try(private_dns_zone_group.keys, []) : [


### PR DESCRIPTION
as existing applied tfvars and example are using `private_dns` instead of `private_dns_zone_group`, reverting this to avoid breaking changes