### PR TITLE
Add optional encryption_at_host_enabled value

### DIFF
--- a/modules/compute/virtual_machine/vm_linux.tf
+++ b/modules/compute/virtual_machine/vm_linux.tf
@@ -62,6 +62,7 @@ resource "azurerm_linux_virtual_machine" "vm" {
   availability_set_id             = can(each.value.availability_set_key) || can(each.value.availability_set.key) ? var.availability_sets[try(var.client_config.landingzone_key, each.value.availability_set.lz_key)][try(each.value.availability_set_key, each.value.availability_set.key)].id : try(each.value.availability_set.id, each.value.availability_set_id, null)
   computer_name                   = azurecaf_name.linux_computer_name[each.key].result
   disable_password_authentication = try(each.value.disable_password_authentication, true)
+  encryption_at_host_enabled      = try(each.value.encryption_at_host_enabled, null)  
   eviction_policy                 = try(each.value.eviction_policy, null)
   license_type                    = try(each.value.license_type, null)
   location                        = var.location

--- a/modules/compute/virtual_machine/vm_windows.tf
+++ b/modules/compute/virtual_machine/vm_windows.tf
@@ -53,7 +53,7 @@ resource "azurerm_windows_virtual_machine" "vm" {
   availability_set_id          = can(each.value.availability_set_key) || can(each.value.availability_set.key) ? var.availability_sets[try(var.client_config.landingzone_key, each.value.availability_set.lz_key)][try(each.value.availability_set_key, each.value.availability_set.key)].id : try(each.value.availability_set.id, each.value.availability_set_id, null)
   computer_name                = azurecaf_name.windows_computer_name[each.key].result
   enable_automatic_updates     = try(each.value.enable_automatic_updates, null)
-  encryption_at_host_enabled   = try(each.encryption_at_host_enabled, null)  
+  encryption_at_host_enabled   = try(each.value.encryption_at_host_enabled, null)  
   eviction_policy              = try(each.value.eviction_policy, null)
   license_type                 = try(each.value.license_type, null)
   location                     = var.location

--- a/modules/compute/virtual_machine/vm_windows.tf
+++ b/modules/compute/virtual_machine/vm_windows.tf
@@ -53,6 +53,7 @@ resource "azurerm_windows_virtual_machine" "vm" {
   availability_set_id          = can(each.value.availability_set_key) || can(each.value.availability_set.key) ? var.availability_sets[try(var.client_config.landingzone_key, each.value.availability_set.lz_key)][try(each.value.availability_set_key, each.value.availability_set.key)].id : try(each.value.availability_set.id, each.value.availability_set_id, null)
   computer_name                = azurecaf_name.windows_computer_name[each.key].result
   enable_automatic_updates     = try(each.value.enable_automatic_updates, null)
+  encryption_at_host_enabled   = try(each.encryption_at_host_enabled, null)  
   eviction_policy              = try(each.value.eviction_policy, null)
   license_type                 = try(each.value.license_type, null)
   location                     = var.location


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description
Simple change which adds the optional encyrption_at_host_enabled parameter to the existing Azure Windows VM Module. This is now supported within the azurerm terraform provider: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/windows_virtual_machine#encryption_at_host_enabled
<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
