### PR TITLE
Fix: shutdown schedules for windows vms

### DIFF
--- a/modules/compute/virtual_machine/shutdown_schedule.tf
+++ b/modules/compute/virtual_machine/shutdown_schedule.tf
@@ -1,7 +1,7 @@
 resource "azurerm_dev_test_global_vm_shutdown_schedule" "enabled" {
   count = can(var.settings.shutdown_schedule) ? 1 : 0
 
-  virtual_machine_id = azurerm_linux_virtual_machine.vm[local.os_type].id
+  virtual_machine_id = local.os_type == "linux" ? azurerm_linux_virtual_machine.vm["linux"].id : azurerm_windows_virtual_machine.vm["windows"].id
   location           = var.location
   enabled            = try(var.settings.shutdown_schedule.enabled, null)
 


### PR DESCRIPTION
# [Issue-1481](https://github.com/aztfmod/terraform-azurerm-caf/issues/1481)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description
The current implementation is only refferencing the azurerm_linux_virtual_machine. Based on the *os_type* it 
should also consider the azurerm_*windows*_virtual_machine.
<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing
Create a Windows and Linux VM, both with shutdown schedules.

<!-- Instructions for testing and validation of your code -->
