### PR TITLE
Add support for literals azuread_group_id in sql managed instances

### DIFF
--- a/examples/mssql_mi/200-mi-two-regions/configuration.tfvars
+++ b/examples/mssql_mi/200-mi-two-regions/configuration.tfvars
@@ -277,9 +277,10 @@ mssql_mi_administrators = {
     resource_group_key = "sqlmi_region1"
     mi_server_key      = "sqlmi1"
     login              = "sqlmiadmin-khairi"
-    azuread_group_key  = "sql_mi_admins"
 
-    # group key or upn supported
+    # group key or existing group OID or upn supported
+    azuread_group_key  = "sql_mi_admins"
+    # azuread_group_id   = "<specify existing azuread group's Object Id (OID) here>"     
     # user_principal_name = ""
   }
 }

--- a/examples/mssql_mi/200-mi/configuration.tfvars
+++ b/examples/mssql_mi/200-mi/configuration.tfvars
@@ -113,14 +113,17 @@ azuread_groups = {
   }
 }
 
+## specify azuread_groups key OR you can import existing azuread group by using group OID as shown below
+
 mssql_mi_administrators = {
   sqlmi1 = {
     resource_group_key = "sqlmi_region1"
     mi_server_key      = "sqlmi1"
     login              = "sqlmiadmin-khairi"
-    azuread_group_key  = "sql_mi_admins"
 
-    # group key or upn supported
+    # group key or existing group OID or upn supported
+    azuread_group_key  = "sql_mi_admins"
+    # azuread_group_id   = "<specify existing azuread group's Object Id (OID) here>"     
     # user_principal_name = ""
   }
 }

--- a/msssql_managed_instances.tf
+++ b/msssql_managed_instances.tf
@@ -64,7 +64,7 @@ module "mssql_mi_administrators" {
   mi_name             = try(module.mssql_managed_instances[each.value.mi_server_key].name, module.mssql_managed_instances_secondary[each.value.mi_server_key].name)
   settings            = each.value
   user_principal_name = try(each.value.user_principal_name, null)
-  group_id            = try(local.combined_objects_azuread_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.azuread_group_key].id, null)
+  group_id            = try(each.value.azuread_group_id, local.combined_objects_azuread_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.azuread_group_key].id, null)
   group_name          = try(local.combined_objects_azuread_groups[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.azuread_group_key].name, null)
 }
 


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)
#1366 Feature request-Add support for existing azuread group for sql admins #1366
## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
