### PR TITLE
feat: adding support for 'static_site_custom_domain' within 'static_site' module

### DIFF
--- a/.github/workflows/standalone-scenarios.json
+++ b/.github/workflows/standalone-scenarios.json
@@ -235,6 +235,5 @@
     "webapps/function_app/102-function_app-linux",
     "webapps/function_app/103-function_app-windows",
     "webapps/static_site/101-simple-static-web-app",
-    "webapps/static_site/102-static-web-app-custom-domain"
   ]
 }

--- a/.github/workflows/standalone-scenarios.json
+++ b/.github/workflows/standalone-scenarios.json
@@ -234,6 +234,7 @@
     "webapps/function_app/101-function_app-private",
     "webapps/function_app/102-function_app-linux",
     "webapps/function_app/103-function_app-windows",
-    "webapps/static_site/101-simple-static-web-app"
+    "webapps/static_site/101-simple-static-web-app",
+    "webapps/static_site/102-static-web-app-custom-domain"
   ]
 }

--- a/.github/workflows/standalone-scenarios.json
+++ b/.github/workflows/standalone-scenarios.json
@@ -234,6 +234,6 @@
     "webapps/function_app/101-function_app-private",
     "webapps/function_app/102-function_app-linux",
     "webapps/function_app/103-function_app-windows",
-    "webapps/static_site/101-simple-static-web-app",
+    "webapps/static_site/101-simple-static-web-app"
   ]
 }

--- a/examples/webapps/static_site/102-static-web-app-custom-domain/configuration.tfvars
+++ b/examples/webapps/static_site/102-static-web-app-custom-domain/configuration.tfvars
@@ -1,0 +1,43 @@
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "westeurope"
+  }
+}
+
+resource_groups = {
+  rg1 = {
+    name   = "staticsite"
+    region = "region1"
+  }
+}
+
+static_sites = {
+  s1 = {
+    name               = "staticsite"
+    resource_group_key = "rg1"
+    region             = "region1"
+
+    sku_tier = "Standard"
+    sku_size = "Standard"
+
+    custom_domains = {
+      # root domain txt token
+      # also needs an ALIAS record set (see: https://docs.microsoft.com/en-us/azure/static-web-apps/custom-domain-external)
+      txt_domain = {
+        domain_name     = "mystaticsite.com"
+        validation_type = "dns-txt-token"
+      }
+      cname_subdomain = {
+        # note: A CNAME cannot be placed at the root domain level
+        # so you cannot use a CNAME entry for mystaticsite.com
+        domain_name     = "subdomain.mystaticsite.com"
+        validation_type = "cname-delegation"
+      }
+      www_subdomain = {
+        domain_name     = "www.mystaticsite.com"
+        validation_type = "cname-delegation"
+      }
+    }
+  }
+}

--- a/modules/webapps/static_site/custom_domain.tf
+++ b/modules/webapps/static_site/custom_domain.tf
@@ -1,0 +1,7 @@
+resource "azurerm_static_site_custom_domain" "custom_domains" {
+  for_each = var.custom_domains
+
+  static_site_id  = azurerm_static_site.static_site.id
+  domain_name     = each.value.domain_name
+  validation_type = each.value.validation_type
+}

--- a/modules/webapps/static_site/output.tf
+++ b/modules/webapps/static_site/output.tf
@@ -12,3 +12,12 @@ output "api_key" {
   value       = azurerm_static_site.static_site.api_key
   description = "The API key of this Static Web App, which is used for later interacting with this Static Web App from other clients, e.g. GitHub Action."
 }
+
+output "custom_domain" {
+  value = {
+    for key, value in try(var.custom_domains, {}) : key => {
+      id = azurerm_static_site_custom_domain.custom_domains[key].id
+      validation_token = azurerm_static_site_custom_domain.custom_domains[key].validation_token
+    }
+  }
+}

--- a/modules/webapps/static_site/variables.tf
+++ b/modules/webapps/static_site/variables.tf
@@ -59,3 +59,7 @@ variable "diagnostic_profiles" {
 variable "diagnostics" {
   default = null
 }
+
+variable "custom_domains" {
+  default = {}
+}

--- a/static_sites.tf
+++ b/static_sites.tf
@@ -17,6 +17,7 @@ module "static_sites" {
   diagnostic_profiles = try(each.value.diagnostic_profiles, null)
   diagnostics         = local.combined_diagnostics
   tags                = try(each.value.tags, null)
+  custom_domains      = try(each.value.custom_domains, {})
 }
 
 output "static_sites" {


### PR DESCRIPTION
Adding support for 'static_site_custom_domain' within 'static_site'. This is a follow up of https://github.com/aztfmod/terraform-azurerm-caf/issues/1240.

# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/1240)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have added example(s) inside the [./examples/] folder
- [x] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Adding support for "azurerm_static_site_custom_domain".

## Does this introduce a breaking change

- [ ] YES
- [x] NO
