### PR TITLE
Bug/agw private subnet cidr optional

### DIFF
--- a/examples/app_gateway/103-public-only/application.tfvars
+++ b/examples/app_gateway/103-public-only/application.tfvars
@@ -4,6 +4,15 @@ application_gateway_applications = {
     application_gateway_key = "agw1"
     name                    = "demoapp1"
 
+    listeners = {
+      public = {
+        name                           = "demo-app1-80-public"
+        front_end_ip_configuration_key = "public"
+        front_end_port_key             = "80"
+        host_name                      = "cafdemo.com"
+      }
+    }
+
     request_routing_rules = {
       default = {
         rule_type = "Basic"

--- a/modules/networking/application_gateway/locals.networking.tf
+++ b/modules/networking/application_gateway/locals.networking.tf
@@ -28,14 +28,14 @@ locals {
       )
     }
     private = {
-      subnet_id = coalesce(
+      subnet_id = try(coalesce(
         try(local.private_vnet.subnets[var.settings.front_end_ip_configurations.private.subnet_key].id, null),
         try(var.settings.front_end_ip_configurations.private.subnet_id, null)
-      )
-      cidr = coalesce(
+      ), null)
+      cidr = try(coalesce(
         try(local.private_vnet.subnets[var.settings.front_end_ip_configurations.private.subnet_key].cidr, null),
         try(var.settings.front_end_ip_configurations.private.subnet_cidr, null)
-      )
+      ), null)
     }
     public = {
       subnet_id = try(
@@ -44,17 +44,17 @@ locals {
         null
       )
 
-      ip_address_id = coalesce(
+      ip_address_id = try(coalesce(
         try(var.public_ip_addresses[var.client_config.landingzone_key][var.settings.front_end_ip_configurations.public.public_ip_key].id, var.public_ip_addresses[var.settings.front_end_ip_configurations.public.lz_key][var.settings.front_end_ip_configurations.public.public_ip_key].id, null),
         try(var.settings.front_end_ip_configurations.public.public_ip_id, null)
-      )
+      ), null)
     }
   }
 
-  private_cidr = coalesce(
+  private_cidr = try(coalesce(
     try(local.ip_configuration.private.cidr[var.settings.front_end_ip_configurations.private.subnet_cidr_index], null),
     try(var.settings.front_end_ip_configurations.private.subnet_cidr, null)
-  )
+  ), null)
   private_ip_address = try(cidrhost(local.private_cidr, var.settings.front_end_ip_configurations.private.private_ip_offset), null)
 
 }


### PR DESCRIPTION
# [Issue-1292](https://github.com/aztfmod/terraform-azurerm-caf/issues/1292)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have added example(s) inside the [./examples/] folder
- [x] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

- Public `http_listener` has been added to the example 103-public-only.
- Private and public frontend ip configurations are now fully optional following AzureRM 2.99.0.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

## Testing

1. `terraform plan`
2. `terraform apply`