### PR TITLE
Conditionally apply arurecaf_name to service bus resources

### DIFF
--- a/examples/messaging/servicebus/100-servicebus-services/configuration.tfvars
+++ b/examples/messaging/servicebus/100-servicebus-services/configuration.tfvars
@@ -95,6 +95,9 @@ servicebus_topics = {
       key = "namespace1"
     }
     name = "topic1"
+    # In case you want to passthrough azurecaf_name prefixes for this resource only
+    # It overrides the global_settings.passthrough parameter
+    # passthrough_caf_name = bool
 
     # auto_delete_on_idle = "P0Y0M0DT0H5M0S"
     # default_message_ttl = "P0Y0M0DT0H5M0S"
@@ -118,6 +121,10 @@ servicebus_topics = {
     subscriptions = {
       sub1 = {
         name               = "subtest1"
+        # In case you want to passthrough azurecaf_name prefixes for this resource only
+        # It overrides the global_settings.passthrough parameter
+        # passthrough_caf_name = bool
+
         max_delivery_count = 1
 
         auto_delete_on_idle                       = "P14DT5M"
@@ -190,6 +197,10 @@ servicebus_topics = {
 servicebus_queues = {
   queue1 = {
     name = "testqueue1"
+    # In case you want to passthrough azurecaf_name prefixes for this resource only
+    # It overrides the global_settings.passthrough parameter
+    # passthrough_caf_name = bool
+
     servicebus_namespace = {
       # lz_key = ""
       key = "namespace1"

--- a/modules/messaging/servicebus/queue/queue.tf
+++ b/modules/messaging/servicebus/queue/queue.tf
@@ -4,7 +4,7 @@ resource "azurecaf_name" "queue" {
   prefixes      = var.global_settings.prefixes
   random_length = var.global_settings.random_length
   clean_input   = true
-  passthrough   = var.global_settings.passthrough
+  passthrough   = try(var.settings.passthrough_caf_name, var.global_settings.passthrough)
   use_slug      = var.global_settings.use_slug
 }
 

--- a/modules/messaging/servicebus/topic/subscription/subscription.tf
+++ b/modules/messaging/servicebus/topic/subscription/subscription.tf
@@ -4,7 +4,7 @@ resource "azurecaf_name" "servicebus_subscription" {
   prefixes      = var.global_settings.prefixes
   random_length = var.global_settings.random_length
   clean_input   = true
-  passthrough   = var.global_settings.passthrough
+  passthrough   = try(var.settings.passthrough_caf_name, var.global_settings.passthrough)
   use_slug      = var.global_settings.use_slug
 }
 

--- a/modules/messaging/servicebus/topic/topic.tf
+++ b/modules/messaging/servicebus/topic/topic.tf
@@ -4,7 +4,7 @@ resource "azurecaf_name" "topic" {
   prefixes      = var.global_settings.prefixes
   random_length = var.global_settings.random_length
   clean_input   = true
-  passthrough   = var.global_settings.passthrough
+  passthrough   = try(var.settings.passthrough_caf_name, var.global_settings.passthrough)
   use_slug      = var.global_settings.use_slug
 }
 


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [x] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->
Since Azure Service BUS topics, queues and subscriptions do not have to comply with unique names when created on different namespaces, the azurecaf_name resource should be optional.

My use case:
I have several namespaces (per environment) - each namespace has its own Connection String, which is dynamically assigned to the applications. 
Topics, queues and subscriptions are not dynamically assigned since developers are expecting to use the same name on every namespace.

Solution:
A new attribute that will override the `global_settings.passthrough` value ONLY for that specific resource.
`passthrough   = try(var.settings.passthrough_caf_name, var.global_settings.passthrough)`

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
