### PR TITLE
Support Storage Account services diagnostic settings

### DIFF
--- a/examples/storage_accounts/100-simple-storage-account-diagnostics/diagnostics.tfvars
+++ b/examples/storage_accounts/100-simple-storage-account-diagnostics/diagnostics.tfvars
@@ -30,15 +30,26 @@ diagnostics_definition = {
   storage = {
     name = "operational_logs_and_metrics"
     categories = {
+      metric = [
+        #["Category name",  "Diagnostics Enabled(true/false)", "Retention Enabled(true/false)", Retention_period]
+        ["Transaction", true, false, 7],
+        ["Capacity", true, false, 7],
+      ]
+    }
+  }
+  storage_blob = {
+    name = "operational_logs_and_metrics"
+    categories = {
       log = [
         # ["Category name",  "Diagnostics Enabled(true/false)", "Retention Enabled(true/false)", Retention_period]
-        # ["StorageRead", true, false, 14],
-        # ["StorageWrite", true, false, 14],
-        # ["StorageDelete", true, false, 14]
+        ["StorageRead", true, false, 14],
+        ["StorageWrite", true, false, 14],
+        ["StorageDelete", true, false, 14]
       ]
       metric = [
         #["Category name",  "Diagnostics Enabled(true/false)", "Retention Enabled(true/false)", Retention_period]
         ["Transaction", true, false, 7],
+        ["Capacity", true, false, 7],
       ]
     }
   }

--- a/examples/storage_accounts/100-simple-storage-account-diagnostics/storage_accounts.tfvars
+++ b/examples/storage_accounts/100-simple-storage-account-diagnostics/storage_accounts.tfvars
@@ -33,5 +33,20 @@ storage_accounts = {
       }
     }
 
+    diagnostic_profiles_blob = {
+      central_logs_region1 = {
+        name             = "log_and_metrics_log_analytics"
+        definition_key   = "storage_blob"
+        destination_type = "log_analytics"
+        destination_key  = "central_logs"
+      }
+      dsa1 = {
+        name             = "log_and_metrics_log_storage"
+        definition_key   = "storage_blob"
+        destination_type = "storage"
+        destination_key  = "all_regions"
+      }
+    }
+
   }
 }

--- a/modules/storage_account/diagnostics.tf
+++ b/modules/storage_account/diagnostics.tf
@@ -7,3 +7,46 @@ module "diagnostics" {
   diagnostics       = var.diagnostics
   profiles          = try(var.diagnostic_profiles, {})
 }
+
+module "diagnostics_blob" {
+  source = "../diagnostics"
+  count  = var.diagnostic_profiles_blob == {} ? 0 : 1
+
+  resource_id       = "${azurerm_storage_account.stg.id}/blobServices/default/"
+  resource_location = azurerm_storage_account.stg.location
+  diagnostics       = var.diagnostics
+  profiles          = try(var.diagnostic_profiles_blob, {})
+}
+
+
+module "diagnostics_queue" {
+  source = "../diagnostics"
+  count  = var.diagnostic_profiles_queue == {} ? 0 : 1
+
+  resource_id       = "${azurerm_storage_account.stg.id}/queueServices/default/"
+  resource_location = azurerm_storage_account.stg.location
+  diagnostics       = var.diagnostics
+  profiles          = try(var.diagnostic_profiles_queue, {})
+}
+
+
+module "diagnostics_table" {
+  source = "../diagnostics"
+  count  = var.diagnostic_profiles_table == {} ? 0 : 1
+
+  resource_id       = "${azurerm_storage_account.stg.id}/tableServices/default/"
+  resource_location = azurerm_storage_account.stg.location
+  diagnostics       = var.diagnostics
+  profiles          = try(var.diagnostic_profiles_table, {})
+}
+
+
+module "diagnostics_file" {
+  source = "../diagnostics"
+  count  = var.diagnostic_profiles_file == {} ? 0 : 1
+
+  resource_id       = "${azurerm_storage_account.stg.id}/fileServices/default/"
+  resource_location = azurerm_storage_account.stg.location
+  diagnostics       = var.diagnostics
+  profiles          = try(var.diagnostic_profiles_file, {})
+}

--- a/modules/storage_account/variables.tf
+++ b/modules/storage_account/variables.tf
@@ -36,6 +36,22 @@ variable "diagnostic_profiles" {
   default = {}
 }
 
+variable "diagnostic_profiles_blob" {
+  default = {}
+}
+
+variable "diagnostic_profiles_queue" {
+  default = {}
+}
+
+variable "diagnostic_profiles_table" {
+  default = {}
+}
+
+variable "diagnostic_profiles_file" {
+  default = {}
+}
+
 variable "diagnostics" {
   default = {}
 }

--- a/storage_accounts.tf
+++ b/storage_accounts.tf
@@ -3,20 +3,24 @@ module "storage_accounts" {
   source   = "./modules/storage_account"
   for_each = var.storage_accounts
 
-  base_tags           = try(local.global_settings.inherit_tags, false) ? try(local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].tags, {}) : {}
-  client_config       = local.client_config
-  diagnostic_profiles = try(each.value.diagnostic_profiles, {})
-  diagnostics         = local.combined_diagnostics
-  global_settings     = local.global_settings
-  location            = can(local.global_settings.regions[each.value.region]) ? local.global_settings.regions[each.value.region] : local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].location
-  managed_identities  = local.combined_objects_managed_identities
-  private_dns         = local.combined_objects_private_dns
-  private_endpoints   = try(each.value.private_endpoints, {})
-  recovery_vaults     = local.combined_objects_recovery_vaults
-  resource_group_name = can(each.value.resource_group.name) || can(each.value.resource_group_name) ? try(each.value.resource_group.name, each.value.resource_group_name) : local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group_key, each.value.resource_group.key)].name
-  resource_groups     = try(each.value.private_endpoints, {}) == {} ? null : local.resource_groups
-  storage_account     = each.value
-  vnets               = local.combined_objects_networking
+  base_tags                 = try(local.global_settings.inherit_tags, false) ? try(local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].tags, {}) : {}
+  client_config             = local.client_config
+  diagnostic_profiles       = try(each.value.diagnostic_profiles, {})
+  diagnostic_profiles_blob  = try(each.value.diagnostic_profiles_blob, {})
+  diagnostic_profiles_queue = try(each.value.diagnostic_profiles_queue, {})
+  diagnostic_profiles_table = try(each.value.diagnostic_profiles_table, {})
+  diagnostic_profiles_file  = try(each.value.diagnostic_profiles_file, {})
+  diagnostics               = local.combined_diagnostics
+  global_settings           = local.global_settings
+  location                  = can(local.global_settings.regions[each.value.region]) ? local.global_settings.regions[each.value.region] : local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].location
+  managed_identities        = local.combined_objects_managed_identities
+  private_dns               = local.combined_objects_private_dns
+  private_endpoints         = try(each.value.private_endpoints, {})
+  recovery_vaults           = local.combined_objects_recovery_vaults
+  resource_group_name       = can(each.value.resource_group.name) || can(each.value.resource_group_name) ? try(each.value.resource_group.name, each.value.resource_group_name) : local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group_key, each.value.resource_group.key)].name
+  resource_groups           = try(each.value.private_endpoints, {}) == {} ? null : local.resource_groups
+  storage_account           = each.value
+  vnets                     = local.combined_objects_networking
 }
 
 output "storage_accounts" {


### PR DESCRIPTION
# [1299](https://github.com/aztfmod/terraform-azurerm-caf/issues/1299)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have added example(s) inside the [./examples/] folder
- [x] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Currently only Storage Account diagnostic settings are supported. We need to be able to add diagnostic settings for Storage Account services such as Blob, Queue, Table, and Files

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
