### PR TITLE
Adds support for defining diagnostic profiles to the data factory module

### DIFF
--- a/data_factory.tf
+++ b/data_factory.tf
@@ -3,12 +3,14 @@ module "data_factory" {
   source   = "./modules/data_factory/data_factory"
   for_each = local.data_factory.data_factory
 
-  global_settings = local.global_settings
-  client_config   = local.client_config
-  settings        = each.value
-  location        = can(local.global_settings.regions[each.value.region]) ? local.global_settings.regions[each.value.region] : local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].location
-  base_tags       = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].tags : {}
-  resource_groups = local.combined_objects_resource_groups
+  global_settings     = local.global_settings
+  client_config       = local.client_config
+  settings            = each.value
+  diagnostics         = local.combined_diagnostics
+  diagnostic_profiles = try(each.value.diagnostic_profiles, {})
+  location            = can(local.global_settings.regions[each.value.region]) ? local.global_settings.regions[each.value.region] : local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].location
+  base_tags           = try(local.global_settings.inherit_tags, false) ? local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].tags : {}
+  resource_groups     = local.combined_objects_resource_groups
 
   remote_objects = {
     managed_identities = local.combined_objects_managed_identities

--- a/examples/data_factory/117-data_factory_diagnostics/configuration.tfvars
+++ b/examples/data_factory/117-data_factory_diagnostics/configuration.tfvars
@@ -1,0 +1,74 @@
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "australiaeast"
+  }
+}
+
+resource_groups = {
+  rg1 = {
+    name   = "example"
+    region = "region1"
+  }
+}
+
+diagnostic_log_analytics = {
+  central_logs_region1 = {
+    region             = "region1"
+    name               = "logs"
+    resource_group_key = "rg1"
+  }
+}
+
+diagnostics_destinations = {
+  # Storage keys must reference the azure region name
+  log_analytics = {
+    central_logs = {
+      log_analytics_key = "central_logs_region1"
+    }
+  }
+}
+
+diagnostic_settings = {
+  azure_data_factory = {
+    name = "operational_logs_and_metrics"
+    categories = {
+      log = [
+        # ["Category name",  "Diagnostics Enabled(true/false)", "Retention Enabled(true/false)", Retention_period]
+        ["ActivityRuns", true, false, 7],
+        ["PipelineRuns", true, false, 7],
+        ["TriggerRuns", true, false, 7],
+        ["SandboxPipelineRuns", true, false, 7],
+        ["SandboxActivityRuns", true, false, 7],
+        ["SSISPackageEventMessages", true, false, 7],
+        ["SSISPackageExecutableStatistics", true, false, 7],
+        ["SSISPackageEventMessageContext", true, false, 7],
+        ["SSISPackageExecutionComponentPhases", true, false, 7],
+        ["SSISPackageExecutionDataStatistics", true, false, 7],
+        ["SSISIntegrationRuntimeLogs", true, false, 7],
+      ]
+      metric = [
+        #["Category name",  "Diagnostics Enabled(true/false)", "Retention Enabled(true/false)", Retention_period]
+        ["AllMetrics", true, false, 7],
+      ]
+    }
+  }
+}
+
+data_factory = {
+  df1 = {
+    name = "example"
+    resource_group = {
+      key = "rg1"
+      #lz_key = ""
+      #name = ""
+    }
+  }
+  diagnostic_profiles = {
+    central_logs_region1 = {
+      definition_key   = "azure_data_factory"
+      destination_type = "log_analytics"
+      destination_key  = "central_logs"
+    }
+  }
+}

--- a/modules/data_factory/data_factory/diagnostics.tf
+++ b/modules/data_factory/data_factory/diagnostics.tf
@@ -1,0 +1,8 @@
+module "diagnostics" {
+  source = "../../diagnostics"
+
+  resource_id       = azurerm_data_factory.df.id
+  resource_location = local.location
+  diagnostics       = var.diagnostics
+  profiles          = var.diagnostic_profiles
+}

--- a/modules/data_factory/data_factory/variables.tf
+++ b/modules/data_factory/data_factory/variables.tf
@@ -21,6 +21,12 @@ variable "base_tags" {
   type        = map(any)
 }
 variable "settings" {}
+variable "diagnostic_profiles" {
+  default = {}
+}
+variable "diagnostics" {
+  default = {}
+}
 variable "remote_objects" {}
 variable "tags" {
   default     = null


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ Yes] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ Yes] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ Yes] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description
Extends the data factory module to enable defining diagnostic profiles inline with the data factory resource definition.
<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [ X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
