### PR TITLE
Add weekly/monthly/yearly parameters in fileshare backup retention policy

### DIFF
--- a/modules/recovery_vault/backup_policies_file_share.tf
+++ b/modules/recovery_vault/backup_policies_file_share.tf
@@ -26,6 +26,36 @@ resource "azurerm_backup_policy_file_share" "fs" {
       count = each.value.retention_daily.count
     }
   }
+
+  dynamic "retention_weekly" {
+    for_each = lookup(each.value, "retention_weekly", null) == null ? [] : [1]
+
+    content {
+      count    = each.value.retention_weekly.count
+      weekdays = each.value.retention_weekly.weekdays
+    }
+  }
+
+  dynamic "retention_monthly" {
+    for_each = lookup(each.value, "retention_monthly", null) == null ? [] : [1]
+
+    content {
+      count    = each.value.retention_monthly.count
+      weekdays = each.value.retention_monthly.weekdays
+      weeks    = each.value.retention_monthly.weeks
+    }
+  }
+
+  dynamic "retention_yearly" {
+    for_each = lookup(each.value, "retention_yearly", null) == null ? [] : [1]
+
+    content {
+      count    = each.value.retention_yearly.count
+      weekdays = each.value.retention_yearly.weekdays
+      weeks    = each.value.retention_yearly.weeks
+      months   = each.value.retention_yearly.months
+    }
+  }
 }
 
 # TODO: SAP HANA in Azure VM when available


### PR DESCRIPTION
:

# Issue
In recovery_vaults / asr / fs / backup_policies configuration,  weekly/monthly/yearly retention parameters are missing. 
These parameters are present for VM backup policies. So this fix is actually just a copy/paste of this VM parameters into FS ressource

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
The 3 parameters was succesfully applied to a file share backup policy