### PR TITLE
Fix vm and vmss custom script timestamp

### DIFF
--- a/examples/compute/virtual_machine/110-win-linuxvm-custom-script-extension/configuration.tfvars
+++ b/examples/compute/virtual_machine/110-win-linuxvm-custom-script-extension/configuration.tfvars
@@ -235,6 +235,7 @@ virtual_machines = {
         identity_type             = "UserAssigned" # optional to use managed_identity for download from location specified in fileuri, UserAssigned or SystemAssigned.
         managed_identity_key      = "user_mi"
         automatic_upgrade_enabled = false
+        # timestamp                 = 123456789
         # managed_identity_id       = "id" # optional to define managed identity principal_id directly
         # lz_key                    = "other_lz" # optional for managed identity defined in other lz
       }

--- a/modules/compute/virtual_machine_extensions/custom_script.tf
+++ b/modules/compute/virtual_machine_extensions/custom_script.tf
@@ -10,7 +10,7 @@ resource "azurerm_virtual_machine_extension" "custom_script" {
   settings = jsonencode(
     {
       fileUris  = local.fileuris,
-      timestamp = try(toint(var.extension.timestamp), 12345678)
+      timestamp = try(tonumber(var.extension.timestamp), 1234568)
     }
   )
 

--- a/modules/compute/virtual_machine_scale_set_extensions/custom_script.tf
+++ b/modules/compute/virtual_machine_scale_set_extensions/custom_script.tf
@@ -10,8 +10,8 @@ resource "azurerm_virtual_machine_scale_set_extension" "custom_script" {
 
   settings = jsonencode(
     {
-      "fileUris" : local.fileuris,
-      "timestamp" : try(toint(var.extension.timestamp), 12345678)
+      fileUris  = local.fileuris,
+      timestamp = try(tonumber(var.extension.timestamp), 1234568)
     }
   )
 


### PR DESCRIPTION
This PR will fix the custom script timestamp in vm and vmss custom scripts

# [1231](https://github.com/aztfmod/terraform-azurerm-caf/issues/1231)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [X] I have added example(s) inside the [./examples/] folder
- [] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [X] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [X] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
