### PR TITLE
Add support for multiple mysql vnet rules

### DIFF
--- a/examples/mysql_server/101-vnet-rule-mysql/configuration.tfvars
+++ b/examples/mysql_server/101-vnet-rule-mysql/configuration.tfvars
@@ -63,6 +63,11 @@ mysql_servers = {
       mysql_vnet_rule = {
         name = "mysql-vnet-rule"
       }
+      msql_vnet_rule_two = {
+        name = "msql-vnet-rule-two"
+        subnet_key = "mysql_subnet_two"
+        vnet_key = "vnet_region1"
+      }
     }
 
     mysql_databases = {
@@ -112,6 +117,11 @@ vnets = {
       mysql_subnet = {
         name              = "mysql_subnet"
         cidr              = ["10.150.100.0/25"]
+        service_endpoints = ["Microsoft.Sql"]
+      }
+      mysql_subnet_two = {
+        name              = "mysql_subnet_two"
+        cidr              = ["10.150.100.128/25"]
         service_endpoints = ["Microsoft.Sql"]
       }
     }

--- a/modules/databases/mysql_server/network_rule.tf
+++ b/modules/databases/mysql_server/network_rule.tf
@@ -4,6 +4,6 @@ resource "azurerm_mysql_virtual_network_rule" "mysql_vnet_rules" {
   name                = each.value.name
   resource_group_name = var.resource_group_name
   server_name         = azurerm_mysql_server.mysql.name
-  subnet_id           = try(var.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id, var.subnet_id)
+  subnet_id           = can(var.subnet_id) ? var.subnet_id : var.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
 }
 

--- a/modules/databases/mysql_server/network_rule.tf
+++ b/modules/databases/mysql_server/network_rule.tf
@@ -4,6 +4,6 @@ resource "azurerm_mysql_virtual_network_rule" "mysql_vnet_rules" {
   name                = each.value.name
   resource_group_name = var.resource_group_name
   server_name         = azurerm_mysql_server.mysql.name
-  subnet_id           = var.subnet_id
+  subnet_id           = try(var.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id, var.subnet_id)
 }
 


### PR DESCRIPTION
# [1227](https://github.com/aztfmod/terraform-azurerm-caf/issues/1227)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Currently it is not possible to create multiple mysql vnet rules with different subnets. The  mysql_vnet_rules block is using vnet and subnet reference from the top mysql server parameters. This change allows to create multipl vnet rules with different subnets

## Does this introduce a breaking change

- [ ] YES
- [x] NO

## Testing
