### PR TITLE
Add missing os_disk property for vm_linux

### DIFF
--- a/modules/compute/virtual_machine/vm_linux.tf
+++ b/modules/compute/virtual_machine/vm_linux.tf
@@ -105,6 +105,14 @@ resource "azurerm_linux_virtual_machine" "vm" {
     storage_account_type      = try(each.value.os_disk.storage_account_type, null)
     write_accelerator_enabled = try(each.value.os_disk.write_accelerator_enabled, false)
     disk_encryption_set_id    = try(each.value.os_disk.disk_encryption_set_key, null) == null ? null : try(var.disk_encryption_sets[var.client_config.landingzone_key][each.value.os_disk.disk_encryption_set_key].id, var.disk_encryption_sets[each.value.os_disk.lz_key][each.value.os_disk.disk_encryption_set_key].id, null)
+
+    dynamic "diff_disk_settings" {
+      for_each = try(each.value.diff_disk_settings, false) == false ? [] : [1]
+
+      content {
+        option = each.value.diff_disk_settings.option
+      }
+    }
   }
 
   dynamic "source_image_reference" {


### PR DESCRIPTION
Linux VM resource is missing the `diff_disk_settings` property of the `os_disk` setting.

https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine#diff_disk_settings