### PR TITLE
Private IP address optional for App Gateway

### DIFF
--- a/modules/networking/application_gateway/locals.networking.tf
+++ b/modules/networking/application_gateway/locals.networking.tf
@@ -51,10 +51,10 @@ locals {
     }
   }
 
-  private_cidr = coalesce(
+  private_cidr = try(coalesce(
     try(local.ip_configuration.private.cidr[var.settings.front_end_ip_configurations.private.subnet_cidr_index], null),
     try(var.settings.front_end_ip_configurations.private.subnet_cidr, null)
-  )
+  ), null)
   private_ip_address = try(cidrhost(local.private_cidr, var.settings.front_end_ip_configurations.private.private_ip_offset), null)
 
 }

--- a/modules/networking/application_gateway/locals.networking.tf
+++ b/modules/networking/application_gateway/locals.networking.tf
@@ -51,10 +51,10 @@ locals {
     }
   }
 
-  private_cidr = try(coalesce(
+  private_cidr = coalesce(
     try(local.ip_configuration.private.cidr[var.settings.front_end_ip_configurations.private.subnet_cidr_index], null),
     try(var.settings.front_end_ip_configurations.private.subnet_cidr, null)
-  ), null)
+  )
   private_ip_address = try(cidrhost(local.private_cidr, var.settings.front_end_ip_configurations.private.private_ip_offset), null)
 
 }

--- a/modules/networking/application_gateway_platform/locals.networking.tf
+++ b/modules/networking/application_gateway_platform/locals.networking.tf
@@ -55,6 +55,6 @@ locals {
     try(local.ip_configuration.private.cidr[var.settings.front_end_ip_configurations.private.subnet_cidr_index], null),
     try(var.settings.front_end_ip_configurations.private.subnet_cidr, null)
   )
-  private_ip_address = cidrhost(local.private_cidr, var.settings.front_end_ip_configurations.private.private_ip_offset)
+  private_ip_address = try(cidrhost(local.private_cidr, var.settings.front_end_ip_configurations.private.private_ip_offset), null)
 
 }

--- a/modules/networking/application_gateway_platform/locals.networking.tf
+++ b/modules/networking/application_gateway_platform/locals.networking.tf
@@ -51,10 +51,10 @@ locals {
     }
   }
 
-  private_cidr = coalesce(
+  private_cidr = try(coalesce(
     try(local.ip_configuration.private.cidr[var.settings.front_end_ip_configurations.private.subnet_cidr_index], null),
     try(var.settings.front_end_ip_configurations.private.subnet_cidr, null)
-  )
+  ), null)
   private_ip_address = try(cidrhost(local.private_cidr, var.settings.front_end_ip_configurations.private.private_ip_offset), null)
 
 }

--- a/modules/networking/application_gateway_platform/locals.networking.tf
+++ b/modules/networking/application_gateway_platform/locals.networking.tf
@@ -28,14 +28,14 @@ locals {
       )
     }
     private = {
-      subnet_id = coalesce(
+      subnet_id = try(coalesce(
         try(local.private_vnet.subnets[var.settings.front_end_ip_configurations.private.subnet_key].id, null),
         try(var.settings.front_end_ip_configurations.private.subnet_id, null)
-      )
-      cidr = coalesce(
+      ), null)
+      cidr = try(coalesce(
         try(local.private_vnet.subnets[var.settings.front_end_ip_configurations.private.subnet_key].cidr, null),
         try(var.settings.front_end_ip_configurations.private.subnet_cidr, null)
-      )
+      ), null)
     }
     public = {
       subnet_id = try(
@@ -44,10 +44,10 @@ locals {
         null
       )
 
-      ip_address_id = coalesce(
+      ip_address_id = try(coalesce(
         try(var.public_ip_addresses[var.client_config.landingzone_key][var.settings.front_end_ip_configurations.public.public_ip_key].id, var.public_ip_addresses[var.settings.front_end_ip_configurations.public.lz_key][var.settings.front_end_ip_configurations.public.public_ip_key].id, null),
         try(var.settings.front_end_ip_configurations.public.public_ip_id, null)
-      )
+      ), null)
     }
   }
 


### PR DESCRIPTION
# [Issue-1370](https://github.com/aztfmod/terraform-azurerm-caf/issues/1370)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [X] I have added example(s) inside the [./examples/] folder
- [X] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [X] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [X] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Some params must be optional following AzureRM 2.99.0, however, they are mandatory parameters in CAF Module 5.6.1 for `azurerm_application_gateway_platform`.

## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
Just doing a `terraform plan` using the config example [here](https://github.com/joselcaguilar/aks-baseline-automation/tree/users/joselcaguilar/tfparity/IaC/terraform)