### PR TITLE
Inject preexisting vnet_id for load balancer

### DIFF
--- a/modules/networking/load_balancers/load_balancers.tf
+++ b/modules/networking/load_balancers/load_balancers.tf
@@ -18,7 +18,7 @@ resource "azurerm_lb" "lb" {
     for_each = try(var.settings.frontend_ip_configurations, {})
     content {
       name                          = frontend_ip_configuration.value.name
-      subnet_id                     = try(var.vnets[try(frontend_ip_configuration.value.lz_key, var.client_config.landingzone_key)][frontend_ip_configuration.value.vnet_key].subnets[frontend_ip_configuration.value.subnet_key].id, null)
+      subnet_id                     = try(var.vnets[try(frontend_ip_configuration.value.lz_key, var.client_config.landingzone_key)][frontend_ip_configuration.value.vnet_key].subnets[frontend_ip_configuration.value.subnet_key].id, frontend_ip_configuration.value.subnet_id, null)
       private_ip_address            = try(frontend_ip_configuration.value.private_ip_address, null)
       private_ip_address_allocation = try(frontend_ip_configuration.value.private_ip_address_allocation, null) #Possible values as Dynamic and Static.
       private_ip_address_version    = try(frontend_ip_configuration.value.private_ip_address_version, null)    #Possible values are IPv4 or IPv6.

--- a/modules/networking/load_balancers/load_balancers.tf
+++ b/modules/networking/load_balancers/load_balancers.tf
@@ -42,7 +42,7 @@ resource "azurerm_lb_backend_address_pool_address" "backend_address_pool_address
 
   name                    = each.value.backend_address_pool_address_name
   backend_address_pool_id = azurerm_lb_backend_address_pool.backend_address_pool.0.id
-  virtual_network_id      = var.vnets[var.client_config.landingzone_key][each.value.vnet_key].id
+  virtual_network_id      = try(var.vnets[var.client_config.landingzone_key][each.value.vnet_key].id, each.value.virtual_network_id)
   ip_address              = each.value.ip_address
 }
 


### PR DESCRIPTION
1. To allow the LB's frontend_ip_configurations to support the referencing of existing subnet through resource id
2. Support for the referencing of existing vnet through resource id, for the LB's backend_address_pool
