### PR TITLE
Fixed deprecation warning for azurerm_api_management_custom_domain

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 2.99"
+      version = "~> 3.0"
       configuration_aliases = [
         azurerm.vhub
       ]

--- a/modules/apim/api_management_custom_domain/module.tf
+++ b/modules/apim/api_management_custom_domain/module.tf
@@ -40,25 +40,37 @@ resource "azurerm_api_management_custom_domain" "apim" {
     }
   }
 
-  dynamic "proxy" {
-    for_each = try(var.settings.proxy, null) != null ? [var.settings.proxy] : []
+  dynamic "gateway" {
+    for_each = (
+      try(
+        coalesce(
+          var.settings.gateway,
+          var.settings.proxy
+        ),
+      null) != null
+      ? [coalesce(
+        var.settings.gateway,
+        var.settings.proxy
+      )]
+      : []
+    )
     content {
-      host_name            = try(proxy.value.host_name, null)
-      certificate          = try(proxy.value.certificate, null)
-      certificate_password = try(proxy.value.certificate_password, null)
-      default_ssl_binding  = try(proxy.value.default_ssl_binding, null)
-      #key_vault_id = var.remote_objects.keyvault_certificates[var.client_config.landingzone_key][proxy.value.key_vault_certificate.certificate_key].secret_id
+      host_name            = try(gateway.value.host_name, null)
+      certificate          = try(gateway.value.certificate, null)
+      certificate_password = try(gateway.value.certificate_password, null)
+      default_ssl_binding  = try(gateway.value.default_ssl_binding, null)
+      #key_vault_id = var.remote_objects.keyvault_certificates[var.client_config.landingzone_key][gateway.value.key_vault_certificate.certificate_key].secret_id
       key_vault_id = try(
         #data.azurerm_key_vault_certificate.manual_certs[each.key].secret_id,
-        try(var.remote_objects.keyvault_certificates[proxy.value.key_vault_certificate.lz_key][proxy.value.key_vault_certificate.certificate_key].secret_id, null),
-        try(var.remote_objects.keyvault_certificates[var.client_config.landingzone_key][proxy.value.key_vault_certificate.certificate_key].secret_id, null),
-        try(var.remote_objects.keyvault_certificate_requests[var.client_config.landingzone_key][proxy.value.certificate_request_key].secret_id, null),
-        try(var.remote_objects.keyvault_certificate_requests[proxy.value.key_vault_certificate.lz_key][proxy.value.certificate_request_key].secret_id, null),
-        try(proxy.value.key_vault_id, null),
+        try(var.remote_objects.keyvault_certificates[gateway.value.key_vault_certificate.lz_key][gateway.value.key_vault_certificate.certificate_key].secret_id, null),
+        try(var.remote_objects.keyvault_certificates[var.client_config.landingzone_key][gateway.value.key_vault_certificate.certificate_key].secret_id, null),
+        try(var.remote_objects.keyvault_certificate_requests[var.client_config.landingzone_key][gateway.value.certificate_request_key].secret_id, null),
+        try(var.remote_objects.keyvault_certificate_requests[gateway.value.key_vault_certificate.lz_key][gateway.value.certificate_request_key].secret_id, null),
+        try(gateway.value.key_vault_id, null),
         null
       )
 
-      negotiate_client_certificate = try(proxy.value.negotiate_client_certificate, null)
+      negotiate_client_certificate = try(gateway.value.negotiate_client_certificate, null)
     }
   }
 


### PR DESCRIPTION
# [1346](https://github.com/aztfmod/terraform-azurerm-caf/issues/1346)


## Description

```proxy``` is deprecated and will be renamed to ```gateway``` in version 3.0 of the AzureRM provider
I also added a fix to preserve the configuration compatibility.

## Does this introduce a breaking change

- [X] YES

azurerm 3.0 is required.

## Testing

Create a apim resource with custom domain
