### PR TITLE
Add jsonencode to convert settings value to string

### DIFF
--- a/modules/compute/virtual_machine_scale_set/vmss_windows.tf
+++ b/modules/compute/virtual_machine_scale_set/vmss_windows.tf
@@ -180,7 +180,7 @@ resource "azurerm_windows_virtual_machine_scale_set" "vmss" {
       force_update_tag           = try(extension.value.force_update_tag, null)
       protected_settings         = try(extension.value.protected_settings, null)
       provision_after_extensions = try(extension.value.provision_after_extensions, null)
-      settings                   = try(extension.value.settings, null)
+      settings                   = try(jsonencode(extension.value.settings), null)
     }
   }
 


### PR DESCRIPTION
The [settings](https://github.com/aztfmod/terraform-azurerm-caf/blob/master/modules/compute/virtual_machine_scale_set/vmss_windows.tf#L183) value of [extensions](https://github.com/aztfmod/terraform-azurerm-caf/blob/master/modules/compute/virtual_machine_scale_set/vmss_windows.tf#L171) requires a string instead of a map to make the configuration below functional.

``` hcl
extensions = {
  microsoft_azure_health_extension = {
    name                       = "HealthExtension"
    publisher                  = "Microsoft.ManagedServices"
    type                       = "ApplicationHealthWindows"
    type_handler_version       = "1.0"
    auto_upgrade_minor_version = "true"
    settings = {
      protocol    = "http"
      port        = "80"
      requestPath = "/"
      # Optional
      # intervalInSeconds = "5.0"
      # numberOfProbes    = "1.0"
    }
  }
}

```

The error below will occur once the `jsonencode()` function is not used.
<img width="1632" alt="image" src="https://user-images.githubusercontent.com/24568457/153409283-a13bd0c9-6ec0-48d4-88f8-92572d1be060.png">

Adding `jsonencode()` fixes this issue.
