### PR TITLE
Multiple diagnostics destinations

### DIFF
--- a/.github/workflows/standalone-scenarios.json
+++ b/.github/workflows/standalone-scenarios.json
@@ -89,6 +89,7 @@
     "databricks/101-standard-databricks-vnet",
     "databricks/102-premium-aml",
     "datalake/101-datalake-storage",
+    "diagnostics_profiles/100-multiple-destinations",
     "diagnostics_profiles/200-diagnostics-eventhub-namespaces",
     "diagnostics_profiles/201-multi-eventhub-diagnostics",
     "eventhub/100-simple-eventhub-namespace",

--- a/documentation/conventions.md
+++ b/documentation/conventions.md
@@ -175,7 +175,7 @@ For each resource, the variable ```diagnostic_profiles``` will be used to store 
 diagnostic_profiles = {
       central_logs_region1 = {
         definition_key   = "azure_kubernetes_cluster"
-        destination_type = "log_analytics"
+        destination_type = "log_analytics" # Can be either a string (allowed values "log_analytics", "storage" or "event_hub") or a list of strings (combination of "log_analytics", "storage", "event_hub", no repeat)
         destination_key  = "central_logs"
       }
     }

--- a/examples/diagnostics_profiles/100-multiple-destinations/configuration.tfvars
+++ b/examples/diagnostics_profiles/100-multiple-destinations/configuration.tfvars
@@ -1,0 +1,12 @@
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "australiaeast"
+  }
+}
+
+resource_groups = {
+  ops = {
+    name = "operations"
+  }
+}

--- a/examples/diagnostics_profiles/100-multiple-destinations/diagnostics.tfvars
+++ b/examples/diagnostics_profiles/100-multiple-destinations/diagnostics.tfvars
@@ -1,0 +1,37 @@
+diagnostic_log_analytics = {
+  central_logs_region1 = {
+    name               = "logs"
+    resource_group_key = "ops"
+    region             = "region1"
+  }
+}
+
+diagnostic_storage_accounts = {
+  dsa1_region1 = {
+    name                     = "diaglogsregion1"
+    region                   = "region1"
+    resource_group_key       = "ops"
+    account_kind             = "StorageV2" # BlobStorage, Storage, StorageV2, BlockBlobStorage, FileStorage
+    account_tier             = "Standard"  # Standard, Premium. For BlockBlobStorage and FileStorage accounts only Premium is valid.
+    account_replication_type = "LRS"       # LRS, GRS, RAGRS, ZRS, GZRS and RAGZRS
+    tags                     = {}
+    enable_system_msi        = true
+  }
+}
+
+diagnostic_event_hub_namespaces = {
+
+  central_logs_region1 = {
+    name               = "centrallogs"
+    resource_group_key = "ops"
+    sku                = "Standard"
+    region             = "region1"
+    event_hubs = {
+      hub1 = {
+        name              = "eventhub1"
+        partition_count   = 4
+        message_retention = 7
+      }
+    }
+  }
+}

--- a/examples/diagnostics_profiles/100-multiple-destinations/diagnostics_definition.tfvars
+++ b/examples/diagnostics_profiles/100-multiple-destinations/diagnostics_definition.tfvars
@@ -1,0 +1,16 @@
+diagnostics_definition = {
+  keyvault = {
+    name = "operational_logs_and_metrics"
+    categories = {
+      log = [
+        # ["Category name",  "Diagnostics Enabled(true/false)", "Retention Enabled(true/false)", Retention_period]
+        ["AuditEvent", true, false, 14],
+        ["AzurePolicyEvaluationDetails", true, false, 14],
+      ]
+      metric = [
+        #["Category name",  "Diagnostics Enabled(true/false)", "Retention Enabled(true/false)", Retention_period]
+        ["AllMetrics", true, false, 7],
+      ]
+    }
+  }
+}

--- a/examples/diagnostics_profiles/100-multiple-destinations/diagnostics_destinations.tfvars
+++ b/examples/diagnostics_profiles/100-multiple-destinations/diagnostics_destinations.tfvars
@@ -1,0 +1,21 @@
+diagnostics_destinations = {
+  event_hub_namespaces = {
+    central_logs = {
+      event_hub_namespace_key = "central_logs_region1"
+    }
+  }
+
+  log_analytics = {
+    central_logs = {
+      log_analytics_key              = "central_logs_region1"
+      log_analytics_destination_type = "Dedicated"
+    }
+  }
+  storage = {
+    central_logs = {
+      australiaeast = {
+        storage_account_key = "dsa1_region1"
+      }
+    }
+  }
+}

--- a/examples/diagnostics_profiles/100-multiple-destinations/keyvaults.tfvars
+++ b/examples/diagnostics_profiles/100-multiple-destinations/keyvaults.tfvars
@@ -1,0 +1,33 @@
+keyvaults = {
+
+  kv1 = {
+    name               = "kv"
+    resource_group_key = "rg1"
+    sku_name           = "standard"
+    # Make sure you set a creation policy.
+    creation_policies = {
+      logged_in_user = {
+        secret_permissions      = ["Set", "Get", "List", "Delete", "Purge"]
+        certificate_permissions = ["managecontacts", "manageissuers"]
+      }
+    }
+
+    network = {
+      bypass         = "AzureServices"
+      default_action = "Allow"
+    }
+    diagnostic_profiles = {
+      log_analytics = {
+        name             = "operational_logs_and_metrics"
+        definition_key   = "keyvault"
+        destination_type = ["log_analytics", "event_hub", "storage"]
+        destination_key  = "central_logs"
+      }
+    }
+  }
+}
+
+provider_azurerm_features_keyvault = {
+  // set to true to cleanup the CI
+  purge_soft_delete_on_destroy = true
+}

--- a/modules/diagnostics/module.tf
+++ b/modules/diagnostics/module.tf
@@ -8,22 +8,22 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostics" {
   name               = try(format("%s%s", try(var.global_settings.prefix_with_hyphen, ""), each.value.name), format("%s%s", try(var.global_settings.prefix_with_hyphen, ""), var.diagnostics.diagnostics_definition[each.value.definition_key].name))
   target_resource_id = var.resource_id
 
-  eventhub_name = each.value.destination_type == "event_hub" ? try(
+  eventhub_name = contains(try([tostring(each.value.destination_type)], tolist(each.value.destination_type)), "event_hub") ? try(
     var.diagnostics.event_hub_namespaces[var.diagnostics.diagnostics_destinations.event_hub_namespaces[each.value.destination_key].event_hub_namespace_key].event_hubs[each.value.event_hub_key].name,
     var.diagnostics.event_hub_namespaces[var.diagnostics.diagnostics_destinations.event_hub_namespaces[each.value.destination_key].event_hub_namespace_key].name,
     each.value.eventhub_name,
     null
   ) : null
 
-  eventhub_authorization_rule_id = each.value.destination_type == "event_hub" ? coalesce(
+  eventhub_authorization_rule_id = contains(try([tostring(each.value.destination_type)], tolist(each.value.destination_type)), "event_hub") ? coalesce(
     try(each.value.eventhub_authorization_rule_id, null),
     try(format("%s/authorizationRules/RootManageSharedAccessKey", var.diagnostics.event_hub_namespaces[var.diagnostics.diagnostics_destinations.event_hub_namespaces[each.value.destination_key].event_hub_namespace_key].id), null)
   ) : null
 
-  log_analytics_workspace_id     = each.value.destination_type == "log_analytics" ? try(var.diagnostics.diagnostics_destinations.log_analytics[each.value.destination_key].log_analytics_resource_id, var.diagnostics.log_analytics[var.diagnostics.diagnostics_destinations.log_analytics[each.value.destination_key].log_analytics_key].id) : null
-  log_analytics_destination_type = each.value.destination_type == "log_analytics" ? lookup(var.diagnostics.diagnostics_definition[each.value.definition_key], "log_analytics_destination_type", null) : null
+  log_analytics_workspace_id     = contains(try([tostring(each.value.destination_type)], tolist(each.value.destination_type)), "log_analytics") ? try(var.diagnostics.diagnostics_destinations.log_analytics[each.value.destination_key].log_analytics_resource_id, var.diagnostics.log_analytics[var.diagnostics.diagnostics_destinations.log_analytics[each.value.destination_key].log_analytics_key].id) : null
+  log_analytics_destination_type = contains(try([tostring(each.value.destination_type)], tolist(each.value.destination_type)), "log_analytics") ? lookup(var.diagnostics.diagnostics_definition[each.value.definition_key], "log_analytics_destination_type", null) : null
 
-  storage_account_id = each.value.destination_type == "storage" ? try(var.diagnostics.diagnostics_destinations.storage[each.value.destination_key][var.resource_location].storage_account_resource_id, var.diagnostics.storage_accounts[var.diagnostics.diagnostics_destinations.storage[each.value.destination_key][var.resource_location].storage_account_key].id) : null
+  storage_account_id = contains(try([tostring(each.value.destination_type)], tolist(each.value.destination_type)), "storage") ? try(var.diagnostics.diagnostics_destinations.storage[each.value.destination_key][var.resource_location].storage_account_resource_id, var.diagnostics.storage_accounts[var.diagnostics.diagnostics_destinations.storage[each.value.destination_key][var.resource_location].storage_account_key].id) : null
 
   dynamic "log" {
     for_each = lookup(var.diagnostics.diagnostics_definition[each.value.definition_key].categories, "log", {})


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/1151)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ x] I have added example(s) inside the [./examples/] folder
- [ x] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

It is not possible to have multiple destinations types within 1 profile

Now it is possible to have multiple destination type but all with the same destination.

## Does this introduce a breaking change

- [ ] YES
- [ x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->

```hcl
diagnostic_profiles = {
  log_analytics = {
    name             = "operational_logs_and_metrics"
    definition_key   = "keyvault"
    destination_type = "log_analytics"
    destination_key  = "central_logs"
  }
}
```

```hcl
diagnostic_profiles = {
  log_analytics = {
    name             = "operational_logs_and_metrics"
    definition_key   = "keyvault"
    destination_type = ["log_analytics", "event_hub", "storage"]
    destination_key  = "central_logs"
  }
}
```
