### PR TITLE
Add role assignments for Log Analytics

### DIFF
--- a/roles.tf
+++ b/roles.tf
@@ -119,9 +119,15 @@ locals {
     subscriptions                              = local.combined_objects_subscriptions
     synapse_workspaces                         = local.combined_objects_synapse_workspaces
     virtual_subnets                            = local.combined_objects_virtual_subnets
+    log_analytics                              = local.current_objects_log_analytics
   }
 
-
+  current_objects_log_analytics = tomap(
+    {
+      (var.current_landingzone_key) = merge(local.combined_objects_log_analytics, local.combined_diagnostics.log_analytics)
+    }
+  )
+    
   logged_in = tomap(
     {
       (var.current_landingzone_key) = {


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/1054)


## Description

This change allows role assignments to Log Analytics within current landing zone

## Does this introduce a breaking change

- [ ] YES
- [ X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->

log_analytics = {
  test = {
    region             = "region1"
    name               = "test-law"
    resource_group_key = "management"
  }
}
 role_mapping = {
   built_in_role_mapping = {
    log_analytics = { # <-- scope_resource_key
      test = {
        "Log Analytics Contributor" = {
          azuread_groups = {
            lz_key = "launchpad"
            keys = [
                     "connectivity",
                   ]
          }
        }
      }
    }
}