### PR TITLE
Add support for azurerm_log_analytics_linked_service to link automation account and log analytics workspace

### DIFF
--- a/automations.tf
+++ b/automations.tf
@@ -15,3 +15,20 @@ output "automations" {
   value = module.automations
 
 }
+
+module "automation_log_analytics_links" {
+  source     = "./modules/automation_log_analytics_links"
+  depends_on = [module.automations, module.log_analytics]
+  for_each   = local.shared_services.automation_log_analytics_links
+
+  global_settings     = local.global_settings
+  settings            = each.value
+  resource_group_name = can(each.value.resource_group.name) || can(each.value.resource_group_name) ? try(each.value.resource_group.name, each.value.resource_group_name) : local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group_key, each.value.resource_group.key)].name
+  workspace_id        = can(each.value.workspace_id) ? each.value.workspace_id : try(local.combined_objects_log_analytics[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.workspace_key].id, local.combined_diagnostics.log_analytics[each.value.workspace_key].id)
+  read_access_id      = try(each.value.automation_account_id, try(local.combined_objects_automations[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.automation_account_key].id, null))
+  write_access_id     = try(each.value.write_access_id, null)
+}
+
+output "automation_log_analytics_links" {
+  value = module.automation_log_analytics_links
+}

--- a/examples/automation/101-automation-account-linked/configuration.tfvars
+++ b/examples/automation/101-automation-account-linked/configuration.tfvars
@@ -1,0 +1,37 @@
+# Create log analytics workspace with Updates solution and linked automation account
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "australiaeast"
+  }
+}
+
+resource_groups = {
+  automation = {
+    name = "automation"
+  }
+}
+
+automations = {
+  auto1 = {
+    name               = "automation"
+    sku                = "basic"
+    resource_group_key = "automation"
+  }
+}
+
+diagnostic_log_analytics = {
+  region1 = {
+    region             = "region1"
+    name               = "logre1"
+    resource_group_key = "automation"
+  }
+}
+
+automation_log_analytics_links = {
+  link1 = {
+    workspace_key          = "region1"
+    automation_account_key = "auto1"
+    resource_group_key     = "automation"
+  }
+}

--- a/examples/module.tf
+++ b/examples/module.tf
@@ -255,6 +255,8 @@ module "example" {
   }
 
   shared_services = {
+    automations                    = var.automations
+    automation_log_analytics_links = var.automation_log_analytics_links
     consumption_budgets            = var.consumption_budgets
     image_definitions              = var.image_definitions
     log_analytics_storage_insights = var.log_analytics_storage_insights

--- a/examples/variables.tf
+++ b/examples/variables.tf
@@ -478,6 +478,9 @@ variable "event_hubs" {
 variable "automations" {
   default = {}
 }
+variable "automation_log_analytics_links" {
+  default = {}
+}
 
 variable "local_network_gateways" {
   default = {}

--- a/local.remote_objects.tf
+++ b/local.remote_objects.tf
@@ -14,6 +14,7 @@ locals {
     application_gateways                           = try(local.combined_objects_application_gateways, null)
     application_insights                           = try(local.combined_objects_application_insights, null)
     application_security_groups                    = try(local.combined_objects_application_security_groups, null)
+    automations                                    = try(local.combined_objects_automations, null)
     availability_sets                              = try(local.combined_objects_availability_sets, null)
     azure_container_registries                     = try(local.combined_objects_azure_container_registries, null)
     azuread_applications                           = try(local.combined_objects_azuread_applications, null)

--- a/locals.combined_objects.tf
+++ b/locals.combined_objects.tf
@@ -16,6 +16,7 @@ locals {
   combined_objects_application_gateways                           = merge(tomap({ (local.client_config.landingzone_key) = module.application_gateways }), try(var.remote_objects.application_gateways, {}))
   combined_objects_application_insights                           = merge(tomap({ (local.client_config.landingzone_key) = module.azurerm_application_insights }), try(var.remote_objects.azurerm_application_insights, {}))
   combined_objects_application_security_groups                    = merge(tomap({ (local.client_config.landingzone_key) = module.application_security_groups }), try(var.remote_objects.application_security_groups, {}))
+  combined_objects_automations                                    = merge(tomap({ (local.client_config.landingzone_key) = module.automations }), try(var.remote_objects.automations, {}))
   combined_objects_availability_sets                              = merge(tomap({ (local.client_config.landingzone_key) = module.availability_sets }), try(var.remote_objects.availability_sets, {}))
   combined_objects_azure_container_registries                     = merge(tomap({ (local.client_config.landingzone_key) = module.container_registry }), try(var.remote_objects.container_registry, {}))
   combined_objects_cosmos_dbs                                     = merge(tomap({ (local.client_config.landingzone_key) = module.cosmos_dbs }), try(var.remote_objects.cosmos_dbs, {}))

--- a/locals.tf
+++ b/locals.tf
@@ -331,6 +331,8 @@ locals {
 
   shared_services = {
     automations                    = try(var.shared_services.automations, {})
+    automation_log_analytics_links = try(var.shared_services.automation_log_analytics_links, {})
+    automation_software_update_configurations = try(var.shared_services.automation_software_update_configurations, {})
     consumption_budgets            = try(var.shared_services.consumption_budgets, {})
     image_definitions              = try(var.shared_services.image_definitions, {})
     log_analytics_storage_insights = try(var.shared_services.log_analytics_storage_insights, {})

--- a/modules/automation_log_analytics_links/module.tf
+++ b/modules/automation_log_analytics_links/module.tf
@@ -1,0 +1,6 @@
+resource "azurerm_log_analytics_linked_service" "linked_service" {
+  resource_group_name = var.resource_group_name
+  workspace_id        = var.workspace_id
+  read_access_id      = var.read_access_id
+  write_access_id      = var.write_access_id
+}

--- a/modules/automation_log_analytics_links/output.tf
+++ b/modules/automation_log_analytics_links/output.tf
@@ -1,0 +1,10 @@
+output "id" {
+  description = "The Log Analytics Workspace linked service id"
+  value       = azurerm_log_analytics_linked_service.linked_service.id
+}
+
+output "name" {
+  description = "The Log Analytics Workspace linked service name"
+  value       = azurerm_log_analytics_linked_service.linked_service.name
+}
+

--- a/modules/automation_log_analytics_links/variables.tf
+++ b/modules/automation_log_analytics_links/variables.tf
@@ -1,0 +1,35 @@
+variable "settings" {
+  description = "Configuration object for the Automation account Log Analytics Workspace link."
+  # # optional fields supported after TF14
+  # type = object({
+  #   name                        = string
+  #   resource_group_key          = string
+  #   tags                        = optional(map(string))
+  # })
+}
+
+variable "global_settings" {
+  description = "Global settings object (see module README.md)"
+}
+
+variable "resource_group_name" {
+  description = "(Required) The name of the resource group where to create the resource."
+  type        = string
+}
+
+variable "workspace_id" {
+  description = "(Required) The Log Analytics Workspace id"
+  type        = string
+}
+
+variable "read_access_id" {
+  description = "(Optional) The ID of the readable Resource that will be linked to the workspace."
+  type        = string
+  default = null
+}
+
+variable "write_access_id" {
+  description = "(Optional) The ID of the writeable Resource that will be linked to the workspace."
+  type        = string
+  default = null
+}


### PR DESCRIPTION
# [No support for azurerm_log_analytics_linked_service](https://github.com/aztfmod/terraform-azurerm-caf/issues/1226)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
