### PR TITLE
Bugfix add missing custom_block_response_body fallback

### DIFF
--- a/modules/networking/front_door_waf_policy/waf_policy.tf
+++ b/modules/networking/front_door_waf_policy/waf_policy.tf
@@ -6,11 +6,11 @@ resource "azurerm_frontdoor_firewall_policy" "wafpolicy" {
   mode                              = try(var.settings.mode, null)
   redirect_url                      = try(var.settings.redirect_url, null)
   custom_block_response_status_code = try(var.settings.custom_block_response_status_code, null)
-  custom_block_response_body        = try(var.settings.custom_block_response_body)
+  custom_block_response_body        = try(var.settings.custom_block_response_body, null)
   tags                              = local.tags
 
   dynamic "custom_rule" {
-    for_each = var.settings.custom_rules
+    for_each = try(var.settings.custom_rules, null)
     content {
       action                         = custom_rule.value.action
       enabled                        = try(custom_rule.value.enabled, true)
@@ -35,7 +35,7 @@ resource "azurerm_frontdoor_firewall_policy" "wafpolicy" {
   }
 
   dynamic "managed_rule" {
-    for_each = var.settings.managed_rules
+    for_each = try(var.settings.managed_rules, null)
     content {
       type    = managed_rule.value.type
       version = managed_rule.value.version

--- a/modules/networking/front_door_waf_policy/waf_policy.tf
+++ b/modules/networking/front_door_waf_policy/waf_policy.tf
@@ -10,7 +10,7 @@ resource "azurerm_frontdoor_firewall_policy" "wafpolicy" {
   tags                              = local.tags
 
   dynamic "custom_rule" {
-    for_each = try(var.settings.custom_rules, null)
+    for_each = try(var.settings.custom_rules, {})
     content {
       action                         = custom_rule.value.action
       enabled                        = try(custom_rule.value.enabled, true)
@@ -35,7 +35,7 @@ resource "azurerm_frontdoor_firewall_policy" "wafpolicy" {
   }
 
   dynamic "managed_rule" {
-    for_each = try(var.settings.managed_rules, null)
+    for_each = try(var.settings.managed_rules, {})
     content {
       type    = managed_rule.value.type
       version = managed_rule.value.version


### PR DESCRIPTION
# [1133](https://github.com/aztfmod/terraform-azurerm-caf/issues/1133)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [X ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [X] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

This change will fix missing custom_block_response_body fallback and make custom_rule/managed_rule optional instead of required.

## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
