### PR TITLE
Update vmss & app insights for referencing remote resource group

### DIFF
--- a/azurerm_application_insights.tf
+++ b/azurerm_application_insights.tf
@@ -15,7 +15,7 @@ module "azurerm_application_insights" {
   disable_ip_masking                    = lookup(each.value, "disable_ip_masking", null)
   workspace_id                          = try(local.combined_objects_log_analytics[try(each.value.log_analytics_workspace.lz_key, local.client_config.landingzone_key)][each.value.log_analytics_workspace.key].id, null)
   global_settings                       = local.global_settings
-  base_tags                             = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags                             = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].tags : {}
   diagnostic_profiles                   = try(each.value.diagnostic_profiles, null)
   diagnostics                           = local.combined_diagnostics
   settings                              = each.value

--- a/diagnostics.tf
+++ b/diagnostics.tf
@@ -29,9 +29,9 @@ module "diagnostic_storage_accounts" {
   global_settings     = local.global_settings
   client_config       = local.client_config
   storage_account     = each.value
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].name
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].location : local.global_settings.regions[each.value.region]
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].tags : {}
 }
 
 resource "azurerm_storage_account_customer_managed_key" "diasacmk" {

--- a/networking.tf
+++ b/networking.tf
@@ -138,7 +138,7 @@ module "public_ip_addresses" {
   )
   diagnostic_profiles = try(each.value.diagnostic_profiles, {})
   diagnostics         = local.combined_diagnostics
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].tags : {}
 }
 
 

--- a/virtual_machines_scale_sets.tf
+++ b/virtual_machines_scale_sets.tf
@@ -19,7 +19,7 @@ module "virtual_machine_scale_sets" {
   availability_sets                = local.combined_objects_availability_sets
   application_gateways             = local.combined_objects_application_gateways
   application_security_groups      = local.combined_objects_application_security_groups
-  base_tags                        = try(local.global_settings.inherit_tags, false) ? module.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags                        = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].tags : {}
   boot_diagnostics_storage_account = try(local.combined_diagnostics.storage_accounts[each.value.boot_diagnostics_storage_account_key].primary_blob_endpoint, {})
   client_config                    = local.client_config
   diagnostics                      = local.combined_diagnostics


### PR DESCRIPTION
Encountered the following issues while provisioning a Virtual Machine Scale Set and Azure Application Insights that references a remote resource group:
![Screenshot 2022-03-15 at 10 46 09 PM](https://user-images.githubusercontent.com/91870398/158406538-0cacb87c-58b8-4096-876c-f25d2ebe0ec4.png)

Tried implementing an enhancement which will search for the landing zone of remote resource group via the `lz_key` attribute, followed by the resource group key in that landing zone via the `key` attribute. This would take precedence before searching for any local resource group via the `resource_group_key` attribute.
