### PR TITLE
Add tags attribute to azuread_service_principal

### DIFF
--- a/examples/azuread/103-service-principal-only/configuration.tfvars
+++ b/examples/azuread/103-service-principal-only/configuration.tfvars
@@ -52,6 +52,10 @@ azuread_service_principals = {
       key = "test_client"
     }
     app_role_assignment_required = true
+    tags = [
+      "HideApp",
+      "WindowsAzureActiveDirectoryIntegratedApp"
+    ]
   }
 }
 

--- a/modules/azuread/service_principal/module.tf
+++ b/modules/azuread/service_principal/module.tf
@@ -2,6 +2,7 @@
 resource "azuread_service_principal" "app" {
   application_id               = var.application_id
   app_role_assignment_required = try(var.settings.app_role_assignment_required, false)
+  tags                         = try(var.settings.tags, null)
 
   # lifecycle {
   #   ignore_changes = [application_id]


### PR DESCRIPTION
This PR adds the attribute "tags" to the resource
azuread_service_principal in the azuread/service_principal module.

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->
This PR adds the ability to specify the tags attribute when deploying a azuread_service_principal resource.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
