### PR TITLE
Add TTL property to all records

### DIFF
--- a/examples/networking/dns_zones/100-simple-dns_zone/dns_zone_records.tfvars
+++ b/examples/networking/dns_zones/100-simple-dns_zone/dns_zone_records.tfvars
@@ -25,6 +25,15 @@ dns_zone_records = {
             "10.10.1.1", "172.10.2.2"
           ]
         }
+        example_alias = {
+          name = "example-alias"
+          ttl = 1
+          resource_id = {
+            public_ip_address = {
+              key = "example_pip1_re1"
+            }
+          }
+        }
       } //a
     }   //records
   }     //record1

--- a/modules/networking/dns_zone/records/record_a.tf
+++ b/modules/networking/dns_zone/records/record_a.tf
@@ -21,8 +21,7 @@ resource "azurerm_dns_a_record" "a_dns_zone_record" {
   name                = each.value.name
   zone_name           = var.zone_name
   resource_group_name = var.resource_group_name
-  ttl                 = try(each.value.ttl, 300)
-  # ttl                 = 300 # Looks like cannot set another value than 300 when using target_resource_id
+  ttl                 = try(each.value.ttl, 300) 
   tags                = merge(var.base_tags, try(each.value.tags, {}))
   target_resource_id  = azurerm_dns_a_record.a[each.value.resource_id.dns_zone_record.key].id
 }
@@ -37,7 +36,6 @@ resource "azurerm_dns_a_record" "a_public_ip_address" {
   zone_name           = var.zone_name
   resource_group_name = var.resource_group_name
   ttl                 = try(each.value.ttl, 300)
-  # ttl                 = 300 # Looks like cannot set another value than 300 when using target_resource_id
   tags                = merge(var.base_tags, try(each.value.tags, {}))
   target_resource_id  = var.resource_ids.public_ip_addresses[try(each.value.resource_id.public_ip_address.lz_key, var.client_config.landingzone_key)][each.value.resource_id.public_ip_address.key].id
 }

--- a/modules/networking/dns_zone/records/record_a.tf
+++ b/modules/networking/dns_zone/records/record_a.tf
@@ -21,7 +21,8 @@ resource "azurerm_dns_a_record" "a_dns_zone_record" {
   name                = each.value.name
   zone_name           = var.zone_name
   resource_group_name = var.resource_group_name
-  ttl                 = 300 # Looks like cannot set another value than 300 when using target_resource_id
+  ttl                 = try(each.value.ttl, 300)
+  # ttl                 = 300 # Looks like cannot set another value than 300 when using target_resource_id
   tags                = merge(var.base_tags, try(each.value.tags, {}))
   target_resource_id  = azurerm_dns_a_record.a[each.value.resource_id.dns_zone_record.key].id
 }
@@ -35,7 +36,8 @@ resource "azurerm_dns_a_record" "a_public_ip_address" {
   name                = each.value.name
   zone_name           = var.zone_name
   resource_group_name = var.resource_group_name
-  ttl                 = 300 # Looks like cannot set another value than 300 when using target_resource_id
+  ttl                 = try(each.value.ttl, 300)
+  # ttl                 = 300 # Looks like cannot set another value than 300 when using target_resource_id
   tags                = merge(var.base_tags, try(each.value.tags, {}))
   target_resource_id  = var.resource_ids.public_ip_addresses[try(each.value.resource_id.public_ip_address.lz_key, var.client_config.landingzone_key)][each.value.resource_id.public_ip_address.key].id
 }

--- a/modules/networking/dns_zone/records/record_aaaa.tf
+++ b/modules/networking/dns_zone/records/record_aaaa.tf
@@ -21,7 +21,7 @@ resource "azurerm_dns_aaaa_record" "aaaa_dns_zone_record" {
   name                = each.value.name
   zone_name           = var.zone_name
   resource_group_name = var.resource_group_name
-  ttl                 = 300 # Looks like cannot set another value than 300 when using target_resource_id
+  ttl                 = try(each.value.ttl, 300)   
   tags                = merge(var.base_tags, try(each.value.tags, {}))
   target_resource_id  = azurerm_dns_aaaa_record.aaaa[each.value.resource_id.dns_zone_record.key].id
 }

--- a/modules/networking/dns_zone/records/record_cname.tf
+++ b/modules/networking/dns_zone/records/record_cname.tf
@@ -21,7 +21,7 @@ resource "azurerm_dns_cname_record" "cname_dns_zone_record" {
   name                = each.value.name
   zone_name           = var.zone_name
   resource_group_name = var.resource_group_name
-  ttl                 = 300 # Looks like cannot set another value than 300 when using target_resource_id
+  ttl                 = try(each.value.ttl, 300)   
   tags                = merge(var.base_tags, try(each.value.tags, {}))
   target_resource_id  = azurerm_dns_cname_record.cname[each.value.resource_id.dns_zone_record.key].id
 }


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [X] I have added example(s) inside the [./examples/] folder
- [X] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [X] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [X] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

DNS records of type alias using resource_id reference was hard coded with ttl = 300, probably becauce of some earlier limitation. Custom ttl, example ttl = 1 is confirmed to work with dns records of type alias now.

## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Expanded existing exampl configuration for "networking/dns_zones/100-simple-dns_zone" with example_alias record with ttl=1, allready part of standalone-scenario.json.
