### PR TITLE
Add support for Central Diagnostics Log Analytics Workspace

### DIFF
--- a/.github/workflows/standalone-scenarios.json
+++ b/.github/workflows/standalone-scenarios.json
@@ -7,6 +7,7 @@
     "app_config/100-simple",
     "app_insights/100-all-attributes",
     "app_insights/100-simple",
+    "app_insights/102-workspace-based-central-logs",
     "automation/100-simple-automation-account",
     "azuread/100-azuread-application-with-sevice-principle-with-builtin-roles",
     "azuread/100-sevice-principle-with-builtin-roles",

--- a/azurerm_application_insights.tf
+++ b/azurerm_application_insights.tf
@@ -13,7 +13,7 @@ module "azurerm_application_insights" {
   retention_in_days                     = lookup(each.value, "retention_in_days", "90")
   sampling_percentage                   = lookup(each.value, "sampling_percentage", null)
   disable_ip_masking                    = lookup(each.value, "disable_ip_masking", null)
-  workspace_id                          = try(local.combined_objects_log_analytics[try(each.value.log_analytics_workspace.lz_key, local.client_config.landingzone_key)][each.value.log_analytics_workspace.key].id, null)
+  workspace_id                          = try(local.combined_objects_log_analytics[try(each.value.log_analytics_workspace.lz_key, local.client_config.landingzone_key)][each.value.log_analytics_workspace.key].id, local.combined_diagnostics.log_analytics[local.combined_diagnostics.diagnostics_destinations.log_analytics[each.value.log_analytics_workspace_destination].log_analytics_key].id, null)
   global_settings                       = local.global_settings
   base_tags                             = try(local.global_settings.inherit_tags, false) ? try(local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].tags, {}) : {}
   diagnostic_profiles                   = try(each.value.diagnostic_profiles, null)

--- a/examples/app_insights/102-workspace-based-central-logs/configuration.tfvars
+++ b/examples/app_insights/102-workspace-based-central-logs/configuration.tfvars
@@ -1,0 +1,37 @@
+global_settings = {
+  regions = {
+    region1 = "uksouth"
+  }
+}
+
+resource_groups = {
+  rg1 = {
+    name = "example-appinsight-rg"
+  }
+}
+
+diagnostic_log_analytics = {
+  central_logs_region1 = {
+    region             = "region1"
+    name               = "central_logs"
+    resource_group_key = "rg1"
+  }
+}
+
+diagnostics_destinations = {
+  log_analytics = {
+    central_logs = {
+      log_analytics_key              = "central_logs_region1"
+      log_analytics_destination_type = "Dedicated"
+    }
+  }
+}
+
+azurerm_application_insights = {
+  webapp = {
+    name                                = "example-appinsights-web"
+    resource_group_key                  = "rg1"
+    application_type                    = "web"
+    log_analytics_workspace_destination = "central_logs"
+  }
+}


### PR DESCRIPTION
# Closes [#1268](https://github.com/aztfmod/terraform-azurerm-caf/issues/1268)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have added example(s) inside the [./examples/] folder
- [x] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Add support to Application Insights for Central Diagnostics Log Analytics Workspace

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Run example in the normal way:

```
cd /tf/caf/examples
az login
terraform init
terraform apply-var-file app_insights/102-workspace-based-central-logs/configuration.tfvars
terraform destroy -var-file app_insights/102-workspace-based-central-logs/configuration.tfvars
```
