### PR TITLE
Migrate VMSS from azurerm_virtual_machine_scaleset

### DIFF
--- a/modules/compute/virtual_machine_scale_set/dynamic_custom_data.tf
+++ b/modules/compute/virtual_machine_scale_set/dynamic_custom_data.tf
@@ -1,0 +1,9 @@
+locals {
+  dynamic_custom_data = {
+    palo_alto_connection_string = {
+      for item in var.settings.vmss_settings :
+      item.name => base64encode("storage-account=${var.storage_accounts[var.client_config.landingzone_key][item.palo_alto_connection_string.storage_account].name}, access-key=${var.storage_accounts[var.client_config.landingzone_key][item.palo_alto_connection_string.storage_account].primary_access_key}, file-share=${var.storage_accounts[var.client_config.landingzone_key][item.palo_alto_connection_string.storage_account].file_share[item.palo_alto_connection_string.file_share].name}, share-directory=${var.storage_accounts[var.client_config.landingzone_key][item.palo_alto_connection_string.storage_account].file_share[item.palo_alto_connection_string.file_share].file_share_directories[item.palo_alto_connection_string.file_share_directory].name}")
+      if try(item.palo_alto_connection_string, null) != null
+    }
+  }
+}

--- a/modules/compute/virtual_machine_scale_set/variables.tf
+++ b/modules/compute/virtual_machine_scale_set/variables.tf
@@ -73,3 +73,7 @@ variable "image_definitions" {
 variable "disk_encryption_sets" {}
 
 variable "load_balancers" {}
+
+variable "storage_accounts" {
+  default = {}
+}

--- a/virtual_machines_scale_sets.tf
+++ b/virtual_machines_scale_sets.tf
@@ -35,6 +35,7 @@ module "virtual_machine_scale_sets" {
   public_ip_addresses              = local.combined_objects_public_ip_addresses
   recovery_vaults                  = local.combined_objects_recovery_vaults
   settings                         = each.value
+  storage_accounts                 = local.combined_objects_storage_accounts    
   vnets                            = local.combined_objects_networking
   location                         = can(local.global_settings.regions[each.value.region]) ? local.global_settings.regions[each.value.region] : local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].location
   resource_group_name              = can(each.value.resource_group.name) || can(each.value.resource_group_name) ? try(each.value.resource_group.name, each.value.resource_group_name) : local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group_key, each.value.resource_group.key)].name


### PR DESCRIPTION
PR Focuses on migration of older / legacy virtual machine scale set module for Linux. Also updated custom_data value to match linux virtual machine. Required to support Palo Alto NVA scale sets