### PR TITLE
Add redis cache outputs and remove service endpoint from example

### DIFF
--- a/examples/redis_cache/103-redis-private-endpoints/configuration.tfvars
+++ b/examples/redis_cache/103-redis-private-endpoints/configuration.tfvars
@@ -63,9 +63,8 @@ vnets = {
     specialsubnets = {}
     subnets = {
       pep = {
-        name = "pep"
-        cidr = ["10.1.0.0/28"]
-        # service_endpoints                              = ["Microsoft.Cache/Redis"]
+        name                                           = "pep"
+        cidr                                           = ["10.1.0.0/28"]
         enforce_private_link_endpoint_network_policies = "true"
       }
     }

--- a/modules/redis_cache/output.tf
+++ b/modules/redis_cache/output.tf
@@ -1,3 +1,34 @@
+output "id" {
+  value = azurerm_redis_cache.redis.id
+}
+
+output "hostname" {
+  value = azurerm_redis_cache.redis.hostname
+}
+
+output "ssl_port" {
+  value = azurerm_redis_cache.redis.ssl_port
+}
+
+output "port" {
+  value = azurerm_redis_cache.redis.port
+}
+
+output "primary_access_key" {
+  value = azurerm_redis_cache.redis.primary_access_key
+}
+
+output "secondary_access_key" {
+  value = azurerm_redis_cache.redis.secondary_access_key 
+}
+
+output "primary_connection_string" {
+  value = azurerm_redis_cache.redis.primary_connection_string 
+}
+
+output "secondary_connection_string" {
+  value = azurerm_redis_cache.redis.secondary_connection_string 
+}
 
 output "redis_cache" {
   value = azurerm_redis_cache.redis


### PR DESCRIPTION
# [1477](https://github.com/aztfmod/terraform-azurerm-caf/issues/1477)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [X] I have added example(s) inside the [./examples/] folder
- [] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [X] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [X] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

- Remove service endpoint from redis example
- Add additional redis cache outputs

## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

```
module.example.module.redis_caches["r1"].module.private_endpoint["pe1"].azurerm_private_endpoint.pep: Still creating... [1m0s elapsed]
module.example.module.redis_caches["r1"].module.private_endpoint["pe1"].azurerm_private_endpoint.pep: Still creating... [1m10s elapsed]
module.example.module.redis_caches["r1"].module.private_endpoint["pe1"].azurerm_private_endpoint.pep: Still creating... [1m20s elapsed]
module.example.module.redis_caches["r1"].module.private_endpoint["pe1"].azurerm_private_endpoint.pep: Still creating... [1m30s elapsed]
module.example.module.redis_caches["r1"].module.private_endpoint["pe1"].azurerm_private_endpoint.pep: Creation complete after 1m37s [id=/subscriptions/XXXXXXXXXXX/resourceGroups/ahpk-rg-redis-rg/providers/Microsoft.Network/privateEndpoints/ahpk-pe-redis]

Apply complete! Resources: 14 added, 0 changed, 0 destroyed.

Outputs:

objects = <sensitive>
```
