### PR TITLE
issue/1273 Add runbook support under automation account

### DIFF
--- a/examples/automation/104-automation-account-runbook/configuration.tfvars
+++ b/examples/automation/104-automation-account-runbook/configuration.tfvars
@@ -1,0 +1,56 @@
+
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "australiaeast"
+  }
+}
+
+
+resource_groups = {
+  automation = {
+    name = "automation"
+  }
+}
+
+automations = {
+  auto1 = {
+    name               = "automation"
+    sku                = "basic"
+    resource_group_key = "automation"
+  }
+}
+
+automation_runbooks = {
+  book_01 = {
+    name                   = "test-001"
+    resource_group_key     = "automation"
+    automation_account_key = "auto1"
+    runbook_type           = "PowerShell"
+    log_progress           = true
+    log_verbose            = false
+    description            = "Script content provided via content attribute"
+
+    # Custom timeouts defined
+    timeouts = {
+      #create = 60
+      update = "55m"
+      read   = "55m"
+      delete = "55m"
+    }
+    content = <<EOT
+    [CmdletBinding()]
+    Write-Output "Hello World"
+    EOT
+  }
+  book_02 = {
+    name                   = "test-book-02"
+    resource_group_key     = "automation"
+    automation_account_key = "auto1"
+    runbook_type           = "PowerShell"
+
+    description = "Read script content from file"
+
+    script_file = "../../../landingzone/configuration/level-2/30_backup/scripts/test.ps1"
+  }
+}

--- a/examples/automation/104-automation-account-runbook/configuration.tfvars
+++ b/examples/automation/104-automation-account-runbook/configuration.tfvars
@@ -51,6 +51,6 @@ automation_runbooks = {
 
     description = "Read script content from file"
 
-    script_file = "../../../landingzone/configuration/level-2/30_backup/scripts/test.ps1"
+    script_file = "./scripts/test.ps1"
   }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -343,6 +343,7 @@ locals {
 
   shared_services = {
     automations                               = try(var.shared_services.automations, {})
+    automation_runbooks                       = try(var.shared_services.automation_runbooks, {})
     automation_log_analytics_links            = try(var.shared_services.automation_log_analytics_links, {})
     automation_software_update_configurations = try(var.shared_services.automation_software_update_configurations, {})
     consumption_budgets                       = try(var.shared_services.consumption_budgets, {})

--- a/modules/automation/runbook/main.tf
+++ b/modules/automation/runbook/main.tf
@@ -1,0 +1,15 @@
+locals {
+  module_tag = {
+    "module" = basename(abspath(path.module))
+  }
+  tags = merge(var.base_tags, local.module_tag, try(var.settings.tags, null))
+}
+
+
+terraform {
+  required_providers {
+    azurecaf = {
+      source = "aztfmod/azurecaf"
+    }
+  }
+}

--- a/modules/automation/runbook/module.tf
+++ b/modules/automation/runbook/module.tf
@@ -1,0 +1,48 @@
+
+resource "azurecaf_name" "auto_account_runbook" {
+  name          = var.settings.name
+  resource_type = "azurerm_automation_runbook"
+  prefixes      = var.global_settings.prefixes
+  random_length = var.global_settings.random_length
+  clean_input   = true
+  passthrough   = var.global_settings.passthrough
+  use_slug      = var.global_settings.use_slug
+}
+
+resource "azurerm_automation_runbook" "auto_account_runbook" {
+  name                = azurecaf_name.auto_account_runbook.result
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  tags                = try(local.tags, {})
+  description         = try(var.settings.description, null)
+
+  automation_account_name = var.automation_account_name
+  runbook_type            = var.runbook_type
+  log_progress            = try(var.settings.log_progress, true)
+  log_verbose             = try(var.settings.log_verbose, false)
+
+  content = try(local.script_content, null)
+
+  dynamic "publish_content_link" {
+    for_each = try(var.settings.publish_content_link, {})
+
+    content {
+      uri = try(publish_content_link.value.uri, null)
+    }
+  }
+
+  dynamic "timeouts" {
+    for_each = lookup(var.settings, "timeouts", {}) == {} ? [] : [1]
+
+    content {
+      create = try(var.settings.timeouts.create, "30m")
+      read   = try(var.settings.timeouts.read, "30m")
+      update = try(var.settings.timeouts.update, "30m")
+      delete = try(var.settings.timeouts.delete, "30m")
+    }
+  }
+}
+
+locals {
+  script_content = try(var.settings.script_file, null) != null ? file(var.settings.script_file) : var.settings.content
+}

--- a/modules/automation/runbook/output.tf
+++ b/modules/automation/runbook/output.tf
@@ -1,0 +1,4 @@
+output "id" {
+  description = "The Automation Runbook ID."
+  value       = azurerm_automation_runbook.auto_account_runbook.id
+}

--- a/modules/automation/runbook/variables.tf
+++ b/modules/automation/runbook/variables.tf
@@ -1,0 +1,37 @@
+variable "location" {
+  description = "(Required) Specifies the supported Azure location where to create the resource. Changing this forces a new resource to be created."
+  type        = string
+}
+
+variable "settings" {
+  description = "Configuration object for the Automation runbook."
+}
+
+variable "global_settings" {
+  description = "Global settings object (see module README.md)"
+}
+
+variable "resource_group_name" {
+  description = "(Required) The name of the resource group where to create the resource."
+  type        = string
+}
+
+variable "base_tags" {
+  description = "Base tags for the resource to be inherited from the resource group."
+  type        = map(any)
+}
+
+variable "runbook_type" {
+  description = "(Required) Type of the runbook"
+  type        = string
+
+  validation {
+    condition     = contains(["Graph", "GraphPowerShell", "GraphPowerShellWorkflow", "PowerShellWorkflow", "PowerShell", "Script"], var.runbook_type)
+    error_message = "The type of the runbook can be either Graph, GraphPowerShell, GraphPowerShellWorkflow, PowerShellWorkflow, PowerShell or Script."
+  }
+}
+
+variable "automation_account_name" {
+  description = "(Required) Name of the related automation account"
+  type        = string
+}


### PR DESCRIPTION
# [Issue-1273](https://github.com/aztfmod/terraform-azurerm-caf/issues/1273)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

This PR will enhance the [terraform-azurerm-caf](https://github.com/aztfmod/terraform-azurerm-caf) to support runbook creation for an automation account

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Use exapmle (examples/automation/104-automation-account-runbook) for testing 
