### PR TITLE
Update image_uri for legacy VM creation method

### DIFF
--- a/modules/compute/virtual_machine/vm_legacy.tf
+++ b/modules/compute/virtual_machine/vm_legacy.tf
@@ -147,7 +147,7 @@ resource "azurerm_virtual_machine" "vm" {
     name                      = try(each.value.os_disk.name, null)
     write_accelerator_enabled = try(each.value.os_disk.write_accelerator_enabled, false)
     create_option             = each.value.os_disk.create_option
-    image_uri                 = try(each.value.image_uri.publisher, null)
+    image_uri                 = try(each.value.image_uri, null)
     os_type                   = try(each.value.os_disk.operating_system, null)
     managed_disk_id           = try(each.value.os_disk.managed_disk_id, null)
     managed_disk_type         = try(each.value.os_disk.managed_disk_type, null)

--- a/modules/compute/virtual_machine/vm_legacy.tf
+++ b/modules/compute/virtual_machine/vm_legacy.tf
@@ -147,7 +147,7 @@ resource "azurerm_virtual_machine" "vm" {
     name                      = try(each.value.os_disk.name, null)
     write_accelerator_enabled = try(each.value.os_disk.write_accelerator_enabled, false)
     create_option             = each.value.os_disk.create_option
-    image_uri                 = try("${each.value.storage_image_reference.publisher}:${each.value.storage_image_reference.offer}:${each.value.storage_image_reference.sku}:${each.value.storage_image_reference.version}", null)
+    image_uri                 = try(each.value.image_uri.publisher, null)
     os_type                   = try(each.value.os_disk.operating_system, null)
     managed_disk_id           = try(each.value.os_disk.managed_disk_id, null)
     managed_disk_type         = try(each.value.os_disk.managed_disk_type, null)


### PR DESCRIPTION
changed to `try(each.value.image_uri.publisher, null)`

# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description
Fixes issues when Market place image has a predefined OS + Data disk.
<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [ ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
