### PR TITLE
Subnet ID has to be optional for App Service

### DIFF
--- a/examples/webapps/appservice/109-appservice-appgw/configuration.tfvars
+++ b/examples/webapps/appservice/109-appservice-appgw/configuration.tfvars
@@ -150,15 +150,23 @@ app_services = {
 
     settings = {
       enabled = true
-      ip_restriction = [
-        {
-          name = "appgw-access"
-          virtual_network_subnet = {
-            vnet_key   = "webapp_appgw"
-            subnet_key = "appgw"
+      site_config = {
+        ip_restriction = [
+          {
+            name        = "appgw-access-by-service-tag"
+            priority    = 100
+            service_tag = "AzureCloud"
+          },
+          {
+            name     = "appgw-access-by-subnet"
+            priority = 101
+            virtual_network_subnet = {
+              vnet_key   = "webapp_appgw"
+              subnet_key = "appgw"
+            }
           }
-        }
-      ]
+        ]
+      }
     }
   }
 }

--- a/modules/webapps/appservice/module.tf
+++ b/modules/webapps/appservice/module.tf
@@ -74,7 +74,7 @@ resource "azurerm_app_service" "app_service" {
         content {
           ip_address                = lookup(ip_restriction.value, "ip_address", null)
           service_tag               = lookup(ip_restriction.value, "service_tag", null)
-          virtual_network_subnet_id = can(ip_restriction.value.virtual_network_subnet_id) || can(ip_restriction.value.virtual_network_subnet.id) ? try(ip_restriction.value.virtual_network_subnet_id, ip_restriction.value.virtual_network_subnet.id) : var.combined_objects.networking[try(ip_restriction.value.virtual_network_subnet.lz_key, var.client_config.landingzone_key)][ip_restriction.value.virtual_network_subnet.vnet_key].subnets[ip_restriction.value.virtual_network_subnet.subnet_key].id
+          virtual_network_subnet_id = can(ip_restriction.value.virtual_network_subnet_id) || can(ip_restriction.value.virtual_network_subnet.id) ? try(ip_restriction.value.virtual_network_subnet_id, ip_restriction.value.virtual_network_subnet.id) : try(var.combined_objects.networking[try(ip_restriction.value.virtual_network_subnet.lz_key, var.client_config.landingzone_key)][ip_restriction.value.virtual_network_subnet.vnet_key].subnets[ip_restriction.value.virtual_network_subnet.subnet_key].id, null)
           name                      = lookup(ip_restriction.value, "name", null)
           priority                  = lookup(ip_restriction.value, "priority", null)
           action                    = lookup(ip_restriction.value, "action", null)

--- a/modules/webapps/appservice/module.tf
+++ b/modules/webapps/appservice/module.tf
@@ -74,7 +74,7 @@ resource "azurerm_app_service" "app_service" {
         content {
           ip_address                = lookup(ip_restriction.value, "ip_address", null)
           service_tag               = lookup(ip_restriction.value, "service_tag", null)
-          virtual_network_subnet_id = can(ip_restriction.value.virtual_network_subnet_id) || can(ip_restriction.value.virtual_network_subnet.id) ? try(ip_restriction.value.virtual_network_subnet_id, ip_restriction.value.virtual_network_subnet.id) : try(var.combined_objects.networking[try(ip_restriction.value.virtual_network_subnet.lz_key, var.client_config.landingzone_key)][ip_restriction.value.virtual_network_subnet.vnet_key].subnets[ip_restriction.value.virtual_network_subnet.subnet_key].id, null)
+          virtual_network_subnet_id = can(ip_restriction.value.virtual_network_subnet_id) || can(ip_restriction.value.virtual_network_subnet.id) || can(ip_restriction.value.virtual_network_subnet.subnet_key) == false ? try(ip_restriction.value.virtual_network_subnet_id, ip_restriction.value.virtual_network_subnet.id, null) : var.combined_objects.networking[try(ip_restriction.value.virtual_network_subnet.lz_key, var.client_config.landingzone_key)][ip_restriction.value.virtual_network_subnet.vnet_key].subnets[ip_restriction.value.virtual_network_subnet.subnet_key].id
           name                      = lookup(ip_restriction.value, "name", null)
           priority                  = lookup(ip_restriction.value, "priority", null)
           action                    = lookup(ip_restriction.value, "action", null)


### PR DESCRIPTION
# [#1081](https://github.com/aztfmod/terraform-azurerm-caf/issues/1081)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [X] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [X] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [X] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

IP restriction could be set via IP Adress or Service Tag or Subnet ID, so Subnet ID has also to be optional. 

## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

```
module.azure.random_string.prefix[0]: Refreshing state... [id=shgm]
module.azure.module.resource_groups["webapp_appgw"].azurecaf_name.rg: Refreshing state... [id=ekojyhoctennqcqe]
module.azure.module.app_service_plans["asp_webapp_appgw"].azurecaf_name.plan: Refreshing state... [id=himyqetuvwsxcjcv]
module.azure.azurecaf_name.public_ip_addresses["pip_appgw"]: Refreshing state... [id=ubpyqnpokmtxcljn]
module.azure.module.resource_groups["webapp_appgw"].azurerm_resource_group.rg: Refreshing state... [id=/subscriptions/9f6c4025-c3e6-4d11-910a-572becb77452/resourceGroups/module-test-rg-webapp-appgw]
module.azure.module.networking["webapp_appgw"].module.subnets["appgw"].azurecaf_name.subnet: Refreshing state... [id=wpglonyiljlkausl]
module.azure.module.networking["webapp_appgw"].azurecaf_name.caf_name_vnet: Refreshing state... [id=edxjtskdttisgcgj]
module.azure.module.public_ip_addresses["pip_appgw"].azurerm_public_ip.pip: Refreshing state... [id=/subscriptions/9f6c4025-c3e6-4d11-910a-572becb77452/resourceGroups/module-test-rg-webapp-appgw/providers/Microsoft.Network/publicIPAddresses/module-test-pip-pip-appgw]
module.azure.module.networking["webapp_appgw"].module.subnets["webapp"].azurecaf_name.subnet: Refreshing state... [id=lsaghslivlnvadvn]
module.azure.module.networking["webapp_appgw"].azurerm_virtual_network.vnet: Refreshing state... [id=/subscriptions/9f6c4025-c3e6-4d11-910a-572becb77452/resourceGroups/module-test-rg-webapp-appgw/providers/Microsoft.Network/virtualNetworks/module-test-vnet-webapp-appgw]
module.azure.module.networking["webapp_appgw"].module.subnets["appgw"].azurerm_subnet.subnet: Refreshing state... [id=/subscriptions/9f6c4025-c3e6-4d11-910a-572becb77452/resourceGroups/module-test-rg-webapp-appgw/providers/Microsoft.Network/virtualNetworks/module-test-vnet-webapp-appgw/subnets/module-test-snet-appgw]
module.azure.module.networking["webapp_appgw"].module.subnets["webapp"].azurerm_subnet.subnet: Refreshing state... [id=/subscriptions/9f6c4025-c3e6-4d11-910a-572becb77452/resourceGroups/module-test-rg-webapp-appgw/providers/Microsoft.Network/virtualNetworks/module-test-vnet-webapp-appgw/subnets/module-test-snet-webapp]
module.azure.module.app_services["webapp_appgw"].azurecaf_name.app_service: Refreshing state... [id=quweigjxowpmbpop]
module.azure.module.app_service_plans["asp_webapp_appgw"].azurerm_app_service_plan.asp: Refreshing state... [id=/subscriptions/9f6c4025-c3e6-4d11-910a-572becb77452/resourceGroups/module-test-rg-webapp-appgw/providers/Microsoft.Web/serverfarms/module-test-plan-asp-webapp-appgw]
module.azure.module.application_gateways["appgw_webapp"].azurecaf_name.agw: Refreshing state... [id=kbjuptcbjuhgbxqd]
module.azure.module.app_services["webapp_appgw"].azurerm_app_service.app_service: Refreshing state... [id=/subscriptions/9f6c4025-c3e6-4d11-910a-572becb77452/resourceGroups/module-test-rg-webapp-appgw/providers/Microsoft.Web/sites/module-test-app-webapp-appgw]
module.azure.azurerm_app_service_virtual_network_swift_connection.vnet_config["webapp_appgw"]: Refreshing state... [id=/subscriptions/9f6c4025-c3e6-4d11-910a-572becb77452/resourceGroups/module-test-rg-webapp-appgw/providers/Microsoft.Web/sites/module-test-app-webapp-appgw/config/virtualNetwork]
module.azure.module.application_gateways["appgw_webapp"].azurerm_application_gateway.agw: Refreshing state... [id=/subscriptions/9f6c4025-c3e6-4d11-910a-572becb77452/resourceGroups/module-test-rg-webapp-appgw/providers/Microsoft.Network/applicationGateways/module-test-agw-appgw-webapp]
```
