### PR TITLE
Enable application logging & web server logging storage container sas url to be dynamically obtained

### DIFF
--- a/modules/webapps/appservice/main.tf
+++ b/modules/webapps/appservice/main.tf
@@ -25,4 +25,6 @@ locals {
 
   backup_storage_account = try(var.settings.backup, null) == null ? null : var.storage_accounts[try(var.settings.backup.lz_key, var.client_config.landingzone_key)][var.settings.backup.storage_account_key]
   backup_sas_url         = try(var.settings.backup, null) == null ? null : "${local.backup_storage_account.primary_blob_endpoint}${local.backup_storage_account.containers[var.settings.backup.container_key].name}${data.azurerm_storage_account_blob_container_sas.backup[0].sas}"
+  logs_sas_url           = try(var.settings.backup, null) == null ? null : "${local.backup_storage_account.primary_blob_endpoint}${local.backup_storage_account.containers[var.settings.logs.container_key].name}${data.azurerm_storage_account_blob_container_sas.logs[0].sas}"
+  http_logs_sas_url       = try(var.settings.backup, null) == null ? null : "${local.backup_storage_account.primary_blob_endpoint}${local.backup_storage_account.containers[var.settings.http_logs.container_key].name}${data.azurerm_storage_account_blob_container_sas.http_logs[0].sas}"
 }

--- a/modules/webapps/appservice/storage_account.tf
+++ b/modules/webapps/appservice/storage_account.tf
@@ -32,8 +32,8 @@ data "azurerm_storage_account_blob_container_sas" "logs" {
   container_name    = local.backup_storage_account.containers[var.settings.logs.container_key].name
   https_only        = true
 
-  start  = time_rotating.sas[0].id
-  expiry = timeadd(time_rotating.sas[0].id, format("%sh", var.settings.logs.sas_policy.expire_in_days * 24))
+  start  = time_rotating.logs_sas[0].id
+  expiry = timeadd(time_rotating.logs_sas[0].id, format("%sh", var.settings.logs.sas_policy.expire_in_days * 24))
 
   permissions {
     read   = true
@@ -53,8 +53,8 @@ data "azurerm_storage_account_blob_container_sas" "http_logs" {
   container_name    = local.backup_storage_account.containers[var.settings.http_logs.container_key].name
   https_only        = true
 
-  start  = time_rotating.sas[0].id
-  expiry = timeadd(time_rotating.sas[0].id, format("%sh", var.settings.http_logs.sas_policy.expire_in_days * 24))
+  start  = time_rotating.http_logs_sas[0].id
+  expiry = timeadd(time_rotating.http_logs_sas[0].id, format("%sh", var.settings.http_logs.sas_policy.expire_in_days * 24))
 
   permissions {
     read   = true

--- a/modules/webapps/appservice/storage_account.tf
+++ b/modules/webapps/appservice/storage_account.tf
@@ -25,6 +25,47 @@ data "azurerm_storage_account_blob_container_sas" "backup" {
   }
 }
 
+data "azurerm_storage_account_blob_container_sas" "logs" {
+  count = try(var.settings.logs, null) != null ? 1 : 0
+
+  connection_string = data.azurerm_storage_account.backup_storage_account.0.primary_connection_string
+  container_name    = local.backup_storage_account.containers[var.settings.logs.container_key].name
+  https_only        = true
+
+  start  = time_rotating.sas[0].id
+  expiry = timeadd(time_rotating.sas[0].id, format("%sh", var.settings.logs.sas_policy.expire_in_days * 24))
+
+  permissions {
+    read   = true
+    add    = true
+    create = true
+    write  = true
+    delete = true
+    list   = true
+  }
+}
+
+
+data "azurerm_storage_account_blob_container_sas" "http_logs" {
+  count = try(var.settings.http_logs, null) != null ? 1 : 0
+
+  connection_string = data.azurerm_storage_account.backup_storage_account.0.primary_connection_string
+  container_name    = local.backup_storage_account.containers[var.settings.http_logs.container_key].name
+  https_only        = true
+
+  start  = time_rotating.sas[0].id
+  expiry = timeadd(time_rotating.sas[0].id, format("%sh", var.settings.http_logs.sas_policy.expire_in_days * 24))
+
+  permissions {
+    read   = true
+    add    = true
+    create = true
+    write  = true
+    delete = true
+    list   = true
+  }
+}
+
 resource "time_rotating" "sas" {
   count = try(var.settings.backup, null) != null ? 1 : 0
 
@@ -32,4 +73,22 @@ resource "time_rotating" "sas" {
   rotation_days    = lookup(var.settings.backup.sas_policy.rotation, "days", null)
   rotation_months  = lookup(var.settings.backup.sas_policy.rotation, "months", null)
   rotation_years   = lookup(var.settings.backup.sas_policy.rotation, "years", null)
+}
+
+resource "time_rotating" "logs_sas" {
+  count = try(var.settings.logs, null) != null ? 1 : 0
+
+  rotation_minutes = lookup(var.settings.logs.sas_policy.rotation, "mins", null)
+  rotation_days    = lookup(var.settings.logs.sas_policy.rotation, "days", null)
+  rotation_months  = lookup(var.settings.logs.sas_policy.rotation, "months", null)
+  rotation_years   = lookup(var.settings.logs.sas_policy.rotation, "years", null)
+}
+
+resource "time_rotating" "http_logs_sas" {
+  count = try(var.settings.http_logs, null) != null ? 1 : 0
+
+  rotation_minutes = lookup(var.settings.http_logs.sas_policy.rotation, "mins", null)
+  rotation_days    = lookup(var.settings.http_logs.sas_policy.rotation, "days", null)
+  rotation_months  = lookup(var.settings.http_logs.sas_policy.rotation, "months", null)
+  rotation_years   = lookup(var.settings.http_logs.sas_policy.rotation, "years", null)
 }


### PR DESCRIPTION
<img width="581" alt="Capture2" src="https://user-images.githubusercontent.com/68215366/155270801-03997132-0ad2-43bb-96c5-fd339c55f67d.PNG">
<img width="332" alt="Capture" src="https://user-images.githubusercontent.com/68215366/155270805-c08dad1a-3f4d-46bc-897f-a3908ab272af.PNG">
Application logging & web server logging is already accommodated for in https://github.com/aztfmod/terraform-azurerm-caf/blob/main/modules/webapps/appservice/module.tf, however it requires sas_url for the storage container. This can be dynamically obtained similar to the backup container approach (which is not accommodated for)