### PR TITLE
Add remote virtual subnet direct referencing for Application Gateway

### DIFF
--- a/application_gateway_platforms.tf
+++ b/application_gateway_platforms.tf
@@ -16,6 +16,7 @@ module "application_gateway_platforms" {
   sku_name                         = each.value.sku_name
   sku_tier                         = each.value.sku_tier
   vnets                            = local.combined_objects_networking
+  virtual_subnets                  = local.combined_objects_virtual_subnets
 
   location            = can(local.global_settings.regions[each.value.region]) ? local.global_settings.regions[each.value.region] : local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].location
   resource_group_name = can(each.value.resource_group.name) || can(each.value.resource_group_name) ? try(each.value.resource_group.name, each.value.resource_group_name) : local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group_key, each.value.resource_group.key)].name

--- a/examples/app_gateway/303-agw-remote-subnet/app_gateways.tfvars
+++ b/examples/app_gateway/303-agw-remote-subnet/app_gateways.tfvars
@@ -1,0 +1,79 @@
+application_gateway_platforms = {
+  agw1 = {
+    resource_group_key = "agw_re1" 
+    name               = "app_gateway_example"
+    lz_key             = "networking"
+    subnet_key         = "web01"
+    sku_name           = "WAF_v2"
+    sku_tier           = "WAF_v2"
+
+    waf_policy = {
+      key = "wp1"
+    }
+
+    capacity = {
+      autoscale = {
+        minimum_scale_unit = 1
+        maximum_scale_unit = 5
+      }
+    }
+    zones        = ["1"]
+    enable_http2 = true
+
+    identity = {
+      type                  = "UserAssigned"
+      managed_identity_keys = ["agw_keyvault_secrets"]
+    }
+
+    front_end_ip_configurations = {
+      public = {
+        name          = "public"
+        public_ip_key = "agw_pip1"
+      }
+      private = {
+        name                          = "private"
+        lz_key                        = "networking"
+        subnet_key                    = "web01"
+        subnet_cidr_index             = 0 
+        private_ip_offset             = 4 
+        private_ip_address_allocation = "Static"
+      }
+    }
+
+    front_end_ports = {
+      80 = {
+        name     = "http-80"
+        port     = 80
+        protocol = "Http"
+      }
+      443 = {
+        name     = "https-443"
+        port     = 443
+        protocol = "Https"
+      }
+    }
+
+    default = {
+      frontend_port_key             = "80"
+      frontend_ip_configuration_key = "private"
+      backend_address_pool_name     = "default-beap"
+      http_setting_name             = "default-be-htst"
+      listener_name                 = "default-httplstn"
+      request_routing_rule_name     = "default-rqrt"
+      cookie_based_affinity         = "Disabled"
+      request_timeout               = "60"
+      rule_type                     = "Basic"
+    }
+  }
+}
+
+public_ip_addresses = {
+  agw_pip1 = {
+    name                    = "public-ip-example"
+    resource_group_key      = "agw_re1"
+    sku                     = "Standard"
+    allocation_method       = "Static"
+    ip_version              = "IPv4"
+    idle_timeout_in_minutes = "4"
+  }
+}

--- a/examples/app_gateway/303-agw-remote-subnet/applications.tfvars
+++ b/examples/app_gateway/303-agw-remote-subnet/applications.tfvars
@@ -1,0 +1,121 @@
+application_gateway_applications_v1 = {
+  demo_app1 = {
+    name                    = "demo_app1"
+    application_gateway_key = "agw1"
+
+    backend_pools = {
+      demo = {
+        name  = "demo_pool01"
+        fqdns = ["babc-app-ptsg-5sspdemoappap-lo.babc-ase-ase01-pd.appserviceenvironment.net"]
+
+        # ip_addresses = ["10.0.0.4", "10.0.0.5"]
+
+        # app_services = {
+        #   lz_key = ""
+        #   key = ""
+        # }
+      }
+    }
+
+    http_settings = {
+      demo = {
+        name                        = "demo_http_setting01"
+        front_end_port_key          = "80"
+        host_name_from_backend_pool = true
+        timeout                     = 45
+      }
+    }
+
+    # frontend_ports to be used only if application configuraiton uses non standards https/https ports i.e anything other than 80/443
+    frontend_ports = {
+      "8443" = {
+        name = "8443"
+        port = 8443
+      }
+    }
+
+    http_listeners = {
+      public = {
+        name                           = "demo_http_listener01"
+        front_end_ip_configuration_key = "public"
+        front_end_port_key             = "80"
+        host_name                      = "demo1.app1.com"
+      }
+      public_ssl = {
+        name                           = "demo_https_listener01"
+        front_end_ip_configuration_key = "public"
+        front_end_port_key             = "443"
+        host_name                      = "demo1.app1.com"
+        ssl_cert_key                   = "demo"
+      }
+    }
+
+    request_routing_rules = {
+      default = {
+        name              = "default_demo_app1"
+        rule_type         = "PathBasedRouting"
+        http_listener_key = "public"
+        backend_pool_key  = "demo"
+        http_settings_key = "demo"
+        url_path_map_key  = "demo"
+        priority          = 100
+      }
+    }
+
+    ssl_certs = {
+      demo = {
+        name = "demo"
+        keyvault = {
+          certificate_key = "demoapp1.cafsandpit.com"
+
+          # lz_key                  = "" #remote keyvault
+
+          # certificate_request_key = "" #for cert request
+
+          # manual cert
+          # key                     = "" #keyvault key
+          # certificate_name        = "" #manual cert name
+        }
+      }
+    }
+
+    url_path_maps = {
+      demo = {
+        name              = "test_path_map"
+        paths             = "/test/*"
+        rule_name         = "test_path_rule"
+        backend_pool_key  = "demo"
+        http_settings_key = "demo"
+      }
+    }
+
+    url_path_rules = {
+      rule1 = {
+        name             = "rule1-demo"
+        url_path_map_key = "demo"
+        paths            = "/test/rule1/*"
+      }
+      rule2 = {
+        name             = "rule2-demo"
+        url_path_map_key = "demo"
+        paths            = "/test/rule2/*"
+      }
+    }
+
+    probes = {
+      test = {
+        name                         = "test-http"
+        protocol                     = "Http" # Http or Https
+        host                         = "test.com"
+        host_name_from_http_settings = false
+        # port                                    = "" # Leave not set if pick port from backend http settings
+        path               = "/api/health"
+        interval           = "60"
+        timeout            = "60"
+        threshold          = "3"
+        min_servers        = "0"
+        match_status_codes = "200-499"
+      }
+    }
+  }
+}

--- a/examples/app_gateway/303-agw-remote-subnet/configuration.tfvars
+++ b/examples/app_gateway/303-agw-remote-subnet/configuration.tfvars
@@ -1,0 +1,13 @@
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "southeastasia"
+  }
+}
+
+resource_groups = {
+  agw_re1 = {
+    name   = "agwrg"
+    region = "region1" 
+  }
+}

--- a/examples/app_gateway/303-agw-remote-subnet/waf_policy.tfvars
+++ b/examples/app_gateway/303-agw-remote-subnet/waf_policy.tfvars
@@ -1,0 +1,50 @@
+application_gateway_waf_policies = {
+  wp1 = {
+    name               = "waf-policy-example"
+    resource_group_key = "agw_re1"
+
+    policy_settings = {
+      enabled                     = true
+      mode                        = "Prevention"
+      request_body_check          = true
+      file_upload_limit_in_mb     = 100
+      max_request_body_size_in_kb = 128
+    }
+
+    managed_rules = {
+      exclusion = {
+        ex1 = {
+          match_variable          = "RequestHeaderNames"
+          selector                = "x-company-secret-header"
+          selector_match_operator = "Equals"
+        }
+        ex2 = {
+          match_variable          = "RequestCookieNames"
+          selector                = "too-tasty"
+          selector_match_operator = "EndsWith"
+        }
+      }
+      managed_rule_set = {
+        mrs1 = {
+          type    = "OWASP"
+          version = "3.1"
+          rule_group_override = {
+            rgo1 = {
+              rule_group_name = "REQUEST-920-PROTOCOL-ENFORCEMENT"
+              disabled_rules = [
+                "920300",
+                "920440"
+              ]
+            }
+            rgo2 = {
+              rule_group_name = "General"
+              disabled_rules = [
+                "200004"
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/networking/application_gateway_platform/locals.networking.tf
+++ b/modules/networking/application_gateway_platform/locals.networking.tf
@@ -24,22 +24,26 @@ locals {
     gateway = {
       subnet_id = coalesce(
         try(local.gateway_vnet.subnets[var.settings.subnet_key].id, null),
+        try(var.virtual_subnets[var.settings.lz_key][var.settings.subnet_key].id, null),
         try(var.settings.subnet_id, null)
       )
     }
     private = {
       subnet_id = coalesce(
         try(local.private_vnet.subnets[var.settings.front_end_ip_configurations.private.subnet_key].id, null),
+        try(var.virtual_subnets[var.settings.front_end_ip_configurations.private.lz_key][var.settings.front_end_ip_configurations.private.subnet_key].id, null),
         try(var.settings.front_end_ip_configurations.private.subnet_id, null)
       )
       cidr = coalesce(
         try(local.private_vnet.subnets[var.settings.front_end_ip_configurations.private.subnet_key].cidr, null),
+        try(var.virtual_subnets[var.settings.front_end_ip_configurations.private.lz_key][var.settings.front_end_ip_configurations.private.subnet_key].cidr, null),
         try(var.settings.front_end_ip_configurations.private.subnet_cidr, null)
       )
     }
     public = {
       subnet_id = try(
         local.public_vnet.subnets[var.settings.front_end_ip_configurations.public.subnet_key].id,
+        var.virtual_subnets[var.settings.front_end_ip_configurations.public.lz_key][var.settings.front_end_ip_configurations.public.subnet_key].id,
         var.settings.front_end_ip_configurations.public.subnet_id,
         null
       )

--- a/modules/networking/application_gateway_platform/variable.tf
+++ b/modules/networking/application_gateway_platform/variable.tf
@@ -20,6 +20,9 @@ variable "public_ip_addresses" {
 variable "vnets" {
   default = {}
 }
+variable "virtual_subnets" {
+  default = {}
+}
 
 variable "sku_name" {
   type        = string


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [X] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [X] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [X] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

To use the attribute `subnet_key` for referencing, one must also supply the dependent attribute `vnet_key`. This may not be applicable for organisations where vendors have created a virtual network prior.

The current workaround is to use `subnet_id` which is to pass the subnet's resource ID, making this vulnerable to problems as the value may be hardcoded / reveal sensitive values like the subscription ID

There is a proposed change below to dynamically reference the virtual subnet which is provisioned in a remote landing zone, even if the virtual network that the subnet belongs to already exists outside of CAF. 

**Current**
```bash
subnet_id = "<placeholder>" # replace with subnet id
```

**Proposed**
```bash
lz_key = "<placeholder>"  # replace with remote landing zone key 
subnet_key = "<placeholder>"  # replace with subnet key
```

## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
