### PR TITLE
 Updated app gateway to use versionless certs from keyvault (for certs auto-refresh)

### DIFF
--- a/modules/networking/application_gateway/application_gateway.tf
+++ b/modules/networking/application_gateway/application_gateway.tf
@@ -268,7 +268,7 @@ resource "azurerm_application_gateway" "agw" {
 
     content {
       name                = ssl_certificate.value.name
-      key_vault_secret_id = ssl_certificate.value.secret_id
+      key_vault_secret_id = ssl_certificate.value.versionless_secret_id
     }
   }
 

--- a/modules/networking/application_gateway_application/ssl_cert.tf
+++ b/modules/networking/application_gateway_application/ssl_cert.tf
@@ -30,7 +30,7 @@ resource "null_resource" "set_ssl_cert" {
       NAME                     = each.value.name
       CERT_FILE                = try(each.value.cert_file, null)
       CERT_PASSWORD            = try(each.value.cert_password, null)
-      KEY_VAULT_SECRET_ID      = try(data.azurerm_key_vault_certificate.manual_certs[each.key].secret_id, var.keyvault_certificates[try(each.value.keyvault.lz_key, var.client_config.landingzone_key)][each.value.keyvault.certificate_key].secret_id, var.keyvault_certificate_requests[try(each.value.keyvault.lz_key, var.client_config.landingzone_key)][each.value.certificate_request_key].secret_id, null)
+      KEY_VAULT_SECRET_ID      = try(data.azurerm_key_vault_certificate.manual_certs[each.key].versionless_secret_id, var.keyvault_certificates[try(each.value.keyvault.lz_key, var.client_config.landingzone_key)][each.value.keyvault.certificate_key].secret_id, var.keyvault_certificate_requests[try(each.value.keyvault.lz_key, var.client_config.landingzone_key)][each.value.certificate_request_key].secret_id, null)
     }
   }
 }


### PR DESCRIPTION
## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have added example(s) inside the [./examples/] folder
- [x] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

When a certificate from a keyvault is used on an App Gateway, the versionless id is used to leverage the auto-refresh of the certificate.

Reference: https://learn.microsoft.com/en-us/azure/application-gateway/key-vault-certs#supported-certificates

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
