### PR TITLE
Fix custom route table on AzureFirewallSubnet

### DIFF
--- a/modules/networking/virtual_network/module.tf
+++ b/modules/networking/virtual_network/module.tf
@@ -85,16 +85,6 @@ module "nsg" {
   virtual_network_name              = azurerm_virtual_network.vnet.name
 }
 
-resource "azurerm_subnet_route_table_association" "rt" {
-  for_each = {
-    for key, subnet in merge(lookup(var.settings, "subnets", {}), lookup(var.settings, "specialsubnets", {})) : key => subnet
-    if try(subnet.route_table_key, null) != null
-  }
-
-  subnet_id      = coalesce(lookup(module.subnets, each.key, null), lookup(module.special_subnets, each.key, null)).id
-  route_table_id = var.route_tables[each.value.route_table_key].id
-}
-
 resource "azurerm_subnet_network_security_group_association" "nsg_vnet_association" {
   for_each = {
     for key, value in try(var.settings.subnets, {}) : key => value


### PR DESCRIPTION
When creating an Azure Firewall, it must be placed on a "special" subnet named AzureFirewallSubnet. If one wants to add a custom route table to this subnet, it must contain a "0.0.0.0/0" route to the internet, or else we get the following error:

"Route Table ktyu-route-test on firewall subnet AzureFirewallSubnet must have 0.0.0.0/0 route with next hop Internet."

However, even if we have this route in our table, terraform-azurerm-caf was still throwing the above error as it tries to associate the table with the subnet before the default route has been added.

This patch fixes this by moving the
azurerm_subnet_route_table_association resource up from the virtual_network submodule into the root networking.tf module. This way the dependencies are correctly inferred and Terraform ensures that the route has been added before trying to create the association.

Fixes https://github.com/aztfmod/terraform-azurerm-caf/issues/868

# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/868)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
