### PR TITLE
Allow admin password in VMSS

### DIFF
--- a/modules/compute/virtual_machine_scale_set/vmss_linux.tf
+++ b/modules/compute/virtual_machine_scale_set/vmss_linux.tf
@@ -62,6 +62,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "vmss" {
   for_each = local.os_type == "linux" ? var.settings.vmss_settings : {}
 
   admin_username      = each.value.admin_username
+  admin_password      = each.value.disable_password_authentication == false ? each.value.admin_password : null
   instances           = each.value.instances
   location            = var.location
   name                = azurecaf_name.linux[each.key].result


### PR DESCRIPTION
This PR gives the user the ability to specify an admin password only if disable_password_authentication is set to false. This matches the feature we have for vm_linux