### PR TITLE
fixes remote lz logic w/ private endpoint resource groups

### DIFF
--- a/data_factory.tf
+++ b/data_factory.tf
@@ -15,7 +15,7 @@ module "data_factory" {
     private_dns        = local.combined_objects_private_dns
     vnets              = local.combined_objects_networking
     private_endpoints  = try(each.value.private_endpoints, {})
-    resource_groups    = try(each.value.private_endpoints, {}) == {} ? null : local.resource_groups
+    resource_groups    = try(each.value.private_endpoints, {}) == {} ? null : local.combined_objects_resource_groups
   }
 
 

--- a/modules/data_factory/data_factory/private_endpoints.tf
+++ b/modules/data_factory/data_factory/private_endpoints.tf
@@ -2,14 +2,14 @@ module "private_endpoint" {
   source   = "../../networking/private_endpoint"
   for_each = var.remote_objects.private_endpoints
 
-  resource_id     = azurerm_data_factory.df.id
-  name            = each.value.name
-  resource_groups = var.resource_groups
-  location        = var.location
-  subnet_id       = var.remote_objects.vnets[try(var.client_config.landingzone_key, each.value.lz_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
-  settings        = each.value
-  global_settings = var.global_settings
-  base_tags       = var.base_tags
-  private_dns     = var.remote_objects.private_dns
-  client_config   = var.client_config
+  resource_id         = azurerm_data_factory.df.id
+  name                = each.value.name
+  resource_group_name = var.remote_objects.resource_groups[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.resource_group_key].name
+  location            = var.location
+  subnet_id           = var.remote_objects.vnets[try(var.client_config.landingzone_key, each.value.lz_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+  settings            = each.value
+  global_settings     = var.global_settings
+  base_tags           = var.base_tags
+  private_dns         = var.remote_objects.private_dns
+  client_config       = var.client_config
 }


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ Yes ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ Yes ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Passing local.resource_groups at root data_factory module prevents downstream selection of remote landing zone (and also causes downstream logic depending on lz_key / landingzone_key to fail).  

At root data_factory module:
- Pass local.combined_objects_resource_groups as remote object vs local.resource_groups

At modules/data_factory/data_factory/private_endpoint:
- Set target resource group name for private endpoint based on lz_key & resource group key

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [ X ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
