### PR TITLE
Add Private Endpoint support for Purview Managed Resources (needs azu…

### DIFF
--- a/examples/purview/101-purview_account_private_link/configuration.tfvars
+++ b/examples/purview/101-purview_account_private_link/configuration.tfvars
@@ -51,17 +51,65 @@ purview_accounts = {
         }
       }
     }
+    # Requires azurerm >= 2.92.0
+    managed_resources_private_endpoints = {
+      blob = {
+        name               = "blob"
+        resource_group_key = "rg1"
+        vnet_key           = "vnet"
+        subnet_key         = "servicesSubnetName"
+        private_service_connection = {
+          name                 = "blob"
+          is_manual_connection = false
+          subresource_names    = ["blob"]
+        }
+        private_dns = {
+          zone_group_name = "default"
+          keys            = ["privatelink.blob.core.windows.net"]
+        }
+      }
+      queue = {
+        name               = "queue"
+        resource_group_key = "rg1"
+        vnet_key           = "vnet"
+        subnet_key         = "servicesSubnetName"
+        private_service_connection = {
+          name                 = "queue"
+          is_manual_connection = false
+          subresource_names    = ["queue"]
+        }
+        private_dns = {
+          zone_group_name = "default"
+          keys            = ["privatelink.queue.core.windows.net"]
+        }
+      }
+      eventhub = {
+        name               = "eventhub"
+        resource_group_key = "rg1"
+        vnet_key           = "vnet"
+        subnet_key         = "servicesSubnetName"
+        private_service_connection = {
+          name                 = "eventhub"
+          is_manual_connection = false
+          subresource_names    = ["namespace"]
+        }
+        private_dns = {
+          zone_group_name = "default"
+          keys            = ["privatelink.servicebus.windows.net"]
+        }
+      }
+    }
   }
 }
 
 keyvaults = {
   kv = {
-    name                        = "kv"
-    resource_group_key          = "rg1"
-    sku_name                    = "standard"
-    enable_rbac_authorization   = true
-    soft_delete_enabled         = true
-    purge_protection_enabled    = true
+    name                      = "kv"
+    resource_group_key        = "rg1"
+    sku_name                  = "standard"
+    enable_rbac_authorization = true
+    soft_delete_enabled       = true
+    purge_protection_enabled  = true
     tags = {
       env = "Standalone"
     }
@@ -142,13 +190,56 @@ private_dns = {
   "privatelink.purview.azure.com" = {
     name               = "privatelink.purview.azure.com"
     resource_group_key = "rg1"
+    vnet_links = {
+      vnet_link_pl = {
+        name     = "vnet_link"
+        vnet_key = "vnet"
+        #lz_key   = "connectivity_private_dns_firewalls_prod"
+      }
+    }
   }
   "privatelink.purviewstudio.azure.com" = {
     name               = "privatelink.purviewstudio.azure.com"
     resource_group_key = "rg1"
+    vnet_links = {
+      vnet_link_pl = {
+        name     = "vnet_link"
+        vnet_key = "vnet"
+        #lz_key   = "connectivity_private_dns_firewalls_prod"
+      }
+    }
   }
-  "privatelink.vaultcore.azure.net" = {
-    name               = "privatelink.vaultcore.azure.net"
+  "privatelink.queue.core.windows.net" = {
+    name               = "privatelink.queue.core.windows.net"
     resource_group_key = "rg1"
+    vnet_links = {
+      vnet_link_pl = {
+        name     = "vnet_link"
+        vnet_key = "vnet"
+        #lz_key   = "connectivity_private_dns_firewalls_prod"
+      }
+    }
+  }
+  "privatelink.blob.core.windows.net" = {
+    name               = "privatelink.blob.core.windows.net"
+    resource_group_key = "rg1"
+    vnet_links = {
+      vnet_link_pl = {
+        name     = "vnet_link"
+        vnet_key = "vnet"
+        #lz_key   = "connectivity_private_dns_firewalls_prod"
+      }
+    }
+  }
+  "privatelink.servicebus.windows.net" = {
+    name               = "privatelink.servicebus.windows.net"
+    resource_group_key = "rg1"
+    vnet_links = {
+      vnet_link_pl = {
+        name     = "vnet_link"
+        vnet_key = "vnet"
+        #lz_key   = "connectivity_private_dns_firewalls_prod"
+      }
+    }
   }
 }

--- a/modules/purview/purview_accounts/private_endpoints.tf
+++ b/modules/purview/purview_accounts/private_endpoints.tf
@@ -19,3 +19,20 @@ module "private_endpoint" {
   settings            = each.value
   subnet_id           = var.remote_objects.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
 }
+
+# Requires azurerm >=2.92.0
+module "managed_resources_private_endpoints" {
+  source   = "../../networking/private_endpoint"
+  for_each = try(var.settings.managed_resources_private_endpoints, {})
+
+  base_tags           = try(merge(var.base_tags, each.value.tags), {})
+  client_config       = var.client_config
+  global_settings     = var.global_settings
+  location            = var.remote_objects.resource_group[var.client_config.landingzone_key][try(each.value.resource_group.key, each.value.resource_group_key)].location
+  name                = each.value.name
+  private_dns         = var.private_dns
+  resource_group_name = var.remote_objects.resource_group[var.client_config.landingzone_key][try(each.value.resource_group.key, each.value.resource_group_key)].name
+  resource_id         = each.value.name == "eventhub" ? azurerm_purview_account.pva.managed_resources[0].event_hub_namespace_id : azurerm_purview_account.pva.managed_resources[0].storage_account_id
+  settings            = each.value
+  subnet_id           = var.remote_objects.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+}


### PR DESCRIPTION
…rerm 2.92.0)

# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ Yes] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [Yes] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ Yes] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->
Module does not currently support creation of Private Endpoints for Purview Managed Resources (blob, queue, Event Hub).

This PR enables the use of a new settings map on the purview_accounts object named managed_resources_private_endpoints to facilitate the creation of the Private Endpoints for Purview Managed Resources.
azurerm provider must be upgraded to >= 2.92.0 
## Does this introduce a breaking change

- [ ] YES
- [ ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
