### PR TITLE
Add Azure Route Server compatibility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See http://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.62.3
+    rev: v1.64.0
     hooks:
     - id: terraform_fmt
     - id: terraform_docs

--- a/examples/networking/route_server/100-simple-route-server/configuration.tfvars
+++ b/examples/networking/route_server/100-simple-route-server/configuration.tfvars
@@ -1,0 +1,62 @@
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "northeurope"
+  }
+}
+resource_groups = {
+  rg-routeserver = {
+    name = "rg-routeserver"
+  }
+}
+vnets = {
+  vnet-routeserver = {
+    resource_group_key = "rg-routeserver"
+    vnet = {
+      name          = "vnet-routeserver"
+      address_space = ["172.20.0.0/24"]
+    }
+    subnets = {
+      RouteServerSubnet = {
+        name = "RouteServerSubnet"
+        cidr = ["172.20.0.128/27"]
+      }
+    }
+  }
+}
+public_ip_addresses = {
+  virtual_hub_ip = {
+    name                    = "pip-aa-conn-vhub"
+    resource_group_key      = "rg-routeserver"
+    sku                     = "Standard"
+    allocation_method       = "Static"
+    ip_version              = "IPv4"
+    idle_timeout_in_minutes = "4"
+  }
+}
+virtual_hubs = {
+  hub1 = {
+    hub_name = "vhub-routeserver"
+    region   = "region1"
+    sku      = "Standard"
+    resource_group = {
+      key = "rg-routeserver"
+    }
+    hub_ip = {
+      hip1 = {
+        name = "vhubip-routeserver"
+        subnet = {
+          vnet_key   = "vnet-routeserver"
+          subnet_key = "RouteServerSubnet"
+        }
+        private_ip_address           = "172.20.0.134"
+        private_ip_allocation_method = "Static"
+        public_ip_address = {
+          #lz_key = "connectivity"
+          public_ip_address_key = "virtual_hub_ip"
+        }
+      }
+    }
+
+  }
+}

--- a/modules/networking/virtual_wan/virtual_hub/variables.tf
+++ b/modules/networking/virtual_wan/virtual_hub/variables.tf
@@ -30,7 +30,7 @@ variable "resource_group_name" {
 
 
 variable "vwan_id" {
-  description = "(Required) Resource ID for the Virtual WAN object"
+  description = "(optional) Resource ID for the Virtual WAN object"
   type        = string
 }
 

--- a/modules/networking/virtual_wan/virtual_hub/virtual_hub.tf
+++ b/modules/networking/virtual_wan/virtual_hub/virtual_hub.tf
@@ -15,7 +15,8 @@ resource "azurerm_virtual_hub" "vwan_hub" {
   resource_group_name = var.resource_group_name
   location            = var.location
   virtual_wan_id      = var.vwan_id
-  address_prefix      = var.virtual_hub_config.hub_address_prefix
+  sku                 = try(var.virtual_hub_config.sku, null)
+  address_prefix      = try(var.virtual_hub_config.hub_address_prefix, null)
   tags                = local.tags
 
   dynamic "route" {

--- a/networking_virtual_hubs.tf
+++ b/networking_virtual_hubs.tf
@@ -23,6 +23,6 @@ module "virtual_hubs" {
   tags                = try(local.global_settings.inherit_tags, false) ? merge(local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][each.value.resource_group.key].tags, try(each.value.tags, null)) : {}
   virtual_hub_config  = each.value
   virtual_networks    = local.combined_objects_networking
-  vwan_id             = local.combined_objects_virtual_wans[try(each.value.virtual_wan.lz_key, local.client_config.landingzone_key)][each.value.virtual_wan.key].virtual_wan.id
+  vwan_id             = can(each.value.virtual_wan) ? local.combined_objects_virtual_wans[try(each.value.virtual_wan.lz_key, local.client_config.landingzone_key)][each.value.virtual_wan.key].virtual_wan.id : null
 }
 


### PR DESCRIPTION
Azure Route Server is actually a standalone Virtual Hub.
Creating a Route Server requires to create a virtual hub with a standard sku, no (null) virtual wan and no address prefix.
This PR is a minor fix on virtual hub module to allow the creation of a route server. It also implements an example.
This should solve #477 .
