### PR TITLE
Fix APIM private virtual_network_configuration block

### DIFF
--- a/api_management.tf
+++ b/api_management.tf
@@ -7,6 +7,7 @@ module "api_management" {
   settings        = each.value
 
   location = lookup(each.value, "region", null) == null ? local.resource_groups[each.value.resource_group_key].location : local.global_settings.regions[each.value.region]
+  vnets    = local.combined_objects_networking
 
   resource_group_name = can(each.value.resource_group.name) || can(each.value.resource_group_name) ? try(each.value.resource_group.name, each.value.resource_group_name) : local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group_key, each.value.resource_group.key)].name
 

--- a/examples/apim/115-api_management_private_virtual_network/configuration.tfvars
+++ b/examples/apim/115-api_management_private_virtual_network/configuration.tfvars
@@ -1,0 +1,49 @@
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "eastus2"
+  }
+}
+
+resource_groups = {
+  rg1 = {
+    name   = "example-agw"
+    region = "region1"
+  }
+}
+
+vnets = {
+  example_vnet = {
+    resource_group_key = "rg1"
+
+    vnet = {
+      name          = "test"
+      address_space = ["10.0.0.0/16"]
+    }
+
+    subnets = {
+      example_subnet_key = {
+        name    = "example_subnet"
+        cidr    = ["10.0.1.0/26"]
+        nsg_key = "example_nsg"
+      }
+
+    }
+    specialsubnets = {}
+  }
+}
+
+api_management = {
+  example_apim = {
+    name                 = "example-apim"
+    resource_group_key   = "rg1"
+    publisher_name       = "My Company"
+    publisher_email      = "company@terraform.io"
+    sku_name             = "Developer_1"
+    virtual_network_type = "Internal"
+    virtual_network_configuration = {
+      vnet_key   = "example_vnet"
+      subnet_key = "example_subnet"
+    }
+  }
+}

--- a/modules/apim/api_management/module.tf
+++ b/modules/apim/api_management/module.tf
@@ -215,7 +215,7 @@ resource "azurerm_api_management" "apim" {
     content {
 
       subnet_id = coalesce(
-        try(each.value.subnet_id, null),
+        try(virtual_network_configuration.value.subnet_id, null),
         try(var.vnets[virtual_network_configuration.value.lz_key][virtual_network_configuration.value.vnet_key].subnets[virtual_network_configuration.value.subnet_key].id, null),
         try(var.vnets[var.client_config.landingzone_key][virtual_network_configuration.value.vnet_key].subnets[virtual_network_configuration.value.subnet_key].id, null)
       )

--- a/modules/apim/api_management/variables.tf
+++ b/modules/apim/api_management/variables.tf
@@ -1,6 +1,9 @@
 variable "global_settings" {
   description = "Global settings object (see module README.md)"
 }
+variable "vnets" {
+  description = "Virtual networks configuration object"
+} 
 variable "client_config" {
   description = "Client configuration object (see module README.md)."
 }


### PR DESCRIPTION
This PR attempts to fix the bug with the ```virtual_network_configuration``` block by declaring the ```vnets``` variable and also resolving to proper subnet id. 