### PR TITLE
Make azuread_groups_membership module landingzone aware

### DIFF
--- a/azuread_groups.tf
+++ b/azuread_groups.tf
@@ -38,7 +38,7 @@ module "azuread_groups_membership" {
   client_config              = local.client_config
   group_key                  = each.key
   settings                   = each.value
-  group_id                   = try(module.azuread_groups[each.key].id, null)
+  group_id                   = try(module.azuread_groups[each.key].id, local.combined_objects_azuread_groups[each.value.group_lz_key][each.key].id)
   azuread_groups             = local.combined_objects_azuread_groups
   azuread_service_principals = local.combined_objects_azuread_service_principals
   managed_identities         = local.combined_objects_managed_identities

--- a/examples/azuread/104-azuread-group-membership/configuration.tfvars
+++ b/examples/azuread/104-azuread-group-membership/configuration.tfvars
@@ -51,4 +51,10 @@ azuread_groups_membership = {
       }
     }
   }
+  ad_group2 = { # ad group key
+    # group_lz_key = "" # group lz_key
+    members = {
+      azuread_service_principal_keys = ["spkey"] # add service principal to group
+    }
+  }
 }


### PR DESCRIPTION
## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

This code change allows you to add a service principal to a group in a different landingzone.

Before the code change using the example config, the code used to fail:

![image](https://user-images.githubusercontent.com/24568457/169494303-57be3eee-6db0-46d5-ba1e-006d778b8f1d.png)

Now it succeeds.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->


