### PR TITLE
gen2_filesystem - substitute empty map when var.settings.properties i…

### DIFF
--- a/modules/storage_account/data_lake_filesystem/gen2_filesystem.tf
+++ b/modules/storage_account/data_lake_filesystem/gen2_filesystem.tf
@@ -5,6 +5,6 @@ resource "azurerm_storage_data_lake_gen2_filesystem" "gen2" {
   name               = var.settings.name
   storage_account_id = var.storage_account_id
   properties = {
-    for key, value in try(var.settings.properties) : key => base64encode(value)
+    for key, value in try(var.settings.properties, {}) : key => base64encode(value)
   }
 }


### PR DESCRIPTION
…s null

# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [X ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ X] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description
Modifies try logic to pass empty map to the "properties" argument of the azurerm_storage_data_lake_gen2_filesystem resource.  
<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [X ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
