### PR TITLE
Rename override backend path environment variable

### DIFF
--- a/modules/networking/application_gateway_application/http_settings.tf
+++ b/modules/networking/application_gateway_application/http_settings.tf
@@ -29,7 +29,7 @@ resource "null_resource" "set_http_settings" {
       ENABLE_PROBE                = try(each.value.enable_probe, null)
       HOST_NAME                   = try(each.value.host_name, null)
       HOST_NAME_FROM_BACKEND_POOL = try(each.value.host_name_from_backend_pool, null)
-      PATH                        = try(each.value.path, null)
+      OVERRIDE_PATH               = try(each.value.path, null)
       PROBE                       = try(each.value.probe, null)
       ROOT_CERTS                  = try(each.value.root_certs, null) //TODO
     }

--- a/modules/networking/application_gateway_application/scripts/set_resource.sh
+++ b/modules/networking/application_gateway_application/scripts/set_resource.sh
@@ -92,7 +92,7 @@ case "${RESOURCE}" in
         enableprobe=$([ -z "${ENABLE_PROBE}" ] && echo "" || echo "--enable-probe ${ENABLE_PROBE} ")
         hostname=$([ -z "${HOST_NAME}" ] && echo "" || echo "--host-name ${HOST_NAME} ")
         hostnamefrombackendpool=$([ -z "${HOST_NAME_FROM_BACKEND_POOL}" ] && echo "" || echo "--host-name-from-backend-pool ${HOST_NAME_FROM_BACKEND_POOL} ")
-        path=$([ -z "${PATH}" ] && echo "" || echo "--path ${PATH} ")
+        path=$([ -z "${OVERRIDE_PATH}" ] && echo "" || echo "--path ${OVERRIDE_PATH} ")
         probe=$([ -z "${PROBE}" ] && echo "" || echo "--probe ${PROBE} ")
         rootcerts=$([ -z "${ROOT_CERTS}" ] && echo "" || echo "--root-certs ${ROOT_CERTS} ")
 


### PR DESCRIPTION
# [1058](https://github.com/aztfmod/terraform-azurerm-caf/issues/1058)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Environment variable used for override backend path setting collides with unix system PATH variable. Renamed the environment variable.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
