### PR TITLE
Allow adding keys to appconfig post creation

### DIFF
--- a/examples/app_config/100-simple/configuration.tfvars
+++ b/examples/app_config/100-simple/configuration.tfvars
@@ -19,3 +19,32 @@ app_config = {
     location           = "region1"
   }
 }
+
+app_config_entries = {
+  key = "appconf1"
+  #lz_key = ""
+
+  settings = {
+    foo = {
+      value = 1
+      label = "label1"
+    }
+    bar = {
+      value = "hello world"
+    }
+  }
+
+  # You can store attributes of other resources as settings, e.g. the client_id of a managed
+  # identity. Only works in a landing zone type deploy.
+  #dynamic_settings = {
+    #msi_client_id = {
+      #managed_identities = {
+        #level0 = {
+          #lz_key =        "launchpad"
+          #attribute_key = "client_id"
+          #label =         "label2"
+        #}
+      #}
+    #}
+  #}
+}

--- a/locals.tf
+++ b/locals.tf
@@ -102,6 +102,7 @@ locals {
   }
   database = {
     app_config                         = try(var.database.app_config, {})
+    app_config_entries                 = try(var.database.app_config_entries, {})
     azurerm_redis_caches               = try(var.database.azurerm_redis_caches, {})
     cosmos_dbs                         = try(var.database.cosmos_dbs, {})
     cosmosdb_sql_databases             = try(var.database.cosmosdb_sql_databases, {})

--- a/modules/databases/app_config/dynamic_settings.tf
+++ b/modules/databases/app_config/dynamic_settings.tf
@@ -1,4 +1,8 @@
+# TODO(pbourke): This module is deprecated. See var.database.app_config_entries for a newer way of
+# adding data to an appconfig instance.
 module "compute_instance" {
+  for_each = length(local.config_settings) > 0 ? toset(["enabled"]) : toset([])
+
   source     = "./settings"
   depends_on = [azurerm_app_configuration.config]
 

--- a/variables.tf
+++ b/variables.tf
@@ -344,6 +344,11 @@ variable "app_config" {
   default = {}
 }
 
+variable "app_config_entries" {
+  description = "Map of objects describing kv entries to an app config"
+  default     = {}
+}
+
 # variable "local_network_gateways" {
 #   default = {}
 # }


### PR DESCRIPTION
Currently, the appconfig module can only add entries to the store on
creation. Also, the module is using arm templates for creation,
presumably because the azurerm provider didn't support originally
support this.

This patch introduces a new mechanism to add entries to an appconfig
after it's been created. One can skip the ARM templates by simply not
passing any 'settings' when creating the appconfig, and then adding data
using the separate `app_config_entries` var.

Dynamic settings are also supported as before.

See https://github.com/Azure/caf-terraform-landingzones/pull/385 for the related `caf_solution` change.

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
