### PR TITLE
Bugfix key_vault_secrets_provider in aks

### DIFF
--- a/examples/compute/kubernetes_services/101-single-cluster/aks.tfvars
+++ b/examples/compute/kubernetes_services/101-single-cluster/aks.tfvars
@@ -76,10 +76,6 @@ aks_clusters = {
     node_resource_group_name = "aks-nodes-re1"
 
     addon_profile = {
-      oms_agent = {
-        enabled           = true
-        log_analytics_key = "central_logs_region1"
-      }
       azure_keyvault_secrets_provider = {
         secret_rotation_enabled  = true
         secret_rotation_interval = "2m"

--- a/examples/compute/kubernetes_services/101-single-cluster/aks.tfvars
+++ b/examples/compute/kubernetes_services/101-single-cluster/aks.tfvars
@@ -75,5 +75,15 @@ aks_clusters = {
 
     node_resource_group_name = "aks-nodes-re1"
 
+    addon_profile = {
+      oms_agent = {
+        enabled           = true
+        log_analytics_key = "central_logs_region1"
+      }
+      azure_keyvault_secrets_provider = {
+        secret_rotation_enabled  = true
+        secret_rotation_interval = "2m"
+      }
+    }
   }
 }

--- a/modules/compute/aks/aks.tf
+++ b/modules/compute/aks/aks.tf
@@ -180,7 +180,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
   }
 
   dynamic "key_vault_secrets_provider" {
-    for_each = can(var.settings.addon_profile.azure_keyvault_secrets_provider) || can(var.settings.key_vault_secrets_provider) ? try(var.settings.addon_profile.azure_keyvault_secrets_provider, var.settings.key_vault_secrets_provider) : {}
+    for_each = can(var.settings.addon_profile.azure_keyvault_secrets_provider) || can(var.settings.key_vault_secrets_provider) ? try([var.settings.addon_profile.azure_keyvault_secrets_provider], [var.settings.key_vault_secrets_provider]) : []
     content {
       secret_rotation_enabled  = key_vault_secrets_provider.value.secret_rotation_enabled
       secret_rotation_interval = key_vault_secrets_provider.value.secret_rotation_interval


### PR DESCRIPTION
Seems there is an issue with key_vault_secrets_provider in AKS:

It tries to interate over each parameter in map not over the map itself:
```
╷
│ Error: Too many key_vault_secrets_provider blocks
│ 
│   on ../modules/compute/aks/aks.tf line 184, in resource "azurerm_kubernetes_cluster" "aks":
│  184:     content {
│ 
│ No more than 1 "key_vault_secrets_provider" blocks are allowed
╵
╷
│ Error: Unsupported attribute
│ 
│   on ../modules/compute/aks/aks.tf line 185, in resource "azurerm_kubernetes_cluster" "aks":
│  185:       secret_rotation_enabled  = key_vault_secrets_provider.value.secret_rotation_enabled
│     ├────────────────
│     │ key_vault_secrets_provider.value is "true"
│ 
│ Can't access attributes on a primitive-typed value (string).
╵
╷
│ Error: Unsupported attribute
│ 
│   on ../modules/compute/aks/aks.tf line 185, in resource "azurerm_kubernetes_cluster" "aks":
│  185:       secret_rotation_enabled  = key_vault_secrets_provider.value.secret_rotation_enabled
│     ├────────────────
│     │ key_vault_secrets_provider.value is "2m"
│ 
│ Can't access attributes on a primitive-typed value (string).
╵
╷
│ Error: Unsupported attribute
│ 
│   on ../modules/compute/aks/aks.tf line 186, in resource "azurerm_kubernetes_cluster" "aks":
│  186:       secret_rotation_interval = key_vault_secrets_provider.value.secret_rotation_interval
│     ├────────────────
│     │ key_vault_secrets_provider.value is "true"
│ 
│ Can't access attributes on a primitive-typed value (string).
╵
╷
│ Error: Unsupported attribute
│ 
│   on ../modules/compute/aks/aks.tf line 186, in resource "azurerm_kubernetes_cluster" "aks":
│  186:       secret_rotation_interval = key_vault_secrets_provider.value.secret_rotation_interval
│     ├────────────────
│     │ key_vault_secrets_provider.value is "2m"
│ 
│ Can't access attributes on a primitive-typed value (string).
╵
```

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [X] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [X] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [X] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
