### PR TITLE
add dynamic value to dynamic kv secret

### DIFF
--- a/.github/workflows/standalone-scenarios.json
+++ b/.github/workflows/standalone-scenarios.json
@@ -83,6 +83,7 @@
     "eventhub/104-namespace-and-evh-with-storage",
     "keyvault/101-keyvault-policies",
     "keyvault/102-keyvault-cert-issuer",
+    "keyvault/104-keyvault-dynamic-secret",
     "logic_app/100-logic_app_workflow",
     "logic_app/102-logic_app_integration_account",
     "logic_app/103-logic_app_action_http",

--- a/examples/keyvault/104-keyvault-dynamic-secret/README.md
+++ b/examples/keyvault/104-keyvault-dynamic-secret/README.md
@@ -1,0 +1,2 @@
+This example tests the creation of a new kv dynamic secret with a dynamic value.
+useful case to deploy SQL server or VM with a dynamic password that created and pushed to the kV instead of writing a plain text password in the configuration file.

--- a/examples/keyvault/104-keyvault-dynamic-secret/configuration.tfvars
+++ b/examples/keyvault/104-keyvault-dynamic-secret/configuration.tfvars
@@ -1,0 +1,52 @@
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "eastus2"
+  }
+}
+
+provider_azurerm_features_keyvault = {
+  // set to true to cleanup the CI
+  purge_soft_delete_on_destroy = true
+}
+
+resource_groups = {
+  kv_region1 = {
+    name = "example-rg1"
+  }
+}
+
+keyvaults = {
+  vm-kv = {
+    name               = "vm-kv"
+    resource_group_key = "kv_region1"
+    sku_name           = "standard"
+    # cert_password_key  = "cert-password"
+    creation_policies = {
+      logged_in_user = {
+        certificate_permissions = ["Get", "List", "Update", "Create", "Import", "Delete", "Purge", "Recover", "Getissuers", "Setissuers", "Listissuers", "Deleteissuers", "Manageissuers", "Restore", "Managecontacts"]
+        secret_permissions      = ["Set", "Get", "List", "Delete", "Purge"]
+      }
+    }
+
+  }
+}
+
+# Store output attributes into keyvault secret
+dynamic_keyvault_secrets = {
+  vm-kv = { # Key of the keyvault
+    admin-username = {
+      secret_name = "admin-username"
+      value       = "administrator"
+    }
+    admin-password = {
+      secret_name = "admin-password"
+      value       = "dynamic"
+      config = {
+        length           = 25
+        special          = true
+        override_special = "_!@"
+      }
+    }
+  }
+}

--- a/modules/security/dynamic_keyvault_secrets/keyvault.tf
+++ b/modules/security/dynamic_keyvault_secrets/keyvault.tf
@@ -14,7 +14,7 @@ module "secret_value" {
   source = "./secret"
   for_each = {
     for key, value in var.settings : key => value
-    if try(value.value, null) != null && try(value.value, null) != ""
+    if try(value.value, null) != null && try(value.value, null) != "" && try(value.value, null) != "dynamic"
   }
 
   name        = each.value.secret_name
@@ -32,4 +32,17 @@ module "secret_immutable" {
   name        = each.value.secret_name
   value       = can(each.value.value) ? each.value.value : var.objects[each.value.output_key][try(each.value.resource_key, each.value.attribute_key)][try(each.value.attribute_key, "")]
   keyvault_id = var.keyvault.id
+}
+
+module "secret_dynamic" {
+  source = "./secret_dynamic"
+  for_each = {
+    for key, value in var.settings : key => value
+    if try(value.value, null) == "dynamic"
+  }
+
+  name        = each.value.secret_name
+  value       = each.value.value
+  keyvault_id = var.keyvault.id
+  config      = each.value.config
 }

--- a/modules/security/dynamic_keyvault_secrets/secret_dynamic/keyvault_secret.tf
+++ b/modules/security/dynamic_keyvault_secrets/secret_dynamic/keyvault_secret.tf
@@ -1,0 +1,17 @@
+resource "random_password" "value" {
+  length           = var.config.length
+  special          = var.config.special
+  override_special = var.config.override_special
+}
+
+resource "azurerm_key_vault_secret" "secret" {
+  name         = var.name
+  value        = random_password.value.result
+  key_vault_id = var.keyvault_id
+
+  lifecycle {
+    ignore_changes = [
+      key_vault_id
+    ]
+  }
+}

--- a/modules/security/dynamic_keyvault_secrets/secret_dynamic/variables.tf
+++ b/modules/security/dynamic_keyvault_secrets/secret_dynamic/variables.tf
@@ -1,0 +1,10 @@
+variable "name" {}
+variable "value" {}
+variable "keyvault_id" {}
+variable "config" {
+  default = {
+    length           = 16
+    special          = true
+    override_special = "_!@"
+  }
+}


### PR DESCRIPTION
this new feature allows the users to create a new random dynamic password as a secret directly by adding the value of the secret equal to "dynamic" and adding a new config object to send the configurations of the new password.