### PR TITLE
Make var.azuread_service_principals landingzone aware

### DIFF
--- a/azuread_groups.tf
+++ b/azuread_groups.tf
@@ -40,7 +40,7 @@ module "azuread_groups_membership" {
   settings                   = each.value
   group_id                   = try(module.azuread_groups[each.key].id, local.combined_objects_azuread_groups[each.value.group_lz_key][each.key].id)
   azuread_groups             = local.combined_objects_azuread_groups
-  azuread_service_principals = local.combined_objects_azuread_service_principals
+  azuread_service_principals = local.combined_objects_azuread_service_principals[try(each.value.lz_key, local.client_config.landingzone_key)]
   managed_identities         = local.combined_objects_managed_identities
   mssql_servers              = local.combined_objects_mssql_servers
 }


### PR DESCRIPTION
## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

This PR fixes an issue where Terraform fails on line 32 of `modules/azuread/groups_members/groups_members.tf` when giving the following map structure.

```
azuread_service_principals = {
  "testlz" = {
    azuread_application = {
      key = "testworkload"
    }
    keyvaults = {
      "testlz" = {
        secret_prefix = "sp"
      }
    }
  }
}
```

## Does this introduce a breaking change

- [ ] YES
- [ ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
