### PR TITLE
Data Disk restore interim fix

### DIFF
--- a/modules/compute/virtual_machine/mssql_vm.tf
+++ b/modules/compute/virtual_machine/mssql_vm.tf
@@ -226,7 +226,7 @@ data "external" "sp_client_secret" {
 resource "random_password" "sql_admin_password" {
   for_each = {
     for key, value in try(var.settings.virtual_machine_settings, {}) : key => value
-    if try(value.mssql_settings.sql_authentication.sql_credential.sql_password_key, null) == null
+    if try(value.mssql_settings.sql_authentication.sql_credential.sql_password_key, null) == null && try(value.mssql_settings, null) != null
   }
 
   length           = 100
@@ -240,7 +240,7 @@ resource "random_password" "sql_admin_password" {
 resource "azurerm_key_vault_secret" "sql_admin_password" {
   for_each = {
     for key, value in try(var.settings.virtual_machine_settings, {}) : key => value
-    if try(value.mssql_settings.sql_authentication.sql_credential.sql_password_key, null) == null
+    if try(value.mssql_settings.sql_authentication.sql_credential.sql_password_key, null) == null && try(value.mssql_settings, null) != null 
   }
 
   name         = can(each.value.mssql_settings.sql_authentication.sql_credential.keyvault_secret_name) ? each.value.mssql_settings.sql_authentication.sql_credential.keyvault_secret_name : format("%s-mssql-login-pw", azurerm_windows_virtual_machine.vm[each.key].name)
@@ -277,7 +277,7 @@ resource "random_password" "encryption_password" {
 resource "azurerm_key_vault_secret" "backup_encryption_password" {
   for_each = {
     for key, value in try(var.settings.virtual_machine_settings, {}) : key => value
-    if try(value.mssql_settings.auto_backup.encryption_password, null) != null && try(value.mssql_settings.auto_backup.encryption_password.encryption_password_key, null) == null
+    if try(value.mssql_settings.auto_backup.encryption_password, null) != null && try(value.mssql_settings.auto_backup.encryption_password.encryption_password_key, null) == null && try(value.mssql_settings, null) != null
   }
 
   name         = can(each.value.mssql_settings.auto_backup.encryption_password.encryption_password_secret_name) ? each.value.mssql_settings.auto_backup.encryption_password.encryption_password_secret_name : format("%s-mssql-bkup-encryption-pw", azurerm_windows_virtual_machine.vm[each.key].name)

--- a/modules/compute/virtual_machine/mssql_vm.tf
+++ b/modules/compute/virtual_machine/mssql_vm.tf
@@ -226,7 +226,7 @@ data "external" "sp_client_secret" {
 resource "random_password" "sql_admin_password" {
   for_each = {
     for key, value in try(var.settings.virtual_machine_settings, {}) : key => value
-    if try(value.mssql_settings.sql_authentication.sql_credential.sql_password_key, null) == null && try(value.mssql_settings, null) != null
+    if try(value.mssql_settings.sql_authentication.sql_credential.sql_password_key, null) == null
   }
 
   length           = 100
@@ -240,7 +240,7 @@ resource "random_password" "sql_admin_password" {
 resource "azurerm_key_vault_secret" "sql_admin_password" {
   for_each = {
     for key, value in try(var.settings.virtual_machine_settings, {}) : key => value
-    if try(value.mssql_settings.sql_authentication.sql_credential.sql_password_key, null) == null && try(value.mssql_settings, null) != null 
+    if try(value.mssql_settings.sql_authentication.sql_credential.sql_password_key, null) == null
   }
 
   name         = can(each.value.mssql_settings.sql_authentication.sql_credential.keyvault_secret_name) ? each.value.mssql_settings.sql_authentication.sql_credential.keyvault_secret_name : format("%s-mssql-login-pw", azurerm_windows_virtual_machine.vm[each.key].name)
@@ -277,7 +277,7 @@ resource "random_password" "encryption_password" {
 resource "azurerm_key_vault_secret" "backup_encryption_password" {
   for_each = {
     for key, value in try(var.settings.virtual_machine_settings, {}) : key => value
-    if try(value.mssql_settings.auto_backup.encryption_password, null) != null && try(value.mssql_settings.auto_backup.encryption_password.encryption_password_key, null) == null && try(value.mssql_settings, null) != null
+    if try(value.mssql_settings.auto_backup.encryption_password, null) != null && try(value.mssql_settings.auto_backup.encryption_password.encryption_password_key, null) == null
   }
 
   name         = can(each.value.mssql_settings.auto_backup.encryption_password.encryption_password_secret_name) ? each.value.mssql_settings.auto_backup.encryption_password.encryption_password_secret_name : format("%s-mssql-bkup-encryption-pw", azurerm_windows_virtual_machine.vm[each.key].name)

--- a/modules/compute/virtual_machine/vm_disk.tf
+++ b/modules/compute/virtual_machine/vm_disk.tf
@@ -43,16 +43,13 @@ resource "azurerm_managed_disk" "disk" {
 resource "azurerm_virtual_machine_data_disk_attachment" "disk" {
   for_each = lookup(var.settings, "data_disks", {})
 
-  managed_disk_id           = azurerm_managed_disk.disk[each.key].id
+  managed_disk_id           = coalesce(
+    try(each.value.restored_disk_id, null),
+    try(azurerm_managed_disk.disk[each.key].id, null)
+  )
   virtual_machine_id        = local.os_type == "linux" ? azurerm_linux_virtual_machine.vm["linux"].id : azurerm_windows_virtual_machine.vm["windows"].id
   lun                       = each.value.lun
   caching                   = lookup(each.value, "caching", "None")
   write_accelerator_enabled = lookup(each.value, "write_accelerator_enabled", false)
-
-  lifecycle {
-    ignore_changes = [
-      managed_disk_id
-    ]
-  }
 
 }


### PR DESCRIPTION
Added option to replace disk attachment to restored data disk.

    data_disks = {
      db_data1 = {
        // restored_disk_id     = "" // the restored disk id will be added here for attachment
        name                 = "testdatadisk"
        storage_account_type = "Standard_LRS"
        # Only Empty is supported. More community contributions required to cover other scenarios
        create_option = "Empty"
        disk_size_gb  = "10"
        lun           = 1
      }
    }