### PR TITLE
Fix remote resources composition bug for VMSS, MSSQL and networking

### DIFF
--- a/azurerm_application_insights.tf
+++ b/azurerm_application_insights.tf
@@ -19,7 +19,6 @@ module "azurerm_application_insights" {
   diagnostic_profiles                   = try(each.value.diagnostic_profiles, null)
   diagnostics                           = local.combined_diagnostics
   settings                              = each.value
-
 }
 
 output "application_insights" {

--- a/azurerm_application_insights.tf
+++ b/azurerm_application_insights.tf
@@ -15,7 +15,7 @@ module "azurerm_application_insights" {
   disable_ip_masking                    = lookup(each.value, "disable_ip_masking", null)
   workspace_id                          = try(local.combined_objects_log_analytics[try(each.value.log_analytics_workspace.lz_key, local.client_config.landingzone_key)][each.value.log_analytics_workspace.key].id, null)
   global_settings                       = local.global_settings
-  base_tags                             = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags                             = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].tags : {}
   diagnostic_profiles                   = try(each.value.diagnostic_profiles, null)
   diagnostics                           = local.combined_diagnostics
   settings                              = each.value

--- a/diagnostics.tf
+++ b/diagnostics.tf
@@ -29,9 +29,9 @@ module "diagnostic_storage_accounts" {
   global_settings     = local.global_settings
   client_config       = local.client_config
   storage_account     = each.value
-  resource_group_name = local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].name
-  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].location : local.global_settings.regions[each.value.region]
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].tags : {}
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].name 
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].location : local.global_settings.regions[each.value.region] 
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].tags : {} 
 }
 
 resource "azurerm_storage_account_customer_managed_key" "diasacmk" {

--- a/diagnostics.tf
+++ b/diagnostics.tf
@@ -29,9 +29,9 @@ module "diagnostic_storage_accounts" {
   global_settings     = local.global_settings
   client_config       = local.client_config
   storage_account     = each.value
-  resource_group_name = local.resource_groups[each.value.resource_group_key].name
-  location            = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  resource_group_name = local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].name
+  location            = lookup(each.value, "region", null) == null ? local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].location : local.global_settings.regions[each.value.region]
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].tags : {}
 }
 
 resource "azurerm_storage_account_customer_managed_key" "diasacmk" {

--- a/modules/compute/container_registry/private_endpoint.tf
+++ b/modules/compute/container_registry/private_endpoint.tf
@@ -6,10 +6,10 @@ module "private_endpoint" {
   base_tags           = local.tags
   client_config       = var.client_config
   global_settings     = var.global_settings
-  location            = var.resource_groups[var.client_config.landingzone_key][each.value.resource_group_key].location
+  location            = var.resource_groups[try(each.value.resource_group.lz_key, var.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].location
   name                = each.value.name
   private_dns         = var.private_dns
-  resource_group_name = var.resource_groups[var.client_config.landingzone_key][each.value.resource_group_key].name
+  resource_group_name = svar.resource_groups[try(each.value.resource_group.lz_key, var.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].name
   resource_id         = azurerm_container_registry.acr.id
   settings            = each.value
 

--- a/modules/compute/container_registry/private_endpoint.tf
+++ b/modules/compute/container_registry/private_endpoint.tf
@@ -9,7 +9,7 @@ module "private_endpoint" {
   location            = var.resource_groups[try(each.value.resource_group.lz_key, var.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].location
   name                = each.value.name
   private_dns         = var.private_dns
-  resource_group_name = svar.resource_groups[try(each.value.resource_group.lz_key, var.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].name
+  resource_group_name = var.resource_groups[try(each.value.resource_group.lz_key, var.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].name
   resource_id         = azurerm_container_registry.acr.id
   settings            = each.value
 

--- a/modules/databases/mssql_server/private_endpoints.tf
+++ b/modules/databases/mssql_server/private_endpoints.tf
@@ -10,8 +10,8 @@ module "private_endpoint" {
 
   resource_id         = azurerm_mssql_server.mssql.id
   name                = each.value.name
-  location            = var.resource_groups[each.value.resource_group_key].location
-  resource_group_name = var.resource_groups[each.value.resource_group_key].name
+  location            = var.resource_groups[try(each.value.resource_group.lz_key, var.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].location
+  resource_group_name = var.resource_groups[try(each.value.resource_group.lz_key, var.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].name
   subnet_id = coalesce(
     try(each.value.subnet_id, null),
     try(var.vnets[var.client_config.landingzone_key][each.value.vnet_key].subnets[each.value.subnet_key].id, null),

--- a/mssql_servers.tf
+++ b/mssql_servers.tf
@@ -19,7 +19,7 @@ module "mssql_servers" {
   azuread_groups      = local.combined_objects_azuread_groups
   vnets               = local.combined_objects_networking
   private_endpoints   = try(each.value.private_endpoints, {})
-  resource_groups     = try(each.value.private_endpoints, {}) == {} ? null : local.resource_groups
+  resource_groups     = local.combined_objects_resource_groups
   private_dns         = local.combined_objects_private_dns
   keyvault_id = coalesce(
     try(each.value.administrator_login_password, null),

--- a/networking.tf
+++ b/networking.tf
@@ -138,7 +138,7 @@ module "public_ip_addresses" {
   )
   diagnostic_profiles = try(each.value.diagnostic_profiles, {})
   diagnostics         = local.combined_diagnostics
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].tags : {} 
 }
 
 

--- a/networking.tf
+++ b/networking.tf
@@ -138,7 +138,7 @@ module "public_ip_addresses" {
   )
   diagnostic_profiles = try(each.value.diagnostic_profiles, {})
   diagnostics         = local.combined_diagnostics
-  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.resource_group_key].tags : {}
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].tags : {}
 }
 
 

--- a/virtual_machines_scale_sets.tf
+++ b/virtual_machines_scale_sets.tf
@@ -19,7 +19,7 @@ module "virtual_machine_scale_sets" {
   availability_sets                = local.combined_objects_availability_sets
   application_gateways             = local.combined_objects_application_gateways
   application_security_groups      = local.combined_objects_application_security_groups
-  base_tags                        = try(local.global_settings.inherit_tags, false) ? module.resource_groups[each.value.resource_group_key].tags : {}
+  base_tags                        = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].tags : {}
   boot_diagnostics_storage_account = try(local.combined_diagnostics.storage_accounts[each.value.boot_diagnostics_storage_account_key].primary_blob_endpoint, {})
   client_config                    = local.client_config
   diagnostics                      = local.combined_diagnostics

--- a/virtual_machines_scale_sets.tf
+++ b/virtual_machines_scale_sets.tf
@@ -19,7 +19,7 @@ module "virtual_machine_scale_sets" {
   availability_sets                = local.combined_objects_availability_sets
   application_gateways             = local.combined_objects_application_gateways
   application_security_groups      = local.combined_objects_application_security_groups
-  base_tags                        = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].tags : {}
+  base_tags                        = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].tags : {} 
   boot_diagnostics_storage_account = try(local.combined_diagnostics.storage_accounts[each.value.boot_diagnostics_storage_account_key].primary_blob_endpoint, {})
   client_config                    = local.client_config
   diagnostics                      = local.combined_diagnostics
@@ -37,7 +37,6 @@ module "virtual_machine_scale_sets" {
   vnets                            = local.combined_objects_networking
   location                         = can(local.global_settings.regions[each.value.region]) ? local.global_settings.regions[each.value.region] : local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].location
   resource_group_name              = can(each.value.resource_group.name) || can(each.value.resource_group_name) ? try(each.value.resource_group.name, each.value.resource_group_name) : local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group_key, each.value.resource_group.key)].name
-
 }
 
 


### PR DESCRIPTION
Encountered the following issues while provisioning a Virtual Machine Scale Set that references a remote resource group:
![Screenshot 2022-03-15 at 10 46 09 PM](https://user-images.githubusercontent.com/91870398/158447658-449c88da-e6a5-454a-aa58-ffe4292ef412.png)

Tried implementing an enhancement which will search for the landing zone of remote resource group via the `lz_key` attribute, followed by the resource group key in that landing zone via the `key` attribute. This would take precedence before searching for any local resource group via the `resource_group_key` attribute.

This was also applied across Azure Application Insights, MSSQL Server and Azure Container Registry.