### PR TITLE
Update custom_roles to use correct resource_type

### DIFF
--- a/modules/roles/custom_roles/module.tf
+++ b/modules/roles/custom_roles/module.tf
@@ -1,8 +1,7 @@
 
 resource "azurecaf_name" "custom_role" {
   name          = var.custom_role.name
-  resource_type = "azurerm_resource_group"
-  #TODO: need to be changed to appropriate resource (no caf reference for now)
+  resource_type = "azurerm_role_definition"
   prefixes      = var.global_settings.prefixes
   random_length = var.global_settings.random_length
   clean_input   = true


### PR DESCRIPTION
The `azurecaf_name` provider now has a `resource_type` for `azurerm_role_definition`.

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [ ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
