### PR TITLE
Added support for app registration, keyvault certificates key & misc bug fixes

### DIFF
--- a/azuread_graph.tf
+++ b/azuread_graph.tf
@@ -42,6 +42,7 @@ module "azuread_graph_application" {
   settings        = each.value
   base_tags       = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
   remote_objects = {
+    azuread_applications = try(var.remote_objects.azuread_applications, {})
   }
 }
 
@@ -95,6 +96,7 @@ module "azuread_graph_application_certificate" {
   settings        = each.value
   remote_objects = {
     azuread_applications = local.combined_objects_azuread_applications
+    keyvault_certificates = local.combined_objects_keyvault_certificates
   }
 }
 output "azuread_graph_application_certificate" {

--- a/examples/azuread_graph/107-azuread_applications/configuration.tfvars
+++ b/examples/azuread_graph/107-azuread_applications/configuration.tfvars
@@ -1,6 +1,6 @@
 azuread_applications = {
   app1 = {
-    display_name     = "example"
+    application_name     = "example"
     identifier_uris  = ["api://test-external-example-app"]
     logo_image       = "./azuread_graph/107-azuread_applications/img/logo.png"
     sign_in_audience = "AzureADMultipleOrgs"
@@ -10,44 +10,46 @@ azuread_applications = {
       requested_access_token_version = 2
 
 
-      oauth2_permission_scope = {
-        admin_consent_description  = "Allow the application to access example on behalf of the signed-in user."
-        admin_consent_display_name = "Access example"
-        enabled                    = true
-        id                         = "96183846-204b-4b43-82e1-5d2222eb4b9b"
-        type                       = "User"
-        user_consent_description   = "Allow the application to access example on your behalf."
-        user_consent_display_name  = "Access example"
-        value                      = "user_impersonation"
+      oauth2_permission_scopes = [
+        {
+          admin_consent_description  = "Allow the application to access example on behalf of the signed-in user."
+          admin_consent_display_name = "Access example"
+          enabled                    = true
+          id                         = "96183846-204b-4b43-82e1-5d2222eb4b9b"
+          type                       = "User"
+          user_consent_description   = "Allow the application to access example on your behalf."
+          user_consent_display_name  = "Access example"
+          value                      = "user_impersonation"
+        },
+        {
+          admin_consent_description  = "Administer the example application"
+          admin_consent_display_name = "Administer"
+          enabled                    = true
+          id                         = "be98fa3e-ab5b-4b11-83d9-04ba2b7946bc"
+          type                       = "Admin"
+          value                      = "administer"
+        }
+      ]
+    }
+
+    app_roles = [
+      {
+        allowed_member_types = ["User", "Application"]
+        description          = "Admins can manage roles and perform all task actions"
+        display_name         = "Admin"
+        enabled              = true
+        id                   = "1b19509b-32b1-4e9f-b71d-4992aa991967"
+        value                = "admin"
+      },
+      {
+        allowed_member_types = ["User"]
+        description          = "ReadOnly roles have limited query access"
+        display_name         = "ReadOnly"
+        enabled              = true
+        id                   = "497406e4-012a-4267-bf18-45a1cb148a01"
+        value                = "User"
       }
-
-      oauth2_permission_scope = {
-        admin_consent_description  = "Administer the example application"
-        admin_consent_display_name = "Administer"
-        enabled                    = true
-        id                         = "be98fa3e-ab5b-4b11-83d9-04ba2b7946bc"
-        type                       = "Admin"
-        value                      = "administer"
-      }
-    }
-
-    app_role = {
-      allowed_member_types = ["User", "Application"]
-      description          = "Admins can manage roles and perform all task actions"
-      display_name         = "Admin"
-      enabled              = true
-      id                   = "1b19509b-32b1-4e9f-b71d-4992aa991967"
-      value                = "admin"
-    }
-
-    app_role = {
-      allowed_member_types = ["User"]
-      description          = "ReadOnly roles have limited query access"
-      display_name         = "ReadOnly"
-      enabled              = true
-      id                   = "497406e4-012a-4267-bf18-45a1cb148a01"
-      value                = "User"
-    }
+    ]
 
     feature_tags = {
       enterprise = true
@@ -55,49 +57,64 @@ azuread_applications = {
     }
 
     optional_claims = {
-      access_token = {
-        name = "myclaim"
-      }
+      access_tokens = [
+        {
+          name = "myclaim"
+        },
+        {
+          name = "otherclaim"
+        }
+      ]
 
-      access_token = {
-        name = "otherclaim"
-      }
+      id_tokens = [
+        {
+          name                  = "userclaim"
+          source                = "user"
+          essential             = true
+          additional_properties = ["emit_as_roles"]
+        }
+      ]
 
-      id_token = {
-        name                  = "userclaim"
-        source                = "user"
-        essential             = true
-        additional_properties = ["emit_as_roles"]
-      }
-
-      saml2_token = {
-        name = "samlexample"
-      }
+      saml2_tokens = [
+        {
+          name = "samlexample"
+        }
+      ]
     }
 
-    required_resource_access = {
-      resource_app = {
-        id = "00000003-0000-0000-c000-000000000000" # Microsoft Graph
+    required_resources_access = [
+      {
+        resource_app = {
+          id = "00000003-0000-0000-c000-000000000000" # Microsoft Graph
+        }
+        resources_access = [
+          {
+            id   = "df021288-bdef-4463-88db-98f22de89214" # User.Read.All
+            type = "Role"
+          },
+          {
+            id   = "b4e74841-8e56-480b-be8b-910348b18b4c" # User.ReadWrite
+            type = "Scope"
+          }
+        ]
+      },
+      {
+        resource_app = {
+          id = "c5393580-f805-4401-95e8-94b7a6ef2fc2" # Office 365 Management
+        }
+        resources_access = [ 
+          {
+            id   = "594c1fb6-4f81-4475-ae41-0c394909246c" # ActivityFeed.Read
+            type = "Role"
+          }
+        ]
       }
-      resource_access = {
-        id   = "df021288-bdef-4463-88db-98f22de89214" # User.Read.All
-        type = "Role"
-      }
+    ]
 
-      resource_access = {
-        id   = "b4e74841-8e56-480b-be8b-910348b18b4c" # User.ReadWrite
-        type = "Scope"
-      }
-    }
-
-    required_resource_access = {
-      resource_app = {
-        id = "c5393580-f805-4401-95e8-94b7a6ef2fc2" # Office 365 Management
-      }
-      resource_access = {
-        id   = "594c1fb6-4f81-4475-ae41-0c394909246c" # ActivityFeed.Read
-        type = "Role"
-      }
+    single_page_application = {
+      redirect_uris = [
+        "https://example.com/TokenCallback"        
+      ]
     }
 
     web = {
@@ -112,3 +129,13 @@ azuread_applications = {
     }
   }
 }
+
+azuread_application_passwords = {
+    pass1 = {
+      application_object = {
+        key = "app1"
+      }
+      display_name = "example-pass"
+      description  = "application password example"      
+    } 
+  }

--- a/examples/azuread_graph/109-azuread_application_certificates/configuration.tf
+++ b/examples/azuread_graph/109-azuread_application_certificates/configuration.tf
@@ -1,0 +1,61 @@
+azuread_applications = {
+  app1 = {
+    application_name     = "example"
+    identifier_uris  = ["api://test-external-example-app"]
+    sign_in_audience = "AzureADMultipleOrgs"
+  }
+}
+
+resource_groups = {
+  rg1 = {
+    name   = "example"    
+  }
+}
+
+/******************************************************************************
+*** Create Key Vault
+******************************************************************************/
+keyvaults = {
+  kv1 = {
+    name                       = "example"
+    resource_group_key         = "rg1"
+    soft_delete_retention_days = 90
+  }
+}
+
+keyvault_certificates = {    
+  kvc1 = {
+    name                = "AppCertificate"
+    keyvault_key        = "kv1"
+    issuer_parameters   = "Self"
+    exportable          = true
+    key_size            = 2048
+    key_type            = "RSA"
+    reuse_key           = false
+    action_type         = "EmailContacts"
+    lifetime_percentage = 80
+    subject             = "CN=app-certificate"
+    subject_alternative_names = {
+      dns_names = []
+    }
+    content_type = "application/x-pkcs12"
+    key_usage = [
+      "digitalSignature",
+      "keyEncipherment"
+    ]
+    validity_in_months = 12
+  }
+}
+
+azuread_application_certificates = {
+  appc1 = {
+    application_object = {
+      key = "app1"
+    }
+    encoding = "hex"
+    keyvault_certificate = {
+      key = "kvc1"
+    }
+    type = "AsymmetricX509Cert"
+  }
+}

--- a/locals.tf
+++ b/locals.tf
@@ -22,7 +22,7 @@ locals {
     azuread_administrative_units                          = try(var.azuread.azuread_administrative_units, {})
     azuread_administrative_unit_members                   = try(var.azuread.azuread_administrative_unit_members, {})
     azuread_groups_memberships                            = try(var.azuread.azuread_groups_memberships, {})
-    azuread_application_certificates                      = try(var.azuread.azureaazuread_application_certificated_administrative_units, {})
+    azuread_application_certificates                      = try(var.azuread.azuread_application_certificates, {})
     azuread_application_federated_identity_credentials    = try(var.azuread.azuread_application_federated_identity_credentials, {})
     azuread_application_passwords                         = try(var.azuread.azuread_application_passwords, {})
     azuread_application_pre_authorizeds                   = try(var.azuread.azuread_application_pre_authorizeds, {})

--- a/modules/azuread_graph/application_certificate/module.tf
+++ b/modules/azuread_graph/application_certificate/module.tf
@@ -1,11 +1,11 @@
 
 resource "azuread_application_certificate" "appc" {
-  application_object_id = can(var.settings.application_object.key) ? var.settings.application_object.id : var.remote_objects.aad[var.settings.application_object.obj_type][try(var.settings.application_object.lz_key, var.client_config.landingzone_key)][var.settings.application_object.key].object_id
+  application_object_id = can(var.settings.application_object.key) == false ? var.settings.application_object.id : var.remote_objects.azuread_applications[try(var.settings.application_object.lz_key, var.client_config.landingzone_key)][var.settings.application_object.key].object_id
   encoding              = try(var.settings.encoding, null)
   key_id                = can(var.settings.key.key) == false ? try(var.settings.key.id, null) : var.remote_objects.aad[var.settings.key.obj_type][try(var.settings.key.lz_key, var.client_config.landingzone_key)][var.settings.key.key].object_id
-  start_date            = try(var.settings.start_date, null)
-  end_date              = try(var.settings.end_date, null)
+  start_date            = can(var.settings.keyvault_certificate.key) == false ? try(var.settings.start_date, null) : var.remote_objects.keyvault_certificates[try(var.settings.keyvault_certificate.lz_key, var.client_config.landingzone_key)][var.settings.keyvault_certificate.key].certificate_attribute[0].not_before
+  end_date              = can(var.settings.keyvault_certificate.key) == false ? try(var.settings.end_date, null) : var.remote_objects.keyvault_certificates[try(var.settings.keyvault_certificate.lz_key, var.client_config.landingzone_key)][var.settings.keyvault_certificate.key].certificate_attribute[0].expires
   end_date_relative     = try(var.settings.end_date_relative, null)
   type                  = try(var.settings.type, null)
-  value                 = var.settings.value
+  value                 = can(var.settings.keyvault_certificate.key) == false ? var.settings.value : var.remote_objects.keyvault_certificates[try(var.settings.keyvault_certificate.lz_key, var.client_config.landingzone_key)][var.settings.keyvault_certificate.key].certificate_data
 }

--- a/modules/azuread_graph/application_password/module.tf
+++ b/modules/azuread_graph/application_password/module.tf
@@ -1,6 +1,6 @@
 
 resource "azuread_application_password" "appp" {
-  application_object_id = can(var.settings.application_object.key) ? var.settings.application_object.id : var.remote_objects.aad[var.settings.application_object.obj_type][try(var.settings.application_object.lz_key, var.client_config.landingzone_key)][var.settings.application_object.key].object_id
+  application_object_id = can(var.settings.application_object.id) ? var.settings.application_object.id : var.remote_objects.azuread_applications[try(var.settings.application_object.lz_key, var.client_config.landingzone_key)][var.settings.application_object.key].object_id
   display_name          = try(var.settings.display_name, null)
   start_date            = try(var.settings.start_date, null)
   end_date              = try(var.settings.end_date, null)

--- a/modules/azuread_graph/group/output.tf
+++ b/modules/azuread_graph/group/output.tf
@@ -110,3 +110,7 @@ output "proxy_addresses" {
   value       = azuread_group.group.proxy_addresses
   description = "Email addresses for the group that direct to the same group mailbox"
 }
+output "rbac_id" {
+  value       = azuread_group.group.object_id
+  description = "The object id used in the Role Assignemnt"
+}

--- a/modules/security/keyvault_certificate/output.tf
+++ b/modules/security/keyvault_certificate/output.tf
@@ -21,3 +21,7 @@ output "thumbprint" {
 output "certificate_attribute" {
   value = azurerm_key_vault_certificate.cert.certificate_attribute
 }
+
+output "certificate_data" {
+  value = azurerm_key_vault_certificate.cert.certificate_data
+}

--- a/roles.tf
+++ b/roles.tf
@@ -17,10 +17,24 @@ module "custom_roles" {
 resource "azurerm_role_assignment" "for" {
   for_each = try(local.roles_to_process, {})
 
-  principal_id         = each.value.object_id_resource_type == "object_ids" ? each.value.object_id_key_resource : each.value.object_id_lz_key == null ? local.services_roles[each.value.object_id_resource_type][var.current_landingzone_key][each.value.object_id_key_resource].rbac_id : local.services_roles[each.value.object_id_resource_type][each.value.object_id_lz_key][each.value.object_id_key_resource].rbac_id
+  principal_id = each.value.object_id_resource_type == "object_ids" ? each.value.object_id_key_resource : coalesce(
+    try(local.services_roles[each.value.object_id_resource_type][each.value.object_id_lz_key][each.value.object_id_key_resource].rbac_id, null),
+    try(local.services_roles[each.value.object_id_resource_type][var.current_landingzone_key][each.value.object_id_key_resource].rbac_id, null)
+  )
   role_definition_id   = each.value.mode == "custom_role_mapping" ? module.custom_roles[each.value.role_definition_name].role_definition_resource_id : null
   role_definition_name = each.value.mode == "built_in_role_mapping" ? each.value.role_definition_name : null
-  scope                = each.value.scope_lz_key == null ? local.services_roles[each.value.scope_resource_key][var.current_landingzone_key][each.value.scope_key_resource].id : local.services_roles[each.value.scope_resource_key][each.value.scope_lz_key][each.value.scope_key_resource].id
+  scope = coalesce(
+    try(local.services_roles[each.value.scope_resource_key][each.value.scope_lz_key][each.value.scope_key_resource].id, null),
+    try(local.services_roles[each.value.scope_resource_key][var.current_landingzone_key][each.value.scope_key_resource].id, null)
+  )
+  
+  lifecycle {
+    ignore_changes = [
+      principal_id,
+      scope
+    ]
+    create_before_destroy = true
+  }
 }
 
 data "azurerm_management_group" "level" {


### PR DESCRIPTION
## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have added example(s) inside the [./examples/] folder
- [x] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description
1. Added support for one application to be able to reference another application by key and its oath2_permission_scope_id  
2. Added support for application certificate to be able to reference a keyvault certificate via remote_objects key
3. Added application support for a list of 
  a) oauth2_permission_scopes
  b) app_roles
  c) access_tokens
  d) id_tokens
  e) public_clients
  f) required_resources_access & resources_access
4. Fixed & Enhanced examples/azuread_graph/107-azuread_applications 
5. Added new examples/azuread_graph/109-azuread_application_certificates

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Execute examples/
  a) azuread_graph/107-azuread_applications 
  b) azuread_graph/109-azuread_application_certificates