### PR TITLE
Container Group Volumes - unsupported attribute

### DIFF
--- a/modules/compute/container_group/container_group.tf
+++ b/modules/compute/container_group/container_group.tf
@@ -132,7 +132,7 @@ resource "azurerm_container_group" "acg" {
           storage_account_name = try(volume.value.storage_account_name, null)
           storage_account_key  = try(volume.value.storage_account_key, null)
           share_name           = try(volume.value.share_name, null)
-          secret               = try(volume.share.secret, null)
+          secret               = try(volume.value.secret, null)
 
           dynamic "git_repo" {
             for_each = try(volume.value.git_repo, null) == null ? [] : [1]

--- a/modules/compute/container_group/container_group.tf
+++ b/modules/compute/container_group/container_group.tf
@@ -122,7 +122,7 @@ resource "azurerm_container_group" "acg" {
       } //liveness_probe
 
       dynamic "volume" {
-        for_each = try(container.value.volume, null) == null ? [] : [1]
+        for_each = try(container.value.volume, [])
 
         content {
           name                 = volume.value.name

--- a/modules/webapps/function_app/output.tf
+++ b/modules/webapps/function_app/output.tf
@@ -14,3 +14,7 @@ output "possible_outbound_ip_addresses" {
   value       = azurerm_function_app.function_app.possible_outbound_ip_addresses
   description = "A comma separated list of outbound IP addresses. not all of which are necessarily in use"
 }
+output "rbac_id" {
+  value       = try(azurerm_function_app.function_app.identity.0.principal_id, null)
+  description = "Principal ID of the system assigned managed identity"
+}

--- a/modules/webapps/function_app/output.tf
+++ b/modules/webapps/function_app/output.tf
@@ -14,7 +14,3 @@ output "possible_outbound_ip_addresses" {
   value       = azurerm_function_app.function_app.possible_outbound_ip_addresses
   description = "A comma separated list of outbound IP addresses. not all of which are necessarily in use"
 }
-output "rbac_id" {
-  value       = try(azurerm_function_app.function_app.identity.0.principal_id, null)
-  description = "Principal ID of the system assigned managed identity"
-}


### PR DESCRIPTION
# [1239 - Container Group Volumes cause 'unsupported attribute', and secret not mapped](https://github.com/aztfmod/terraform-azurerm-caf/issues/1239)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have added example(s) inside the [./examples/] folder
- [x] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing
Add the below to a `configuration.tfvars` instance:
```
container_groups = {
  aci_dns = {
    name               = "aci_dns"
    region             = "region1"
    resource_group_key = "dns"
    ip_address_type    = "Private"
    os_type            = "Linux"
    
    network_profile = {
      key = "aci_dns"
    }

    containers = {
      coredns = {
        name   = "dns-forwarder"
        image  = "coredns/coredns:1.9.0"
        cpu    = "2"
        memory = "2"

        commands = ["/coredns", "-conf", "/app/conf/Corefile"]

        volume = {
          dnscfg = {
            name       = "dns-forwarder-conf"
            mount_path = "/app/conf"
            read_only  = true
            secret     = {
              Corefile = "xxx"
            }
          }
        }

        ports = {
          1 = {
            port     = 53
            protocol = "UDP"
          }
        }
      }
    }
  }
}
```
