### PR TITLE
Fix logic for MSSQL Server AzureAD administrator

### DIFF
--- a/modules/databases/mssql_server/server.tf
+++ b/modules/databases/mssql_server/server.tf
@@ -11,13 +11,13 @@ resource "azurerm_mssql_server" "mssql" {
   tags                          = local.tags
 
   dynamic "azuread_administrator" {
-    for_each = try(var.settings.azuread_administrator.azuread_authentication_only, false) == true ? [var.settings.azuread_administrator] : []
+    for_each = can(var.settings.azuread_administrator) ? [var.settings.azuread_administrator] : []
 
     content {
       azuread_authentication_only = try(azuread_administrator.value.azuread_authentication_only, null)
-      login_username              = try(azuread_administrator.value.login_username, try(var.azuread_groups[var.client_config.landingzone_key][azuread_administrator.value.azuread_group_key].name, var.azuread_groups[azuread_administrator.value.lz_key][azuread_administrator.value.azuread_group_key].name))
-      object_id                   = try(azuread_administrator.value.object_id, try(var.azuread_groups[var.client_config.landingzone_key][azuread_administrator.value.azuread_group_key].id, var.azuread_groups[azuread_administrator.value.lz_key][azuread_administrator.value.azuread_group_key].id))
-      tenant_id                   = try(azuread_administrator.value.tenant_id, try(var.azuread_groups[var.client_config.landingzone_key][azuread_administrator.value.azuread_group_key].tenant_id, var.azuread_groups[azuread_administrator.value.lz_key][azuread_administrator.value.azuread_group_key].tenant_id))
+      login_username              = try(azuread_administrator.value.login_username, var.azuread_groups[try(azuread_administrator.value.lz_key, var.client_config.landingzone_key)][azuread_administrator.value.azuread_group_key].name)
+      object_id                   = try(azuread_administrator.value.object_id, var.azuread_groups[try(azuread_administrator.value.lz_key, var.client_config.landingzone_key)][azuread_administrator.value.azuread_group_key].id)
+      tenant_id                   = try(azuread_administrator.value.tenant_id, var.azuread_groups[try(azuread_administrator.value.lz_key, var.client_config.landingzone_key)][azuread_administrator.value.azuread_group_key].tenant_id)
     }
   }
 


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->
The current implementation is creating dynamic configuration based on a optional attribute ([doc](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/mssql_server#azuread_authentication_only)).
This PR allow assigning AzureAD administrator to a SQL Server without enforcing usage of "Active Directory Only" users.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
