### PR TITLE
MSSQL Redeploy on adding new SQL Server

### DIFF
--- a/modules/databases/mssql_database/database.tf
+++ b/modules/databases/mssql_database/database.tf
@@ -10,6 +10,11 @@ resource "azurecaf_name" "mssqldb" {
 }
 
 resource "azurerm_mssql_database" "mssqldb" {
+  lifecycle {
+    ignore_changes = [
+      server_id
+    ]
+  }
   name                        = azurecaf_name.mssqldb.result
   server_id                   = var.server_id
   auto_pause_delay_in_minutes = try(var.settings.auto_pause_delay_in_minutes, null)


### PR DESCRIPTION
Added Lifecycle to MSSQL Databases to prevent redeploy on addition of new SQL Servers.