### PR TITLE
Add missing value iterator in dynamic private_dns_zone_group block

### DIFF
--- a/modules/networking/private_endpoint/private_endpoint.tf
+++ b/modules/networking/private_endpoint/private_endpoint.tf
@@ -28,14 +28,14 @@ resource "azurerm_private_endpoint" "pep" {
     for_each = can(var.settings.private_dns) ? [var.settings.private_dns] : []
 
     content {
-      name = try(var.settings.private_dns.zone_group_name, private_dns_zone_group.zone_group_name)
+      name = private_dns_zone_group.value.zone_group_name
       private_dns_zone_ids = concat(
         flatten([
-          for key in try(private_dns_zone_group.keys, []) : [
-            can(private_dns_zone_group.lz_key) ? var.private_dns[private_dns_zone_group.lz_key][key].id : var.private_dns[var.client_config.landingzone_key][key].id
+          for key in try(private_dns_zone_group.value.keys, []) : [
+            can(private_dns_zone_group.value.lz_key) ? var.private_dns[private_dns_zone_group.value.lz_key][key].id : var.private_dns[var.client_config.landingzone_key][key].id
           ]
         ]),
-        try(private_dns_zone_group.ids, [])
+        try(private_dns_zone_group.value.ids, [])
       )
     }
   }


### PR DESCRIPTION
It's done correctly [here](https://github.com/aztfmod/terraform-azurerm-caf/blob/main/modules/networking/private_links/endpoints/private_endpoint/private_endpoint.tf#L29-L49), so bringing this module in line with that