### PR TITLE
Conditional improvements to autoscale module

### DIFF
--- a/modules/monitoring/monitor_autoscale_settings/monitor_autoscale_settings.tf
+++ b/modules/monitoring/monitor_autoscale_settings/monitor_autoscale_settings.tf
@@ -27,7 +27,7 @@ resource "azurerm_monitor_autoscale_setting" "this" {
       }
 
       dynamic "rule" {
-        for_each = profile.value.rules
+        for_each = try(profile.value.rules, {}) == "rules" ? [profile.value.rules] : []
         content {
           metric_trigger {
             metric_name              = rule.value.metric_trigger.metric_name
@@ -41,7 +41,7 @@ resource "azurerm_monitor_autoscale_setting" "this" {
             metric_namespace         = try(rule.value.metric_trigger.metric_namespace, null)
             divide_by_instance_count = try(rule.value.metric_trigger.divide_by_instance_count, null)
             dynamic "dimensions" {
-              for_each = try(rule.value.metric_trigger.dimensions, {})
+              for_each = try(rule.value.metric_trigger.dimensions, {}) == {} ? [] : [1]
               content {
                 name     = dimensions.value.name
                 operator = dimensions.value.operator
@@ -59,7 +59,7 @@ resource "azurerm_monitor_autoscale_setting" "this" {
       }
 
       dynamic "recurrence" {
-        for_each = try(var.settings.profiles[profile.key].recurrence, {}) != {} ? [1] : []
+        for_each = try(var.settings.profiles[profile.key].recurrence, {}) == {} ? [] : [1]
         content {
           timezone = var.settings.profiles[profile.key].recurrence.timezone
           days     = var.settings.profiles[profile.key].recurrence.days
@@ -69,7 +69,7 @@ resource "azurerm_monitor_autoscale_setting" "this" {
       }
 
       dynamic "fixed_date" {
-        for_each = try(var.settings.profiles[profile.key].fixed_date, {}) != {} ? [1] : []
+        for_each = try(var.settings.profiles[profile.key].fixed_date, {}) == {} ? [] : [1]
         content {
           timezone = try(var.settings.profiles[profile.key].fixed_date.timezone, null)
           start    = var.settings.profiles[profile.key].fixed_date.start
@@ -81,11 +81,11 @@ resource "azurerm_monitor_autoscale_setting" "this" {
   }
 
   dynamic "notification" {
-    for_each = try(var.settings.notification)
+    for_each = try(var.settings.notification, {}) == {} ? [] : [1]
     content {
 
       dynamic "email" {
-        for_each = try(var.settings.notification.email, {}) != {} ? [1] : []
+        for_each = try(var.settings.notification.email, {}) == {} ? [] : [1]
         content {
           send_to_subscription_administrator    = try(var.settings.notification.email.send_to_subscription_administrator, null)
           send_to_subscription_co_administrator = try(var.settings.notification.email.send_to_subscription_co_administrator, null)
@@ -94,7 +94,7 @@ resource "azurerm_monitor_autoscale_setting" "this" {
       }
 
       dynamic "webhook" {
-        for_each = try(var.settings.profiles.notification.webhook, {})
+        for_each = try(var.settings.profiles.notification.webhook, {}) == {} ? [] : [1]
         content {
           service_uri = var.settings.profiles.notification.webhook.service.uri
           properties  = try(var.settings.profiles.notification.webhook.properties, null)


### PR DESCRIPTION
This PR further improves the autoscale module. The module now allows you to exclude the 'rule' and 'notification' blocks, along with a few other improvements to improve the readability of the code.