### PR TITLE
Example doesn't assign the owner when used in code

### DIFF
--- a/examples/azuread/201-groups-and-roles/configuration.tfvars
+++ b/examples/azuread/201-groups-and-roles/configuration.tfvars
@@ -65,12 +65,7 @@ azuread_groups = {
       ]
 
     }
-    owners = {
-      user_principal_names = []
-      service_principal_keys = [
-        "app2"
-      ]
-    }
+    owners = []
     prevent_duplicate_name = false
   }
 


### PR DESCRIPTION
[Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/1180)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ X ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

This example file doesn't match the code expected in modules/azuread/groups/group.tf. As a result you will have the var.client_config.object_id added as the azure AD group owner regardless.
Not sure if this is the direction you want but it does make the example align to the code.

## Does this introduce a breaking change

- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
