### PR TITLE
Allow AD group in Remote LZ as AKS Cluster Admin

### DIFF
--- a/.github/workflows/standalone-scenarios.json
+++ b/.github/workflows/standalone-scenarios.json
@@ -37,6 +37,7 @@
     "compute/kubernetes_services/104-private-cluster",
     "compute/kubernetes_services/105-cluster-usermsi",
     "compute/kubernetes_services/107-agic-brownfield",
+    "compute/kubernetes_services/108-single-cluster-remote-adgroup-admin",
     "compute/proximity_placement_group",
     "compute/virtual_machine_scale_set/100-linux-win-vmss-lb",
     "compute/virtual_machine_scale_set/101-linux-win-vmss-agw",

--- a/aks_clusters.tf
+++ b/aks_clusters.tf
@@ -20,7 +20,11 @@ module "aks_clusters" {
   admin_group_object_ids = try(each.value.admin_groups.azuread_group_keys, null) == null ? null : try(
     each.value.admin_groups.ids,
     [
-      for group_key in try(each.value.admin_groups.azuread_groups.keys, {}) : local.combined_objects_azuread_groups[local.client_config.landingzone_key][group_key].id
+      for group_key in try(each.value.admin_groups.azuread_group_keys, {}) : 
+      coalesce(      
+        try( local.combined_objects_azuread_groups[each.value.admin_groups.lz_key][group_key].id, null ),
+        try( local.combined_objects_azuread_groups[local.client_config.landingzone_key][group_key].id, null )
+      )
     ]
   )
 

--- a/examples/compute/kubernetes_services/108-single-cluster-remote-adgroup-admin/aks.tfvars
+++ b/examples/compute/kubernetes_services/108-single-cluster-remote-adgroup-admin/aks.tfvars
@@ -43,10 +43,12 @@ aks_clusters = {
         log_analytics_key = "central_logs_region1"
       }
     }
-    admin_groups = {
-      lz_key             = "remote_lz" # Replace with remote landingzone key
-      azuread_group_keys = ["aks_admins"] # Replace with Azure AD group key
-    }
+
+# Uncomment this admin_groups block and configure as per comments
+#    admin_groups = {
+#      lz_key             = "remote_lz" # Replace with remote landingzone key
+#      azuread_group_keys = ["aks_admins"] # Replace with Azure AD group key
+#    }
 
     load_balancer_profile = {
       # Only one option can be set

--- a/examples/compute/kubernetes_services/108-single-cluster-remote-adgroup-admin/aks.tfvars
+++ b/examples/compute/kubernetes_services/108-single-cluster-remote-adgroup-admin/aks.tfvars
@@ -1,0 +1,83 @@
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "australiaeast"
+  }
+}
+
+resource_groups = {
+  aks_re1 = {
+    name   = "aks-re1"
+    region = "region1"
+  }
+}
+
+aks_clusters = {
+  cluster_re1 = {
+    name               = "akscluster-re1-001"
+    resource_group_key = "aks_re1"
+    os_type            = "Linux"
+
+    identity = {
+      type = "SystemAssigned"
+    }
+
+    vnet_key = "spoke_aks_re1"
+
+    network_profile = {
+      network_plugin    = "azure"
+      load_balancer_sku = "Standard"
+    }
+
+    # enable_rbac = true
+    role_based_access_control = {
+      enabled = true
+      azure_active_directory = {
+        managed = true
+      }
+    }
+
+    addon_profile = {
+      oms_agent = {
+        enabled           = true
+        log_analytics_key = "central_logs_region1"
+      }
+    }
+    admin_groups = {
+      lz_key             = "remote_lz" # Replace with remote landingzone key
+      azuread_group_keys = ["aks_admins"] # Replace with Azure AD group key
+    }
+
+    load_balancer_profile = {
+      # Only one option can be set
+      managed_outbound_ip_count = 1
+    }
+
+    default_node_pool = {
+      name    = "sharedsvc"
+      vm_size = "Standard_F4s_v2"
+      #subnet_key            = "aks_nodepool_system"
+      subnet = {
+        key = "aks_nodepool_system"
+        #resource_id = "/subscriptions/97958dac-xxxx-xxxx-xxxx-9f436fa73bd4/resourceGroups/qxgc-rg-aks-re1/providers/Microsoft.Network/virtualNetworks/qxgc-vnet-aks/subnets/qxgc-snet-aks_nodepool_system"
+      }
+      enabled_auto_scaling  = false
+      enable_node_public_ip = false
+      max_pods              = 30
+      node_count            = 1
+      os_disk_size_gb       = 512
+      tags = {
+        "project" = "system services"
+      }
+    }
+
+    node_resource_group_name = "aks-nodes-re1"
+
+    addon_profile = {
+      azure_keyvault_secrets_provider = {
+        secret_rotation_enabled  = true
+        secret_rotation_interval = "2m"
+      }
+    }
+  }
+}

--- a/examples/compute/kubernetes_services/108-single-cluster-remote-adgroup-admin/diagnostics.tfvars
+++ b/examples/compute/kubernetes_services/108-single-cluster-remote-adgroup-admin/diagnostics.tfvars
@@ -1,0 +1,7 @@
+diagnostic_log_analytics = {
+  central_logs_region1 = {
+    region             = "region1"
+    name               = "logs"
+    resource_group_key = "aks_re1"
+  }
+}

--- a/examples/compute/kubernetes_services/108-single-cluster-remote-adgroup-admin/networking.tfvars
+++ b/examples/compute/kubernetes_services/108-single-cluster-remote-adgroup-admin/networking.tfvars
@@ -1,0 +1,190 @@
+vnets = {
+  spoke_aks_re1 = {
+    resource_group_key = "aks_re1"
+    region             = "region1"
+    vnet = {
+      name          = "aks"
+      address_space = ["100.64.48.0/22"]
+    }
+    specialsubnets = {}
+    subnets = {
+      aks_nodepool_system = {
+        name    = "aks_nodepool_system"
+        cidr    = ["100.64.48.0/24"]
+        nsg_key = "azure_kubernetes_cluster_nsg"
+      }
+      aks_nodepool_user1 = {
+        name    = "aks_nodepool_user1"
+        cidr    = ["100.64.49.0/24"]
+        nsg_key = "azure_kubernetes_cluster_nsg"
+      }
+      aks_nodepool_user2 = {
+        name    = "aks_nodepool_user2"
+        cidr    = ["100.64.50.0/24"]
+        nsg_key = "azure_kubernetes_cluster_nsg"
+      }
+      AzureBastionSubnet = {
+        name    = "AzureBastionSubnet" #Must be called AzureBastionSubnet
+        cidr    = ["100.64.51.64/27"]
+        nsg_key = "azure_bastion_nsg"
+      }
+      private_endpoints = {
+        name                                           = "private_endpoints"
+        cidr                                           = ["100.64.51.0/27"]
+        enforce_private_link_endpoint_network_policies = true
+      }
+      jumpbox = {
+        name    = "jumpbox"
+        cidr    = ["100.64.51.128/27"]
+        nsg_key = "azure_bastion_nsg"
+      }
+    }
+
+  }
+}
+
+network_security_group_definition = {
+  # This entry is applied to all subnets with no NSG defined
+  empty_nsg = {}
+  azure_kubernetes_cluster_nsg = {
+    nsg = [
+      {
+        name                       = "aks-http-in-allow",
+        priority                   = "100"
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_range     = "80"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+      },
+      {
+        name                       = "aks-https-in-allow",
+        priority                   = "110"
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_range     = "443"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+      },
+      {
+        name                       = "aks-api-out-allow-1194",
+        priority                   = "100"
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "udp"
+        source_port_range          = "*"
+        destination_port_range     = "1194"
+        source_address_prefix      = "*"
+        destination_address_prefix = "AzureCloud"
+      },
+      {
+        name                       = "aks-api-out-allow-9000",
+        priority                   = "110"
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_range     = "9000"
+        source_address_prefix      = "*"
+        destination_address_prefix = "AzureCloud"
+      },
+      {
+        name                       = "aks-ntp-out-allow",
+        priority                   = "120"
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "udp"
+        source_port_range          = "*"
+        destination_port_range     = "123"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+      },
+      {
+        name                       = "aks-https-out-allow-443",
+        priority                   = "130"
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_range     = "443"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+      },
+    ]
+  }
+  azure_bastion_nsg = {
+
+    nsg = [
+      {
+        name                       = "bastion-in-allow",
+        priority                   = "100"
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_range     = "443"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+      },
+      {
+        name                       = "bastion-control-in-allow-443",
+        priority                   = "120"
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_range     = "135"
+        source_address_prefix      = "GatewayManager"
+        destination_address_prefix = "*"
+      },
+      {
+        name                       = "Kerberos-password-change",
+        priority                   = "121"
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_range     = "4443"
+        source_address_prefix      = "GatewayManager"
+        destination_address_prefix = "*"
+      },
+      {
+        name                       = "bastion-vnet-out-allow-22",
+        priority                   = "103"
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_range     = "22"
+        source_address_prefix      = "*"
+        destination_address_prefix = "VirtualNetwork"
+      },
+      {
+        name                       = "bastion-vnet-out-allow-3389",
+        priority                   = "101"
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_range     = "3389"
+        source_address_prefix      = "*"
+        destination_address_prefix = "VirtualNetwork"
+      },
+      {
+        name                       = "bastion-azure-out-allow",
+        priority                   = "120"
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "tcp"
+        source_port_range          = "*"
+        destination_port_range     = "443"
+        source_address_prefix      = "*"
+        destination_address_prefix = "AzureCloud"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
# [1256 - Feature request - Remote AD Group for AKS Admin Groups](https://github.com/aztfmod/terraform-azurerm-caf/issues/1256)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have added example(s) inside the [./examples/] folder
- [x] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

This allows you to specify an AD group from a remote landing zone as part of the `admin_groups` block in the AKS module.

Original credit to @yanndb


## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Run the example in `compute/kubernetes_services/108-single-cluster-remote-adgroup-admin`
