### PR TITLE
Fix file share ACL and Access Policy

### DIFF
--- a/.github/workflows/standalone-scenarios.json
+++ b/.github/workflows/standalone-scenarios.json
@@ -227,6 +227,7 @@
     "storage_accounts/106-storage-account-queue",
     "storage_accounts/107-storage-account-management-policy",
     "storage_accounts/109-storage-account-advanced-options-cmk",
+    "storage_accounts/110-file-share-with-acl",
     "storage_container/101-storage_container",
     "synapse_analytics/100-synapse",
     "synapse_analytics/101-synapse-sparkpool",

--- a/examples/storage_accounts/110-file-share-with-acl/configuration.tfvars
+++ b/examples/storage_accounts/110-file-share-with-acl/configuration.tfvars
@@ -1,0 +1,47 @@
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "uksouth"
+  }
+}
+
+resource_groups = {
+  test = {
+    name = "test"
+  }
+}
+
+# https://docs.microsoft.com/en-us/azure/storage/
+storage_accounts = {
+  sa1 = {
+    name = "sa1dev"
+    # This option is to enable remote RG reference
+    # resource_group = {
+    #   lz_key = ""
+    #   key    = ""
+    # }
+
+    resource_group_key = "test"
+    # Account types are BlobStorage, BlockBlobStorage, FileStorage, Storage and StorageV2. Defaults to StorageV2
+    account_kind = "StorageV2"
+    # Account Tier options are Standard and Premium. For BlockBlobStorage and FileStorage accounts only Premium is valid.
+    account_tier = "Standard"
+    #  Valid options are LRS, GRS, RAGRS, ZRS, GZRS and RAGZRS
+    account_replication_type = "LRS" # https://docs.microsoft.com/en-us/azure/storage/common/storage-redundancy
+
+    file_shares = {
+      share1 = {
+        name  = "share1"
+        quota = 50
+
+        acl = {
+          id = "GhostedRecall"
+
+          access_policy = {
+            permissions = "r"
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/storage_account/file_share/file_share.tf
+++ b/modules/storage_account/file_share/file_share.tf
@@ -9,12 +9,12 @@ resource "azurerm_storage_share" "fs" {
   enabled_protocol     = try(var.settings.enabled_protocol, null)
 
   dynamic "acl" {
-    for_each = try(var.settings.acl, {})
+    for_each = try(var.settings.acl, null) != null ? [var.settings.acl] : []
     content {
       id = acl.value.id
 
       dynamic "access_policy" {
-        for_each = try(var.settings.access_policy, {})
+        for_each = try(acl.value.access_policy, null) != null ? [acl.value.access_policy] : []
         content {
           permissions = access_policy.value.permissions
           start       = try(access_policy.value.start, null)


### PR DESCRIPTION
## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [X] I have added example(s) inside the [./examples/] folder
- [X] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [X] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [X] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Fix issue with the storage account file share where the module would not pick up ACL or Access Policy configuration of a file share

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->

```
cd examples
az login
terraform init
terraform plan -var-file -var-file storage_accounts/110-file-share-with-acl/configuration.tfvars
terraform apply -var-file -var-file storage_accounts/110-file-share-with-acl/configuration.tfvars
terraform destroy -var-file -var-file storage_accounts/110-file-share-with-acl/configuration.tfvars
```
