### PR TITLE
use `ignore_missing_property` to suppress diff

### DIFF
--- a/modules/databases/mssql_managed_instance/managed_instance.tf
+++ b/modules/databases/mssql_managed_instance/managed_instance.tf
@@ -74,10 +74,7 @@ resource "azapi_resource" "sqlmi_admin_password" {
     }
   })
 
-  lifecycle {
-    ignore_changes = [body]
-  }
-
+  ignore_missing_property = true
 }
 
 data "external" "sqlmi_admin_password" {


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

The `Microsoft.KeyVault/vaults/secrets` resource contains credential that won't be returned in response, to suppress that diff, it's recommended to use `ignore_missing_property = true`

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
