### PR TITLE
Add additional secrets for database resources  (mariadb, mysql, postgres)

### DIFF
--- a/modules/databases/mariadb_server/server.tf
+++ b/modules/databases/mariadb_server/server.tf
@@ -54,6 +54,22 @@ resource "azurerm_key_vault_secret" "mariadb_admin" {
   key_vault_id = var.keyvault_id
 }
 
+resource "azurerm_key_vault_secret" "mariadb_admin_login_name" {
+  count = try(var.settings.administrator_login_password, null) == null ? 1 : 0
+
+  name         = format("%s-login-name", azurecaf_name.mariadb.result)
+  value        = format("%s@%s", var.settings.administrator_login, azurerm_mariadb_server.mariadb.fqdn)
+  key_vault_id = var.keyvault_id
+}
+
+resource "azurerm_key_vault_secret" "mariadb_fqdn" {
+  count = try(var.settings.administrator_login_password, null) == null ? 1 : 0
+
+  name         = format("%s-fqdn", azurecaf_name.mariadb.result)
+  value        = azurerm_mariadb_server.mariadb.fqdn
+  key_vault_id = var.keyvault_id
+}
+
 resource "azurecaf_name" "mariadb" {
   name          = var.settings.name
   resource_type = "azurerm_mariadb_server"

--- a/modules/databases/mysql_server/server.tf
+++ b/modules/databases/mysql_server/server.tf
@@ -74,6 +74,22 @@ resource "azurerm_key_vault_secret" "sql_admin" {
   key_vault_id = var.keyvault_id
 }
 
+resource "azurerm_key_vault_secret" "mysql_admin_login_name" {
+  count = try(var.settings.administrator_login_password, null) == null ? 1 : 0
+
+  name         = format("%s-login-name", azurecaf_name.mysql.result)
+  value        = format("%s@%s", var.settings.administrator_login, azurerm_mysql_server.mysql.fqdn)
+  key_vault_id = var.keyvault_id
+}
+
+resource "azurerm_key_vault_secret" "mysql_fqdn" {
+  count = try(var.settings.administrator_login_password, null) == null ? 1 : 0
+
+  name         = format("%s-fqdn", azurecaf_name.mysql.result)
+  value        = azurerm_mysql_server.mysql.fqdn
+  key_vault_id = var.keyvault_id
+}
+
 resource "azurerm_mysql_active_directory_administrator" "aad_admin" {
   count = try(var.settings.azuread_administrator, null) == null ? 0 : 1
 

--- a/modules/databases/postgresql_server/server.tf
+++ b/modules/databases/postgresql_server/server.tf
@@ -76,8 +76,21 @@ resource "azurerm_key_vault_secret" "sql_admin" {
   key_vault_id = var.keyvault_id
 }
 
+resource "azurerm_key_vault_secret" "postgresql_admin_login_name" {
+  count = try(var.settings.administrator_login_password, null) == null ? 1 : 0
 
+  name         = format("%s-login-name", azurecaf_name.postgresql.result)
+  value        = format("%s@%s", var.settings.administrator_login, azurerm_postgresql_server.postgresql.fqdn)
+  key_vault_id = var.keyvault_id
+}
 
+resource "azurerm_key_vault_secret" "postgresql_fqdn" {
+  count = try(var.settings.administrator_login_password, null) == null ? 1 : 0
+
+  name         = format("%s-fqdn", azurecaf_name.postgresql.result)
+  value        = azurerm_postgresql_server.postgresql.fqdn
+  key_vault_id = var.keyvault_id
+}
 
 
 


### PR DESCRIPTION
Fix #1015 (Flexible servers do not need login name secret)

