### PR TITLE
Add SSL policy for all HTTPS listeners by default

### DIFF
--- a/examples/app_gateway/302-listener-ssl-policy/agw_application.tfvars
+++ b/examples/app_gateway/302-listener-ssl-policy/agw_application.tfvars
@@ -1,0 +1,122 @@
+
+application_gateway_applications_v1 = {
+  demo_app1 = {
+    name                    = "demo_app1"
+    application_gateway_key = "agw1"
+
+    backend_pools = {
+      demo = {
+        name  = "demo_pool01"
+        fqdns = ["babc-app-ptsg-5sspdemoappap-lo.babc-ase-ase01-pd.appserviceenvironment.net"]
+
+        # ip_addresses = ["10.0.0.4", "10.0.0.5"]
+
+        # app_services = {
+        #   lz_key = ""
+        #   key = ""
+        # }
+      }
+    }
+
+    http_settings = {
+      demo = {
+        name                        = "demo_http_setting01"
+        front_end_port_key          = "80"
+        host_name_from_backend_pool = true
+        timeout                     = 45
+      }
+    }
+
+    # frontend_ports to be used only if application configuraiton uses non standards https/https ports i.e anything other than 80/443
+    frontend_ports = {
+      "8443" = {
+        name = "8443"
+        port = 8443
+      }
+    }
+
+    http_listeners = {
+      public = {
+        name                           = "demo_http_listener01"
+        front_end_ip_configuration_key = "public"
+        front_end_port_key             = "80"
+        host_name                      = "demo1.app1.com"
+      }
+      public_ssl = {
+        name                           = "demo_https_listener01"
+        front_end_ip_configuration_key = "public"
+        front_end_port_key             = "443"
+        host_name                      = "demo1.app1.com"
+        ssl_cert_key                   = "demo"
+      }
+    }
+
+    request_routing_rules = {
+      default = {
+        name              = "default_demo_app1"
+        rule_type         = "PathBasedRouting"
+        http_listener_key = "public"
+        backend_pool_key  = "demo"
+        http_settings_key = "demo"
+        url_path_map_key  = "demo"
+        priority          = 100
+      }
+    }
+
+    ssl_certs = {
+      demo = {
+        name = "demo"
+        keyvault = {
+          certificate_key = "demoapp1.cafsandpit.com"
+
+          # lz_key                  = "" #remote keyvault
+
+          # certificate_request_key = "" #for cert request
+
+          # manual cert
+          # key                     = "" #keyvault key
+          # certificate_name        = "" #manual cert name
+        }
+      }
+    }
+
+    url_path_maps = {
+      demo = {
+        name              = "test_path_map"
+        paths             = "/test/*"
+        rule_name         = "test_path_rule"
+        backend_pool_key  = "demo"
+        http_settings_key = "demo"
+      }
+    }
+
+    url_path_rules = {
+      rule1 = {
+        name             = "rule1-demo"
+        url_path_map_key = "demo"
+        paths            = "/test/rule1/*"
+      }
+      rule2 = {
+        name             = "rule2-demo"
+        url_path_map_key = "demo"
+        paths            = "/test/rule2/*"
+      }
+    }
+
+    probes = {
+      test = {
+        name                         = "test-http"
+        protocol                     = "Http" # Http or Https
+        host                         = "test.com"
+        host_name_from_http_settings = false
+        # port                                    = "" # Leave not set if pick port from backend http settings
+        path               = "/api/health"
+        interval           = "60"
+        timeout            = "60"
+        threshold          = "3"
+        min_servers        = "0"
+        match_status_codes = "200-499"
+      }
+    }
+  }
+}

--- a/examples/app_gateway/302-listener-ssl-policy/agw_platform.tfvars
+++ b/examples/app_gateway/302-listener-ssl-policy/agw_platform.tfvars
@@ -1,0 +1,73 @@
+application_gateway_platforms = {
+  agw1 = {
+    resource_group_key = "agw_region1"
+    name               = "app_gateway_example"
+    vnet_key           = "vnet_region1"
+    subnet_key         = "app-gateway-subnet"
+    sku_name           = "WAF_v2"
+    sku_tier           = "WAF_v2"
+    capacity = {
+      autoscale = {
+        minimum_scale_unit = 0
+        maximum_scale_unit = 5
+      }
+    }
+    zones        = ["1"]
+    enable_http2 = true
+
+    identity = {
+      managed_identity_keys = [
+        "agw1_keyvault_demo_certs"
+      ]
+    }
+
+    front_end_ip_configurations = {
+      public = {
+        name          = "public"
+        public_ip_key = "example_agw_pip1_rg1"
+      }
+      private = {
+        name                          = "private"
+        vnet_key                      = "vnet_region1"
+        subnet_key                    = "app-gateway-subnet"
+        subnet_cidr_index             = 0 # It is possible to have more than one cidr block per subnet
+        private_ip_offset             = 4 # e.g. cidrhost(10.10.0.0/25,4) = 10.10.0.4 => AGW private IP address
+        private_ip_address_allocation = "Static"
+      }
+    }
+
+    front_end_ports = {
+      80 = {
+        name     = "http"
+        port     = 80
+        protocol = "Http"
+      }
+      443 = {
+        name     = "https"
+        port     = 443
+        protocol = "Https"
+      }
+    }
+    
+    #default: wont be able to change after creation as this is required for agw tf resource
+    default = {
+      frontend_port_key             = "80"              
+      frontend_ip_configuration_key = "public"         
+      backend_address_pool_name     = "default-beap"    
+      http_setting_name             = "default-be-htst" 
+      listener_name                 = "default-httplstn"
+      request_routing_rule_name     = "default-rqrt"
+      cookie_based_affinity         = "Disabled"
+      request_timeout               = "60"
+      rule_type                     = "Basic" 
+    }
+
+    listener_ssl_policy = {
+      default = {
+        policy_type          = "Predefined"
+        policy_name          = "AppGwSslPolicy20170401S"
+        min_protocol_version = "TLSv1_2"  
+      }
+    } 
+  }
+}

--- a/examples/app_gateway/302-listener-ssl-policy/certificates.tfvars
+++ b/examples/app_gateway/302-listener-ssl-policy/certificates.tfvars
@@ -1,0 +1,86 @@
+keyvault_certificates = {
+  "demoapp1.cafsandpit.com" = {
+
+    keyvault_key = "certificates"
+
+    # may only contain alphanumeric characters and dashes
+    name = "demoapp1-cafsandpit-com"
+
+    subject            = "CN=demoapp1"
+    validity_in_months = 12
+
+    subject_alternative_names = {
+      #  A list of alternative DNS names (FQDNs) identified by the Certificate.
+      # Changing this forces a new resource to be created.
+      dns_names = [
+        "demoapp1.cafsandpit.com"
+      ]
+
+      # A list of email addresses identified by this Certificate.
+      # Changing this forces a new resource to be created.
+      # emails = []
+
+      # A list of User Principal Names identified by the Certificate.
+      # Changing this forces a new resource to be created.
+      # upns = []
+    }
+
+    tags = {
+      type = "SelfSigned"
+    }
+
+    # Possible values include Self (for self-signed certificate),
+    # or Unknown (for a certificate issuing authority like Let's Encrypt
+    # and Azure direct supported ones).
+    # Changing this forces a new resource to be created
+    issuer_parameters = "Self"
+
+    exportable = true
+
+    # Possible values include 2048 and 4096.
+    # Changing this forces a new resource to be created.
+    key_size  = 4096
+    key_type  = "RSA"
+    reuse_key = true
+
+    # The Type of action to be performed when the lifetime trigger is triggered.
+    # Possible values include AutoRenew and EmailContacts.
+    # Changing this forces a new resource to be created.
+    action_type = "AutoRenew"
+
+    # The number of days before the Certificate expires that the action
+    # associated with this Trigger should run.
+    # Changing this forces a new resource to be created.
+    # Conflicts with lifetime_percentage
+    days_before_expiry = 30
+
+
+    # The percentage at which during the Certificates Lifetime the action
+    # associated with this Trigger should run.
+    # Changing this forces a new resource to be created.
+    # Conflicts with days_before_expiry
+    # lifetime_percentage = 90
+
+    # The Content-Type of the Certificate, such as application/x-pkcs12 for a PFX
+    # or application/x-pem-file for a PEM.
+    # Changing this forces a new resource to be created.
+    content_type = "application/x-pkcs12"
+
+    # A list of uses associated with this Key.
+    # Possible values include
+    # cRLSign, dataEncipherment, decipherOnly,
+    # digitalSignature, encipherOnly, keyAgreement, keyCertSign,
+    # keyEncipherment and nonRepudiation
+    # and are case-sensitive.
+    # Changing this forces a new resource to be created
+    key_usage = [
+      "cRLSign",
+      "dataEncipherment",
+      "digitalSignature",
+      "keyAgreement",
+      "keyCertSign",
+      "keyEncipherment",
+    ]
+  }
+
+}

--- a/examples/app_gateway/302-listener-ssl-policy/configuration.tfvars
+++ b/examples/app_gateway/302-listener-ssl-policy/configuration.tfvars
@@ -1,0 +1,13 @@
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "australiaeast"
+  }
+}
+
+resource_groups = {
+  agw_region1 = {
+    name   = "example-agw"
+    region = "region1"
+  }
+}

--- a/examples/app_gateway/302-listener-ssl-policy/keyvaults.tfvars
+++ b/examples/app_gateway/302-listener-ssl-policy/keyvaults.tfvars
@@ -1,0 +1,26 @@
+keyvaults = {
+  certificates = {
+    name               = "demo_certs"
+    resource_group_key = "agw_region1"
+    sku_name           = "standard"
+
+    enabled_for_deployment = true
+
+    creation_policies = {
+      logged_in_user = {
+        certificate_permissions = ["Get", "List", "Update", "Create", "Import", "Delete", "Purge", "Recover"]
+        secret_permissions      = ["Set", "Get", "List", "Delete", "Purge", "Recover"]
+      }
+    }
+  }
+}
+
+keyvault_access_policies = {
+  certificates = {
+    agw1_keyvault_demo_certs = {
+      managed_identity_key    = "agw1_keyvault_demo_certs"
+      certificate_permissions = ["Get"]
+      secret_permissions      = ["Get"]
+    }
+  }
+}

--- a/examples/app_gateway/302-listener-ssl-policy/managed_identities.tfvars
+++ b/examples/app_gateway/302-listener-ssl-policy/managed_identities.tfvars
@@ -1,0 +1,6 @@
+managed_identities = {
+  agw1_keyvault_demo_certs = {
+    name               = "agw1-demo-certs-msi"
+    resource_group_key = "agw_region1"
+  }
+}

--- a/examples/app_gateway/302-listener-ssl-policy/network_security_group_definition.tfvars
+++ b/examples/app_gateway/302-listener-ssl-policy/network_security_group_definition.tfvars
@@ -1,0 +1,47 @@
+#
+# Definition of the networking security groups
+#
+network_security_group_definition = {
+  # This entry is applied to all subnets with no NSG defined
+  empty_nsg = {
+  }
+
+  application_gateway = {
+
+    nsg = [
+      {
+        name                       = "Inbound-HTTP",
+        priority                   = "120"
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "*"
+        source_port_range          = "*"
+        destination_port_range     = "80-82"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+      },
+      {
+        name                       = "Inbound-HTTPs",
+        priority                   = "130"
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "*"
+        source_port_range          = "*"
+        destination_port_range     = "443"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+      },
+      {
+        name                       = "Inbound-AGW",
+        priority                   = "140"
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "*"
+        source_port_range          = "*"
+        destination_port_range     = "65200-65535"
+        source_address_prefix      = "GatewayManager"
+        destination_address_prefix = "*"
+      },
+    ]
+  }
+}

--- a/examples/app_gateway/302-listener-ssl-policy/networking.tfvars
+++ b/examples/app_gateway/302-listener-ssl-policy/networking.tfvars
@@ -1,0 +1,31 @@
+vnets = {
+  vnet_region1 = {
+    resource_group_key = "agw_region1"
+    vnet = {
+      name          = "app_gateway_vnet"
+      address_space = ["10.100.100.0/24"]
+    }
+    specialsubnets = {}
+    subnets = {
+      app-gateway-subnet = {
+        name    = "app_gateway_subnet"
+        cidr    = ["10.100.100.0/25"]
+        nsg_key = "application_gateway"
+      }
+    }
+
+  }
+}
+
+public_ip_addresses = {
+  example_agw_pip1_rg1 = {
+    name                    = "example_agw_pip1"
+    resource_group_key      = "agw_region1"
+    sku                     = "Standard"
+    allocation_method       = "Static"
+    ip_version              = "IPv4"
+    availability_zone       = "1"
+    idle_timeout_in_minutes = "4"
+
+  }
+}

--- a/modules/networking/application_gateway_platform/application_gateway.tf
+++ b/modules/networking/application_gateway_platform/application_gateway.tf
@@ -67,6 +67,17 @@ resource "azurerm_application_gateway" "agw" {
     }
   }
 
+  dynamic "ssl_policy" {
+    for_each = can(var.settings.listener_ssl_policy.default) == null ? [] : [var.settings.listener_ssl_policy.default]
+    content {
+      disabled_protocols   = try(ssl_policy.value.disabled_protocols, null)
+      policy_type          = try(ssl_policy.value.policy_type, null)
+      policy_name          = try(ssl_policy.value.policy_name, null)
+      cipher_suites        = try(ssl_policy.value.cipher_suites, null)
+      min_protocol_version = try(ssl_policy.value.min_protocol_version, null)
+    }
+  }
+
   dynamic "autoscale_configuration" {
     for_each = can(var.settings.capacity.autoscale) ? [var.settings.capacity.autoscale] : []
 

--- a/modules/networking/application_gateway_platform/application_gateway.tf
+++ b/modules/networking/application_gateway_platform/application_gateway.tf
@@ -68,7 +68,7 @@ resource "azurerm_application_gateway" "agw" {
   }
 
   dynamic "ssl_policy" {
-    for_each = can(var.settings.listener_ssl_policy.default) == null ? [] : [var.settings.listener_ssl_policy.default]
+    for_each = try(var.settings.listener_ssl_policy, {})
     content {
       disabled_protocols   = try(ssl_policy.value.disabled_protocols, null)
       policy_type          = try(ssl_policy.value.policy_type, null)


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [X] I have added example(s) inside the [./examples/] folder
- [x] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [X] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [X] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Currently, there is no option of defining SSL policy for listeners by default, whether choosing from one of the predefined policies or creating a custom security policy. The PR configures a default listener SSL policy which is applied to all HTTPS listeners unless they are overridden by listener specific SSL Policy under SSL settings.

## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
