### PR TITLE
Add support for key_vault_reference_identity_id with MSI for App Service

### DIFF
--- a/modules/webapps/appservice/module.tf
+++ b/modules/webapps/appservice/module.tf
@@ -33,6 +33,8 @@ resource "azurerm_app_service" "app_service" {
     }
   }
 
+  key_vault_reference_identity_id = can(var.settings.key_vault_reference_identity.key) ? var.combined_objects.managed_identities[try(var.settings.identity.lz_key, var.client_config.landingzone_key)][var.settings.key_vault_reference_identity.key].id : try(var.settings.key_vault_reference_identity.id, null)
+  
   dynamic "site_config" {
     for_each = lookup(var.settings, "site_config", {}) != {} ? [1] : []
 

--- a/modules/webapps/appservice/slot.tf
+++ b/modules/webapps/appservice/slot.tf
@@ -19,10 +19,12 @@ resource "azurerm_app_service_slot" "slots" {
 
     content {
       type         = try(var.identity.type, null)
-      identity_ids = try(var.identity.identity_ids, null)
+      identity_ids = lower(var.identity.type) == "userassigned" ? local.managed_identities : null
     }
   }
 
+  key_vault_reference_identity_id = can(var.settings.key_vault_reference_identity.key) ? var.combined_objects.managed_identities[try(var.settings.identity.lz_key, var.client_config.landingzone_key)][var.settings.key_vault_reference_identity.key].id : try(var.settings.key_vault_reference_identity.id, null)
+  
   dynamic "site_config" {
     for_each = lookup(var.settings, "site_config", {}) != {} ? [1] : []
 


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/1077)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

When using a managed identity with a slot, the code differed from the main module. The fix I've introduced is a direct copy from the main module code to the slot module. This fixes this bug.

added support for `key_vault_reference_identity_id `. 
Using a user-assigned managed identity to retrieve keyvault secrets is now enabled.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

## Testing

Add the following to the `webapp.tfvars`:

```
settings = {
      enabled = true
      key_vault_reference_identity = {
        key = "managed_identity_key"
      }
    }

    slots = {
      staging = {
        name = "staging"
        identity = {
          type = "UserAssigned"
          identity_ids = ["managed_identity_key"]
        }
      }
    }
```