### PR TITLE
Add resource provider registration resource

### DIFF
--- a/examples/module.tf
+++ b/examples/module.tf
@@ -24,6 +24,7 @@ module "example" {
   role_mapping                          = var.role_mapping
   storage_accounts                      = var.storage_accounts
   subscription_billing_role_assignments = var.subscription_billing_role_assignments
+  resource_provider_registration        = var.resource_provider_registration
   tags                                  = local.tags
 
   azuread = {

--- a/examples/subscriptions/101-resource-provider-registration/configuration.tfvars
+++ b/examples/subscriptions/101-resource-provider-registration/configuration.tfvars
@@ -1,0 +1,12 @@
+resource_provider_registration = {
+  container_service = {
+    name         = "Microsoft.ContainerService"
+    feature_name = "AKS-DataPlaneAutoApprove"
+    registered   = true
+  }
+  network_rule_name_logging = {
+    name         = "Microsoft.Network"
+    feature_name = "AFWEnableNetworkRuleNameLogging"
+    registered   = true
+  }
+}

--- a/resource_provider_registration.tf
+++ b/resource_provider_registration.tf
@@ -1,0 +1,9 @@
+resource "azurerm_resource_provider_registration" "default" {
+  for_each = var.resource_provider_registration
+  name     = each.value.name
+
+  feature {
+    name       = each.value.feature_name
+    registered = each.value.registered
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -399,3 +399,6 @@ variable "purview" {
 variable "sentinel_watchlists" {
   default = {}
 }
+variable "resource_provider_registration" {
+  default = {}
+}


### PR DESCRIPTION
## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

This PR adds the Terraform [azurerm_resource_provider_registration](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_provider_registration) resource.

It includes examples for two features to enable, could be expand with more feature examples.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
