### PR TITLE
Support 64 characters for win vm and vmss in resource name

### DIFF
--- a/modules/compute/virtual_machine/vm_windows.tf
+++ b/modules/compute/virtual_machine/vm_windows.tf
@@ -15,7 +15,7 @@ resource "azurecaf_name" "windows" {
 resource "azurecaf_name" "windows_computer_name" {
   for_each = local.os_type == "windows" ? var.settings.virtual_machine_settings : {}
 
-  name          = try(each.value.computer_name, each.value.name)
+  name          = substr(try(each.value.computer_name, each.value.name), 0, 14)
   resource_type = "azurerm_windows_virtual_machine"
   prefixes      = var.global_settings.prefixes
   random_length = var.global_settings.random_length

--- a/modules/compute/virtual_machine_scale_set/vmss_linux.tf
+++ b/modules/compute/virtual_machine_scale_set/vmss_linux.tf
@@ -299,9 +299,9 @@ resource "azurerm_linux_virtual_machine_scale_set" "vmss_autoscaled" {
       network_security_group_id     = try(network_interface.value.network_security_group_id, null)
 
       ip_configuration {
-        name                                         = azurecaf_name.linux_nic[network_interface.key].result
-        primary                                      = try(network_interface.value.primary, false)
-        subnet_id                                    = can(network_interface.value.subnet_id) ? network_interface.value.subnet_id : var.vnets[try(network_interface.value.lz_key, var.client_config.landingzone_key)][network_interface.value.vnet_key].subnets[network_interface.value.subnet_key].id
+        name      = azurecaf_name.linux_nic[network_interface.key].result
+        primary   = try(network_interface.value.primary, false)
+        subnet_id = can(network_interface.value.subnet_id) ? network_interface.value.subnet_id : var.vnets[try(network_interface.value.lz_key, var.client_config.landingzone_key)][network_interface.value.vnet_key].subnets[network_interface.value.subnet_key].id
         ####################################################################
         # load_balancer_backend_address_pool_ids       = try(local.load_balancer_backend_address_pool_ids, null)
         # Copied from azurerm_linux_virtual_machine_scale_set resource above to auto-scaled here as

--- a/modules/compute/virtual_machine_scale_set/vmss_windows.tf
+++ b/modules/compute/virtual_machine_scale_set/vmss_windows.tf
@@ -16,7 +16,7 @@ resource "azurecaf_name" "windows" {
 resource "azurecaf_name" "windows_computer_name_prefix" {
   for_each = local.os_type == "windows" ? var.settings.vmss_settings : {}
 
-  name          = try(each.value.computer_name_prefix, each.value.name)
+  name          = substr(try(each.value.computer_name_prefix, each.value.name), 0, 14)
   resource_type = "azurerm_vm_windows_computer_name_prefix"
   prefixes      = var.global_settings.prefixes
   random_length = var.global_settings.random_length


### PR DESCRIPTION
# [Issue-199](https://github.com/aztfmod/terraform-provider-azurecaf/issues/199)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

This PR is about support up to 64 characters in windows vm and vmss resorce name

This change should only be merged if the [PR](https://github.com/aztfmod/terraform-provider-azurecaf/pull/200) in [aztfmod/terraform-provider-azurecaf](https://github.com/aztfmod/terraform-provider-azurecaf) is approved and merged.

- Support 64 characters for win vm and vmss resource name (See: https://github.com/aztfmod/terraform-provider-azurecaf/pull/200

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
