### PR TITLE
feat(compute): Add identity outputs to vm and vmss deployments

### DIFF
--- a/modules/compute/virtual_machine/output.tf
+++ b/modules/compute/virtual_machine/output.tf
@@ -78,3 +78,8 @@ data "azurerm_managed_disk" "os_disk" {
 output "os_disk_id" {
   value = data.azurerm_managed_disk.os_disk.id
 }
+
+output "identity" {
+  value       = local.os_type == "linux" ? try(azurerm_linux_virtual_machine.vm["linux"].identity, null) : try(azurerm_windows_virtual_machine.vm["windows"].identity, null)
+  description = "The identity block of the virtual machine"
+}

--- a/modules/compute/virtual_machine_scale_set/output.tf
+++ b/modules/compute/virtual_machine_scale_set/output.tf
@@ -31,3 +31,8 @@ output "ssh_keys" {
     ssh_private_key_open_ssh = azurerm_key_vault_secret.ssh_public_key_openssh[local.os_type].name #for backard compat, wrong name, will be removed in future version.
   } : null
 }
+
+output "identity" {
+  value       = local.os_type == "linux" ? try(azurerm_linux_virtual_machine_scale_set.vmss["linux"].identity, azurerm_linux_virtual_machine_scale_set.vmss_autoscaled["linux"].identity, null) : try(azurerm_windows_virtual_machine_scale_set.vmss["windows"].identity, null)
+  description = "The identity block of the virtual machine scale set"
+}


### PR DESCRIPTION
# [Issue 1471](https://github.com/aztfmod/terraform-azurerm-caf/issues/1471)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] ~~I have added example(s) inside the [./examples/] folder~~
- [ ] ~~I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)~~
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

Adds `identity` outputs to the vm and vmss deployments to enable RBAC/IAM configuration based on system identities.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->

Ran terraform validate 