### PR TITLE
Fis issue with internal module "nsg_flows" and custom network_watchers

### DIFF
--- a/network_security_groups.tf
+++ b/network_security_groups.tf
@@ -13,6 +13,7 @@ module "network_security_groups" {
   resource_group_name = local.resource_groups[each.value.resource_group_key].name
   settings            = each.value
   client_config       = local.client_config
+  network_watchers    = local.combined_objects_network_watchers
 
   // Module to support the NSG creation outside of the a subnet
   // version = 1 of NSG can be attached to a nic or a subnet


### PR DESCRIPTION
Added:

network_watchers    = local.combined_objects_network_watchers

to module "network_security_groups"

var.network_watcher is required by internal module "nsg_flows". If not present self deployed network watchers can't be referenced from nsg flows.