### PR TITLE
add support for application_insights_web_test

### DIFF
--- a/.github/workflows/standalone-scenarios.json
+++ b/.github/workflows/standalone-scenarios.json
@@ -11,6 +11,7 @@
     "app_insights/100-all-attributes",
     "app_insights/100-simple",
     "app_insights/102-workspace-based-central-logs",
+    "app_insights/103-web-test",
     "automation/100-simple-automation-account",
     "automation/101-automation-account-linked",
     "automation/102-automation-msi",

--- a/azurerm_application_insights.tf
+++ b/azurerm_application_insights.tf
@@ -25,3 +25,16 @@ output "application_insights" {
   value     = module.azurerm_application_insights
   sensitive = true
 }
+
+module "azurerm_application_insights_web_test" {
+  source   = "./modules/app_insights/web_test"
+  for_each = local.webapp.azurerm_application_insights_web_test
+
+  name                    = lookup(each.value, "name", null)
+  location                = can(local.global_settings.regions[each.value.region]) ? local.global_settings.regions[each.value.region] : local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].location
+  resource_group_name     = can(each.value.resource_group.name) || can(each.value.resource_group_name) ? try(each.value.resource_group.name, each.value.resource_group_name) : local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group_key, each.value.resource_group.key)].name
+  application_insights_id = can(each.value.application_insights_id) ? try(each.value.application_insights_id, null) : local.combined_objects_application_insights[try(each.value.application_insights.lz_key, local.client_config.landingzone_key)][try(each.value.application_insights_key, each.value.application_insights.key)].id
+
+  global_settings = local.global_settings
+  settings        = each.value
+}

--- a/examples/app_insights/103-web-test/configuration.tfvars
+++ b/examples/app_insights/103-web-test/configuration.tfvars
@@ -1,0 +1,46 @@
+
+global_settings = {
+  regions = {
+    region1 = "australiaeast"
+  }
+}
+
+resource_groups = {
+  rg1 = {
+    name   = "examples-app-insights"
+    region = "region1"
+  }
+}
+
+azurerm_application_insights = {
+  webapp = {
+    name               = "tf-test-appinsights-web"
+    resource_group_key = "rg1"
+    application_type   = "web"
+  }
+}
+
+azurerm_application_insights_web_test = {
+  web_test = {
+    name               = "example-web-test"
+    resource_group_key = "rg1"
+    application_insights = {
+      key = "webapp"
+    }
+    kind          = "ping"
+    frequency     = 300
+    timeout       = 60
+    enabled       = true
+    geo_locations = ["us-tx-sn1-azr", "us-il-ch1-azr"]
+    retry_enabled = true
+    description   = "A sample Web test"
+
+    configuration = <<XML
+<WebTest Name="WebTest1" Id="ABD48585-0831-40CB-9069-682EA6BB3583" Enabled="True" CssProjectStructure="" CssIteration="" Timeout="0" WorkItemIds="" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010" Description="" CredentialUserName="" CredentialPassword="" PreAuthenticate="True" Proxy="default" StopOnError="False" RecordedResultFile="" ResultsLocale="">
+  <Items>
+    <Request Method="GET" Guid="a5f10126-e4cd-570d-961c-cea43999a200" Version="1.1" Url="http://microsoft.com" ThinkTime="0" Timeout="300" ParseDependentRequests="True" FollowRedirects="True" RecordResult="True" Cache="False" ResponseTimeGoal="0" Encoding="utf-8" ExpectedHttpStatusCode="200" ExpectedResponseUrl="" ReportingName="" IgnoreHttpStatusCode="False" />
+  </Items>
+</WebTest>
+XML
+  }
+}

--- a/examples/module.tf
+++ b/examples/module.tf
@@ -294,13 +294,14 @@ module "example" {
 
   }
   webapp = {
-    azurerm_application_insights = var.azurerm_application_insights
-    app_service_environments     = var.app_service_environments
-    app_service_environments_v3  = var.app_service_environments_v3
-    app_service_plans            = var.app_service_plans
-    app_services                 = var.app_services
-    function_apps                = var.function_apps
-    static_sites                 = var.static_sites
+    azurerm_application_insights          = var.azurerm_application_insights
+    azurerm_application_insights_web_test = var.azurerm_application_insights_web_test
+    app_service_environments              = var.app_service_environments
+    app_service_environments_v3           = var.app_service_environments_v3
+    app_service_plans                     = var.app_service_plans
+    app_services                          = var.app_services
+    function_apps                         = var.function_apps
+    static_sites                          = var.static_sites
   }
   data_factory = {
     data_factory                                 = var.data_factory
@@ -375,6 +376,5 @@ module "example" {
     digital_twins_endpoint_eventhubs    = var.digital_twins_endpoint_eventhubs
     digital_twins_endpoint_eventgrids   = var.digital_twins_endpoint_eventgrids
     digital_twins_endpoint_servicebuses = var.digital_twins_endpoint_servicebuses
-
   }
 }

--- a/examples/variables.tf
+++ b/examples/variables.tf
@@ -309,6 +309,9 @@ variable "synapse_workspaces" {
 variable "azurerm_application_insights" {
   default = {}
 }
+variable "azurerm_application_insights_web_test" {
+  default = {}
+}
 variable "role_mapping" {
   default = {}
 }

--- a/locals.tf
+++ b/locals.tf
@@ -371,13 +371,14 @@ locals {
   }
 
   webapp = {
-    app_service_environments     = try(var.webapp.app_service_environments, {})
-    app_service_environments_v3  = try(var.webapp.app_service_environments_v3, {})
-    app_service_plans            = try(var.webapp.app_service_plans, {})
-    app_services                 = try(var.webapp.app_services, {})
-    azurerm_application_insights = try(var.webapp.azurerm_application_insights, {})
-    function_apps                = try(var.webapp.function_apps, {})
-    static_sites                 = try(var.webapp.static_sites, {})
+    app_service_environments              = try(var.webapp.app_service_environments, {})
+    app_service_environments_v3           = try(var.webapp.app_service_environments_v3, {})
+    app_service_plans                     = try(var.webapp.app_service_plans, {})
+    app_services                          = try(var.webapp.app_services, {})
+    azurerm_application_insights          = try(var.webapp.azurerm_application_insights, {})
+    azurerm_application_insights_web_test = try(var.webapp.azurerm_application_insights_web_test, {})
+    function_apps                         = try(var.webapp.function_apps, {})
+    static_sites                          = try(var.webapp.static_sites, {})
   }
 
   enable = {

--- a/modules/app_insights/web_test/main.tf
+++ b/modules/app_insights/web_test/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    azurecaf = {
+      source = "aztfmod/azurecaf"
+    }
+  }
+}
+
+locals {
+  module_tag = {
+    "module" = basename(abspath(path.module))
+  }
+  tags = merge(var.base_tags, local.module_tag, try(var.settings.tags, null))
+}

--- a/modules/app_insights/web_test/module.tf
+++ b/modules/app_insights/web_test/module.tf
@@ -1,0 +1,25 @@
+resource "azurecaf_name" "appiwt" {
+  name          = var.name
+  resource_type = "azurerm_application_insights_web_test"
+  prefixes      = var.global_settings.prefixes
+  random_length = var.global_settings.random_length
+  clean_input   = true
+  passthrough   = var.global_settings.passthrough
+  use_slug      = var.global_settings.use_slug
+}
+
+resource "azurerm_application_insights_web_test" "appiwt" {
+  name                    = azurecaf_name.appiwt.result
+  location                = var.location
+  resource_group_name     = var.resource_group_name
+  application_insights_id = var.application_insights_id
+  kind                    = var.settings.kind
+  geo_locations           = var.settings.geo_locations
+  configuration           = var.settings.configuration
+  frequency               = try(var.settings.frequency, null)
+  timeout                 = try(var.settings.timeout, null)
+  enabled                 = try(var.settings.enabled)
+  retry_enabled           = try(var.settings.retry_enabled, null)
+  description             = try(var.settings.description, null)
+  tags                    = local.tags
+}

--- a/modules/app_insights/web_test/output.tf
+++ b/modules/app_insights/web_test/output.tf
@@ -1,0 +1,4 @@
+output "id" {
+  description = "The ID of the Application Insights web test."
+  value       = azurerm_application_insights_web_test.appiwt.id
+}

--- a/modules/app_insights/web_test/variables.tf
+++ b/modules/app_insights/web_test/variables.tf
@@ -1,0 +1,32 @@
+variable "name" {
+  description = "(Required) Specifies the name of the Application Insights WebTest. Changing this forces a new resource to be created."
+  type        = string
+}
+
+variable "location" {
+  description = "(Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created. It needs to correlate with location of parent resource (azurerm_application_insights)."
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "(Required) The name of the resource group in which to create the Application Insights WebTest. Changing this forces a new resource."
+}
+
+variable "application_insights_id" {
+  description = "(Required) The ID of the Application Insights component on which the WebTest operates. Changing this forces a new resource to be created."
+}
+
+variable "global_settings" {
+  description = "Global settings object when the resource is deploye in landing zones context."
+  default     = null
+  type        = any
+}
+
+variable "settings" {
+}
+
+variable "base_tags" {
+  description = "Base tags for the resource to be inherited from the resource group."
+  type        = map(any)
+  default     = {}
+}


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/1131)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have added example(s) inside the [./examples/] folder
- [x] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

- Adding support for Application insights web test -> https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_insights_web_test

This requires https://github.com/aztfmod/terraform-provider-azurecaf/pull/211

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
