### PR TITLE
Making private_ip_address optional in AGW following AzureRM 2.99.0

### DIFF
--- a/examples/app_gateway/103-public-only/application.tfvars
+++ b/examples/app_gateway/103-public-only/application.tfvars
@@ -1,0 +1,42 @@
+application_gateway_applications = {
+  demo_app1_80 = {
+
+    application_gateway_key = "agw1"
+    name                    = "demoapp1"
+
+    request_routing_rules = {
+      default = {
+        rule_type = "Basic"
+      }
+    }
+
+    backend_http_setting = {
+      port                                = 443
+      protocol                            = "Https"
+      pick_host_name_from_backend_address = true
+      probe_key                           = "probe_1"
+    }
+
+    backend_pool = {
+      fqdns = [
+        "cafdemo.appserviceenvironment.net"
+      ]
+    }
+
+    probes = {
+      probe_1 = {
+        name                = "probe-backend-443"
+        protocol            = "Https"
+        path                = "/status-0123456789abcdef"
+        host                = "cafdemo.appserviceenvironment.net"
+        interval            = 30
+        timeout             = 30
+        unhealthy_threshold = 3
+        match = {
+          status_code = ["200-399"]
+        }
+      }
+    }
+
+  }
+}

--- a/examples/app_gateway/103-public-only/configuration.tfvars
+++ b/examples/app_gateway/103-public-only/configuration.tfvars
@@ -1,0 +1,124 @@
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "australiaeast"
+  }
+}
+
+
+resource_groups = {
+  agw_region1 = {
+    name   = "example-agw"
+    region = "region1"
+  }
+}
+
+application_gateways = {
+  agw1 = {
+    resource_group_key = "agw_region1"
+    name               = "app_gateway_example"
+    vnet_key           = "vnet_region1"
+    subnet_key         = "app-gateway-subnet"
+    sku_name           = "WAF_v2"
+    sku_tier           = "WAF_v2"
+    capacity = {
+      autoscale = {
+        minimum_scale_unit = 0
+        maximum_scale_unit = 10
+      }
+    }
+    zones        = ["1"]
+    enable_http2 = true
+
+    front_end_ip_configurations = {
+      public = {
+        name          = "public"
+        public_ip_key = "example_agw_pip1_rg1"
+        #subnet_id = "/subscriptions/97958dac-xxxx-xxxx-xxxx-9f436fa73bd4/resourceGroups/vupf-rg-example-agw/providers/Microsoft.Network/virtualNetworks/vupf-vnet-app_gateway_vnet/subnets/vupf-snet-app_gateway_subnet"
+        #public_ip_id = "/subscriptions/97958dac-xxxx-xxxx-xxxx-9f436fa73bd4/resourceGroups/vupf-rg-example-agw/providers/Microsoft.Network/publicIPAddresses/vupf-pip-example_agw_pip1"
+      }
+    }
+
+    front_end_ports = {
+      80 = {
+        name     = "http"
+        port     = 80
+        protocol = "Http"
+      }
+      443 = {
+        name     = "https"
+        port     = 443
+        protocol = "Https"
+      }
+    }
+
+    waf_configuration = {
+      enabled                  = true
+      firewall_mode            = "Prevention" # or Detection
+      rule_set_type            = "OWASP"      # OWASP
+      rule_set_version         = "3.1"        # OWASP(2.2.9, 3.0, 3.1, 3.2)
+      file_upload_limit_mb     = 100
+      request_body_check       = true
+      max_request_body_size_kb = 128
+
+      # Optional
+      disabled_rule_groups = {
+        general = {
+          rule_group_name = "General"
+          rules           = ["200004"]
+        }
+        # Disable a spacific rule in the rule group
+        REQUEST-913-SCANNER-DETECTION = {
+          rule_group_name = "REQUEST-913-SCANNER-DETECTION"
+          rules           = ["913102"]
+        }
+        # Disable all rule in the rule group
+        REQUEST-930-APPLICATION-ATTACK-LFI = {
+          rule_group_name = "REQUEST-930-APPLICATION-ATTACK-LFI"
+        }
+      }
+
+      # Optional
+      exclusions = {
+        exc1 = {
+          match_variable          = "RequestHeaderNames"
+          selector_match_operator = "Equals" # StartsWith, EndsWith, Contains
+          selector                = "SomeHeader"
+        }
+      }
+    }
+
+  }
+}
+
+vnets = {
+  vnet_region1 = {
+    resource_group_key = "agw_region1"
+    vnet = {
+      name          = "app_gateway_vnet"
+      address_space = ["10.100.100.0/24"]
+    }
+    specialsubnets = {}
+    subnets = {
+      app-gateway-subnet = {
+        name    = "app_gateway_subnet"
+        cidr    = ["10.100.100.0/25"]
+        nsg_key = "application_gateway"
+      }
+    }
+
+  }
+}
+
+public_ip_addresses = {
+  example_agw_pip1_rg1 = {
+    name                    = "example_agw_pip1"
+    resource_group_key      = "agw_region1"
+    sku                     = "Standard"
+    allocation_method       = "Static"
+    ip_version              = "IPv4"
+    availability_zone       = "1"
+    idle_timeout_in_minutes = "4"
+
+  }
+}

--- a/examples/app_gateway/103-public-only/network_security_group_definition.tfvars
+++ b/examples/app_gateway/103-public-only/network_security_group_definition.tfvars
@@ -1,0 +1,47 @@
+#
+# Definition of the networking security groups
+#
+network_security_group_definition = {
+  # This entry is applied to all subnets with no NSG defined
+  empty_nsg = {
+  }
+
+  application_gateway = {
+
+    nsg = [
+      {
+        name                       = "Inbound-HTTP",
+        priority                   = "120"
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "*"
+        source_port_range          = "*"
+        destination_port_range     = "80-82"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+      },
+      {
+        name                       = "Inbound-HTTPs",
+        priority                   = "130"
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "*"
+        source_port_range          = "*"
+        destination_port_range     = "443"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+      },
+      {
+        name                       = "Inbound-AGW",
+        priority                   = "140"
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "*"
+        source_port_range          = "*"
+        destination_port_range     = "65200-65535"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+      },
+    ]
+  }
+}

--- a/modules/networking/application_gateway/locals.networking.tf
+++ b/modules/networking/application_gateway/locals.networking.tf
@@ -55,6 +55,6 @@ locals {
     try(local.ip_configuration.private.cidr[var.settings.front_end_ip_configurations.private.subnet_cidr_index], null),
     try(var.settings.front_end_ip_configurations.private.subnet_cidr, null)
   )
-  private_ip_address = cidrhost(local.private_cidr, var.settings.front_end_ip_configurations.private.private_ip_offset)
+  private_ip_address = try(cidrhost(local.private_cidr, var.settings.front_end_ip_configurations.private.private_ip_offset), null)
 
 }


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/1280)

## PR Checklist

---

- [x] I have added example(s) inside the [./examples/] folder
- [] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

The parameter `private_ip_address` is optional in AzureRM 2.99.0, however, it's a mandatory parameter in CAF Module 5.6.0.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

## Testing

Just doing a `terraform plan` using the config example in #1280 