### PR TITLE
Data Factory: Add try to vnet integration block

### DIFF
--- a/modules/data_factory/data_factory_integration_runtime_azure_ssis/module.tf
+++ b/modules/data_factory/data_factory_integration_runtime_azure_ssis/module.tf
@@ -117,10 +117,10 @@ resource "azurerm_data_factory_integration_runtime_azure_ssis" "dfiras" {
     for_each = try(var.settings.vnet_integration, null) != null ? [var.settings.vnet_integration] : []
 
     content {
-      vnet_id     = vnet_integration.value.vnet_id
-      subnet_name = vnet_integration.value.subnet_name
-      subnet_id   = vnet_integration.value.subnet_id
-      public_ips  = vnet_integration.value.public_ips
+      vnet_id     = try(vnet_integration.value.vnet_id, null)
+      subnet_name = try(vnet_integration.value.subnet_name, null)
+      subnet_id   = try(vnet_integration.value.subnet_id, null)
+      public_ips  = try(vnet_integration.value.public_ips, null)
     }
   }
 


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/1320)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Data Factory Integration Runtime Azure SSIS' "vnet_integration" dynamic block requires all four attributes to be passed, however Terraform permits all four as optional.

Additionally, Terraform states that only "subnet_id" or "subnet_name" can be specified - not both.

This PR allows all four attributes to be optional rather than forced - allowing the resource to be deployed successfully.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
