### PR TITLE
Fix remote resource composition for log analytics

### DIFF
--- a/diagnostics.tf
+++ b/diagnostics.tf
@@ -73,6 +73,8 @@ module "diagnostic_log_analytics" {
 
   global_settings = local.global_settings
   log_analytics   = each.value
+  settings        = each.value
+  client_config   = local.client_config
   resource_groups = local.resource_groups
   base_tags       = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
 }

--- a/modules/log_analytics/main.tf
+++ b/modules/log_analytics/main.tf
@@ -13,5 +13,12 @@ locals {
     "module" = basename(abspath(path.module))
   }
   tags = merge(var.base_tags, local.module_tag, try(var.log_analytics.tags, null))
+  resource_group = coalesce(
+    try(var.resource_groups[var.client_config.landingzone_key][var.settings.resource_group_key], null),
+    try(var.resource_groups[var.settings.lz_key][var.settings.resource_group_key], null),
+    try(var.resource_groups[var.client_config.landingzone_key][var.settings.resource_group.key], null),
+    try(var.resource_groups[var.settings.resource_group.lz_key][var.settings.resource_group.key], null),
+    try(var.resource_groups[var.log_analytics.resource_group.key], null)
+  )
 }
 

--- a/modules/log_analytics/solutions.tf
+++ b/modules/log_analytics/solutions.tf
@@ -1,13 +1,9 @@
 resource "azurerm_log_analytics_solution" "solution" {
   for_each = lookup(var.log_analytics, "solutions_maps", {})
 
-  solution_name = each.key
-  # location              = var.global_settings.regions[var.log_analytics.region]
-  location = coalesce(
-    try(var.global_settings.regions[var.log_analytics.region], null),
-    try(var.resource_groups[var.log_analytics.resource_group_key].location, null),
-  )
-  resource_group_name   = var.resource_groups[var.log_analytics.resource_group_key].name
+  solution_name         = each.key
+  location              = lookup(var.settings, "region", null) == null ? local.resource_group.location : var.global_settings.regions[var.settings.region]
+  resource_group_name   = local.resource_group.name
   workspace_resource_id = azurerm_log_analytics_workspace.law.id
   workspace_name        = azurerm_log_analytics_workspace.law.name
   tags                  = local.tags

--- a/modules/log_analytics/variables.tf
+++ b/modules/log_analytics/variables.tf
@@ -1,6 +1,10 @@
 variable "global_settings" {
   description = "Global settings object (see module README.md)"
 }
+variable "client_config" {
+  description = "Client configuration object"
+}
+variable "settings" {}
 variable "log_analytics" {}
 variable "resource_groups" {}
 variable "base_tags" {

--- a/modules/log_analytics/workspace.tf
+++ b/modules/log_analytics/workspace.tf
@@ -8,13 +8,11 @@ resource "azurecaf_name" "law" {
   passthrough   = var.global_settings.passthrough
   use_slug      = var.global_settings.use_slug
 }
+
 resource "azurerm_log_analytics_workspace" "law" {
-  name = azurecaf_name.law.result
-  location = coalesce(
-    try(var.global_settings.regions[var.log_analytics.region], null),
-    try(var.resource_groups[var.log_analytics.resource_group_key].location, null),
-  )
-  resource_group_name = var.resource_groups[var.log_analytics.resource_group_key].name
+  name                = azurecaf_name.law.result
+  location            = lookup(var.settings, "region", null) == null ? local.resource_group.location : var.global_settings.regions[var.settings.region]
+  resource_group_name = local.resource_group.name
   sku                 = lookup(var.log_analytics, "sku", "PerGB2018")
   retention_in_days   = lookup(var.log_analytics, "retention_in_days", 30)
   tags                = local.tags


### PR DESCRIPTION

Encountered an issue while provisioning a Log Analytics workspace that references a remote resource group.

Tried implementing an enhancement which will search for the landing zone of remote resource group via the `lz_key` attribute, followed by the resource group key in that landing zone via the `key` attribute. This would take precedence before searching for any local resource group via the `resource_group_key` attribute.