### PR TITLE
Enable AAD role assignment for AAD security groups

### DIFF
--- a/azuread_roles.tf
+++ b/azuread_roles.tf
@@ -1,4 +1,12 @@
 
+module "azuread_roles_security_groups" {
+  source   = "./modules/azuread/roles"
+  for_each = try(local.azuread.azuread_roles.azuread_groups, {})
+
+  object_id     = module.azuread_groups[each.key].id
+  azuread_roles = each.value.roles
+}
+  
 module "azuread_roles_applications" {
   source   = "./modules/azuread/roles"
   for_each = try(local.azuread.azuread_roles.azuread_apps, {})


### PR DESCRIPTION
this will fix issue: https://github.com/aztfmod/terraform-azurerm-caf/issues/1026

**Limitations**: Assigning AAD roles to AAD groups works only with _AAD Premium_ functionality **enabled**.