### PR TITLE
AGW Application dependencies issues during destroy

### DIFF
--- a/modules/networking/application_gateway_application/http_listener.tf
+++ b/modules/networking/application_gateway_application/http_listener.tf
@@ -29,7 +29,7 @@ resource "null_resource" "set_http_listener" {
 }
 
 resource "null_resource" "delete_http_listener" {
-  depends_on = [null_resource.delete_http_settings, null_resource.delete_backend_pool, null_resource.delete_ssl_cert, null_resource.delete_root_cert, null_resource.set_frontend_port]
+  depends_on = [null_resource.delete_http_settings, null_resource.delete_backend_pool, null_resource.delete_ssl_cert, null_resource.delete_root_cert, null_resource.delete_frontend_port]
 
   for_each = try(var.settings.http_listeners, {})
 

--- a/modules/networking/application_gateway_application/http_settings.tf
+++ b/modules/networking/application_gateway_application/http_settings.tf
@@ -37,7 +37,7 @@ resource "null_resource" "set_http_settings" {
 }
 
 resource "null_resource" "delete_http_settings" {
-  depends_on = [null_resource.set_probe, null_resource.delete_backend_pool, null_resource.delete_ssl_cert, null_resource.delete_root_cert]
+  depends_on = [null_resource.delete_probe, null_resource.delete_backend_pool, null_resource.delete_ssl_cert, null_resource.delete_root_cert]
 
   for_each = try(var.settings.http_settings, {})
 


### PR DESCRIPTION
# Issue described in Description section directly

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [X] I have added example(s) inside the [./examples/] folder
- [X] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [X] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [X] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->
- Probes must be removed before than http_settings in `modules/networking/application_gateway_application/http_settings.tf`
- Frontend ports must be removed before than listeners in `modules/networking/application_gateway_application/http_listener.tf`

## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
It was tested [here](https://github.com/Azure/aks-baseline-automation/actions/runs/3241645514/jobs/5313865607), the error raised is described below:
```
module.caf.module.application_gateway_applications["aspnetapp_az1_agw1"].null_resource.delete_probe["probe_1"] (local-exec): ERROR: (InvalidResourceReference) Resource /subscriptions/***/resourceGroups/rg-bu0001a0008/providers/Microsoft.Network/applicationGateways/appgateway-re1-001/probes/probe-fqdn-backend-aks referenced by resource /subscriptions/***/resourceGroups/rg-bu0001a0008/providers/Microsoft.Network/applicationGateways/appgateway-re1-001/backendHttpSettingsCollection/aks_http_setting_1 was not found. Please make sure that the referenced resource exists, and that both resources are in the same region.
```