### PR TITLE
Add auto_stop_enabled parameter

### DIFF
--- a/examples/data_explorer/101-kusto_clusters_basic/configuration.tfvars
+++ b/examples/data_explorer/101-kusto_clusters_basic/configuration.tfvars
@@ -13,7 +13,8 @@ resource_groups = {
 }
 kusto_clusters = {
   kc1 = {
-    name = "kustocluster"
+    name              = "kustocluster"
+    auto_stop_enabled = false
     resource_group = {
       key = "rg1"
       #lz_key = ""

--- a/modules/databases/data_explorer/kusto_clusters/module.tf
+++ b/modules/databases/data_explorer/kusto_clusters/module.tf
@@ -55,5 +55,6 @@ resource "azurerm_kusto_cluster" "kusto" {
   trusted_external_tenants = try(var.settings.trusted_external_tenants, null)
   zones                    = try(var.settings.zones, null)
   engine                   = try(var.settings.engine, null)
+  auto_stop_enabled        = try(var.settings.auto_stop_enabled, null)
   tags                     = local.tags
 }


### PR DESCRIPTION
The Data Explorer has a configuration Auto Stop Cluster, which is activated by default.  This attribute is only available from AzureRM 2.96.0, since the last update we are on 2.99.0.

https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kusto_cluster#auto_stop_enabled

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [X] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [X] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [X] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
