### PR TITLE
1253 app gateway existing certs

### DIFF
--- a/.github/workflows/standalone-scenarios.json
+++ b/.github/workflows/standalone-scenarios.json
@@ -4,6 +4,7 @@
     "app_gateway/100-simple-app-gateway",
     "app_gateway/101-private-public",
     "app_gateway/102-waf-policy",
+    "app_gateway/202-app-gateway-single-cert-multiple-listeners",
     "app_gateway/210-agw-with-keyvault",
     "app_insights/100-all-attributes",
     "app_insights/100-simple",

--- a/examples/app_gateway/202-app-gateway-single-cert-multiple-listeners/application_gateway_applications
+++ b/examples/app_gateway/202-app-gateway-single-cert-multiple-listeners/application_gateway_applications
@@ -1,0 +1,103 @@
+application_gateway_applications = {
+  test_ssl_443 = {
+    application_gateway_key = "agw_core"
+    name                    = "testssl"
+
+    listeners = {
+      public_ssl = {
+        name                           = "testssl-443-public"
+        front_end_ip_configuration_key = "public"
+        front_end_port_key             = "443"
+        host_name                      = "testssl.np.domain.com"
+        request_routing_rule_key       = "default"
+        existing_certificate_key       = "wildcard_np_domain_com" # Set this to the key specified in application_gateways.tfvars
+      }
+    }
+
+    request_routing_rules = {
+      default = {
+        rule_type = "Basic"
+      }
+    }
+
+    backend_http_setting = {
+      port                                = 443
+      protocol                            = "Https"
+      pick_host_name_from_backend_address = true
+      probe_key                           = "google_com"
+    }
+
+    backend_pool = {
+      fqdns = [
+        "www.google.com"
+      ]
+    }
+
+    probes = {
+      google_com = {
+        name                = "probe-google-be-443"
+        protocol            = "Https"
+        path                = "/"
+        host                = "www.google.com"
+        interval            = 10
+        timeout             = 10
+        unhealthy_threshold = 3
+        match = {
+          status_code = ["200-399"]
+        }
+      }
+    }
+  }
+  
+  app2_ssl_443 = {
+    application_gateway_key = "agw_core"
+    name                    = "app2"
+
+    listeners = {
+      public_ssl = {
+        name                           = "app2-443-public"
+        front_end_ip_configuration_key = "public"
+        front_end_port_key             = "443"
+        host_name                      = "app2.np.domain.com"
+        request_routing_rule_key       = "default"
+        existing_certificate_key       = "wildcard_np_domain_com" # Set this to the key specified in application_gateways.tfvars
+      }
+    }
+
+    request_routing_rules = {
+      default = {
+        rule_type = "Basic"
+      }
+    }
+
+    backend_http_setting = {
+      port                                = 443
+      protocol                            = "Https"
+      pick_host_name_from_backend_address = true
+      probe_key                           = "bing_com"
+    }
+
+    backend_pool = {
+      fqdns = [
+        "www.bing.com"
+      ]
+    }
+
+    probes = {
+      bing_com = {
+        name                = "probe-bing-be-443"
+        protocol            = "Https"
+        path                = "/"
+        host                = "www.bing.com"
+        interval            = 10
+        timeout             = 10
+        unhealthy_threshold = 3
+        match = {
+          status_code = ["200-399"]
+        }
+      }
+    }
+  }
+  
+  
+}

--- a/examples/app_gateway/202-app-gateway-single-cert-multiple-listeners/application_gateways.tfvars
+++ b/examples/app_gateway/202-app-gateway-single-cert-multiple-listeners/application_gateways.tfvars
@@ -3,7 +3,6 @@ application_gateways = {
     resource_group_key = "core_services"
     name = "app-gateway"
 
-    lz_key     = "connectivity_level3_dev"
     vnet_key   = "shared_spoke"
     subnet_key = "app-gateway-public"
 
@@ -32,7 +31,6 @@ application_gateways = {
       private = {
         name                          = "private"
         vnet_key                      = "shared_spoke"
-        lz_key                        = "connectivity_level3_dev"
         subnet_key                    = "app-gateway-public"
         subnet_cidr_index             = 0 # It is possible to have more than one cidr block per subnet
         private_ip_offset             = 4 # e.g. cidrhost(10.10.0.0/25,4) = 10.10.0.4 => AGW private IP address

--- a/examples/app_gateway/202-app-gateway-single-cert-multiple-listeners/application_gateways.tfvars
+++ b/examples/app_gateway/202-app-gateway-single-cert-multiple-listeners/application_gateways.tfvars
@@ -1,6 +1,6 @@
 application_gateways = {
   agw_core = {
-    resource_group_key = "main"
+    resource_group_key = "core_services"
     name = "app-gateway"
 
     lz_key     = "connectivity_level3_dev"

--- a/examples/app_gateway/202-app-gateway-single-cert-multiple-listeners/application_gateways.tfvars
+++ b/examples/app_gateway/202-app-gateway-single-cert-multiple-listeners/application_gateways.tfvars
@@ -1,0 +1,57 @@
+application_gateways = {
+  agw_core = {
+    resource_group_key = "main"
+    name = "app-gateway"
+
+    lz_key     = "connectivity_level3_dev"
+    vnet_key   = "shared_spoke"
+    subnet_key = "app-gateway-public"
+
+    sku_name = "Standard_v2"
+    sku_tier = "Standard_v2"
+    capacity = {
+      autoscale = {
+        minimum_scale_unit = 1
+        maximum_scale_unit = 2
+      }
+    }
+    zones        = ["1"]
+    enable_http2 = true
+
+    identity = {
+      managed_identity_keys = [
+        "appgw_keyvault_certs"
+      ]
+    }
+
+    front_end_ip_configurations = {
+      public = {
+        name          = "public"
+        public_ip_key = "appgw_pip"
+      }
+      private = {
+        name                          = "private"
+        vnet_key                      = "shared_spoke"
+        lz_key                        = "connectivity_level3_dev"
+        subnet_key                    = "app-gateway-public"
+        subnet_cidr_index             = 0 # It is possible to have more than one cidr block per subnet
+        private_ip_offset             = 4 # e.g. cidrhost(10.10.0.0/25,4) = 10.10.0.4 => AGW private IP address
+        private_ip_address_allocation = "Static"
+      }
+    }
+
+    front_end_ports = {
+      80 = {
+        name     = "http-80"
+        port     = 80
+        protocol = "Http"
+      }
+      443 = {
+        name     = "https-443"
+        port     = 443
+        protocol = "Https"
+      }
+    }
+
+  }
+}

--- a/examples/app_gateway/202-app-gateway-single-cert-multiple-listeners/application_gateways.tfvars
+++ b/examples/app_gateway/202-app-gateway-single-cert-multiple-listeners/application_gateways.tfvars
@@ -52,6 +52,20 @@ application_gateways = {
         protocol = "Https"
       }
     }
+    
+    # This is the important block!
+    # NOTE - This example does not provision a certificate in the vault.
+    #        You can manually upload/generate one for your environment, then
+    #        reference with keyvault_key or keyvault_id. Just ensure the appropriate
+    #        role_assignment is provisioned for the AGW Managed Identity, and also the 
+    #        Service Principal that the pipeline runs under.
+    manual_certificates = {
+      wildcard_np_dca = {
+        certificate_name = "wildcard-np-domain-com"
+        keyvault_key     = "cert_kv"
+        # keyvault_id = "/sub/a-b-c-d-e/rg/xyz"
+      }
+    }
 
   }
 }

--- a/examples/app_gateway/202-app-gateway-single-cert-multiple-listeners/application_gateways.tfvars
+++ b/examples/app_gateway/202-app-gateway-single-cert-multiple-listeners/application_gateways.tfvars
@@ -60,7 +60,7 @@ application_gateways = {
     #        role_assignment is provisioned for the AGW Managed Identity, and also the 
     #        Service Principal that the pipeline runs under.
     manual_certificates = {
-      wildcard_np_dca = {
+      wildcard_np_domain_com = {
         certificate_name = "wildcard-np-domain-com"
         keyvault_key     = "cert_kv"
         # keyvault_id = "/sub/a-b-c-d-e/rg/xyz"

--- a/examples/app_gateway/202-app-gateway-single-cert-multiple-listeners/application_gateways.tfvars
+++ b/examples/app_gateway/202-app-gateway-single-cert-multiple-listeners/application_gateways.tfvars
@@ -57,7 +57,7 @@ application_gateways = {
     #        reference with keyvault_key or keyvault_id. Just ensure the appropriate
     #        role_assignment is provisioned for the AGW Managed Identity, and also the 
     #        Service Principal that the pipeline runs under.
-    manual_certificates = {
+    manual_certs_multiple_listeners = {
       wildcard_np_domain_com = {
         certificate_name = "wildcard-np-domain-com"
         keyvault_key     = "cert_kv"

--- a/examples/app_gateway/202-app-gateway-single-cert-multiple-listeners/key_vaults.tfvars
+++ b/examples/app_gateway/202-app-gateway-single-cert-multiple-listeners/key_vaults.tfvars
@@ -1,0 +1,17 @@
+keyvaults = {
+  cert_kv = {
+    name               = "agw-certs"
+    sku_name           = "standard"
+
+    resource_group_key = "core_services"
+
+    enable_rbac_authorization = true
+    
+    creation_policies = {
+      logged_in_user = {
+        certificate_permissions = ["Get", "List", "Update", "Create", "Import", "Delete", "Purge", "Recover", "Getissuers", "Setissuers", "Listissuers", "Deleteissuers", "Manageissuers", "Restore", "Managecontacts"]
+        secret_permissions      = ["Set", "Get", "List", "Delete", "Purge"]
+      }
+    }
+  }
+}

--- a/examples/app_gateway/202-app-gateway-single-cert-multiple-listeners/managed_identities.tfvars
+++ b/examples/app_gateway/202-app-gateway-single-cert-multiple-listeners/managed_identities.tfvars
@@ -1,0 +1,6 @@
+managed_identities = {
+  appgw_keyvault_certs = {
+    name = "agw-certificates"
+    resource_group_key = "core_services"
+  }
+}

--- a/examples/app_gateway/202-app-gateway-single-cert-multiple-listeners/networking.tfvars
+++ b/examples/app_gateway/202-app-gateway-single-cert-multiple-listeners/networking.tfvars
@@ -1,0 +1,24 @@
+vnets = {
+  shared_spoke = {
+    resource_group_key = "core_services"
+    region = "region1"
+
+    vnet = {
+      name          = "dev-core-services"
+      address_space = ["10.1.0.0/20"]
+    }
+    
+    specialsubnets = {}
+    
+    subnets = {
+      app-gateway-public = {
+        name            = "app_gateway_public"
+        cidr            = ["10.1.0.0/24"]
+      }
+      app-gateway-private = {
+        name = "app_gateway_private"
+        cidr = ["10.1.1.0/24"]
+      }
+    }
+  }
+}

--- a/examples/app_gateway/202-app-gateway-single-cert-multiple-listeners/resource_groups.tfvars
+++ b/examples/app_gateway/202-app-gateway-single-cert-multiple-listeners/resource_groups.tfvars
@@ -1,0 +1,10 @@
+resource_groups = {
+  core_services = {
+    name   = "core-services"
+    region = "region1"
+  }
+}
+
+regions = {
+  region1 = "uksouth"
+}

--- a/examples/app_gateway/202-app-gateway-single-cert-multiple-listeners/role_mappings.tfvars
+++ b/examples/app_gateway/202-app-gateway-single-cert-multiple-listeners/role_mappings.tfvars
@@ -1,0 +1,11 @@
+role_mapping = {
+  built_in_role_mapping = {
+    keyvaults = {
+      "Key Vault Secrets User" = {
+          managed_identities = {
+            keys = ["appgw_keyvault_certs"]
+          }
+        }
+    }
+  }  
+}


### PR DESCRIPTION
# [1253 - Bug report - App Gateway Manual Certificates existing resource conflict](https://github.com/aztfmod/terraform-azurerm-caf/issues/1253)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have added example(s) inside the [./examples/] folder
- [x] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Gives support for a single certificate to be used with multiple listeners. The original implementation (https://github.com/aztfmod/terraform-azurerm-caf/pull/357) did not facilitate this scenario.

I've not removed it, as there is still a valid use for it (e.g. when you have distinct certificates for each listener). Although this PR's implementation can also cater for the above, it'd cause a breaking change, hence leaving it in the code.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

- Run the example in `examples/app_gateway/202-app-gateway-single-cert-multiple-listeners`
