### PR TITLE
adding the option to add owners to groups by user_principal_name

### DIFF
--- a/modules/azuread/groups/group.tf
+++ b/modules/azuread/groups/group.tf
@@ -3,10 +3,28 @@ resource "azuread_group" "group" {
   display_name            = var.global_settings.passthrough ? format("%s", var.azuread_groups.name) : format("%s%s", try(format("%s-", var.global_settings.prefixes.0), ""), var.azuread_groups.name)
   description             = lookup(var.azuread_groups, "description", null)
   prevent_duplicate_names = lookup(var.azuread_groups, "prevent_duplicate_names", null)
-  owners = coalescelist(
+  owners = local.owners
+  // Note: This module is effected by these bugs:
+  // https://github.com/hashicorp/terraform-provider-azuread/issues/464
+  // https://github.com/microsoftgraph/msgraph-metadata/issues/92
+  // tldr: If your group is initaly owned by a service principal and you add a user to the owners, you are not able to remove the user from the owners again. At least one user has to stay owner.
+
+}
+data "azuread_user" "main" {
+  for_each = try(toset(var.azuread_groups.owners.user_principal_names), {})
+  user_principal_name = each.value
+}
+
+locals {
+  owners = concat(
     try(tolist(var.azuread_groups.owners), []),
     [
       var.client_config.object_id
-    ]
+    ],
+      local.ad_user_oids
   )
+  ad_user_oids = [ for user in try(var.azuread_groups.owners.user_principal_names, []):
+    data.azuread_user.main[user].object_id
+  ]
 }
+

--- a/modules/azuread/groups/group.tf
+++ b/modules/azuread/groups/group.tf
@@ -7,7 +7,7 @@ resource "azuread_group" "group" {
   // Note: This module is effected by these bugs:
   // https://github.com/hashicorp/terraform-provider-azuread/issues/464
   // https://github.com/microsoftgraph/msgraph-metadata/issues/92
-  // tldr: If your group is initaly owned by a service principal and you add a user to the owners, you are not able to remove the user from the owners again. At least one user has to stay owner.
+  // tldr: If your group is initially owned by a service principal and you add a user to the owners, you are not able to remove the user from the owners again. At least one user has to stay owner.
 
 }
 data "azuread_user" "main" {


### PR DESCRIPTION
# [1252](https://github.com/aztfmod/terraform-azurerm-caf/issues/1252)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
The existing examples already document this feature, there was just no implementation for it:
[azuread/104-azuread-group-membership/configuration.tfvars](https://github.com/aztfmod/terraform-azurerm-caf/blob/main/examples/azuread/104-azuread-group-membership/configuration.tfvars)  
```
    owners = {
      user_principal_names = []
    }
```

- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->
The /[azuread](https://github.com/aztfmod/terraform-azurerm-caf/tree/main/modules/azuread)/[groups](https://github.com/aztfmod/terraform-azurerm-caf/tree/main/modules/azuread/groups) module only supports owners via object id.
For my use case it would be nice to be able to reference user principal names instead.

## Does this introduce a breaking change

- [ ] YES
- [x] NO  
the old interface is left untouched

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing
used this example to test the module:
```
  group_key = {
    name                   = "group-name"
    description            = "description"
    prevent_duplicate_name = true
    owners = {
      user_principal_names = ["foo@baz.com"]
    }
  }
```
found that this implementation as well as the current implementation effected by this bug:
See my notes in code:
```
  // Note: This module is effected by these bugs:
  // https://github.com/hashicorp/terraform-provider-azuread/issues/464
  // https://github.com/microsoftgraph/msgraph-metadata/issues/92
  // tldr: If your group is initially owned by a service principal and you add a user to the owners, you are not able to remove the user from the owners again. At least one user has to stay owner.
```


