### PR TITLE
fix: null check, output and separate file to different key

### DIFF
--- a/examples/apim/117-api_management_product/configuration.tfvars
+++ b/examples/apim/117-api_management_product/configuration.tfvars
@@ -60,6 +60,7 @@ api_management_product = {
 </policies>
 XML
 
+      # xml_file = "apim/117-api_management_product/policies/example-policy.xml"
       # xml_link = "https://github.com/Azure/api-management-policy-snippets/blob/master/examples/Filter%20response%20content%20based%20on%20product%20name.policy.xml"
     }
   }

--- a/examples/apim/117-api_management_product/policies/example-policy.xml
+++ b/examples/apim/117-api_management_product/policies/example-policy.xml
@@ -1,0 +1,5 @@
+<policies>
+  <inbound>
+    <find-and-replace from="xyz" to="abc" />
+  </inbound>
+</policies>

--- a/modules/apim/api_management_product/module.tf
+++ b/modules/apim/api_management_product/module.tf
@@ -12,15 +12,16 @@ resource "azurerm_api_management_product" "apim" {
 }
 
 resource "azurerm_api_management_product_policy" "apim" {
-  count               = try(var.settings.policy, null) == null ? 1 : 0
+  count               = try(var.settings.policy, null) != null ? 1 : 0
   api_management_name = var.api_management_name
   resource_group_name = var.resource_group_name
   product_id          = var.settings.product_id
 
   xml_content = try(
     try(
-      file("${path.cwd}/${var.settings.policy.xml_content}"),
-    var.settings.policy.xml_content),
+      file("${path.cwd}/${var.settings.policy.xml_file}"),
+      var.settings.policy.xml_content
+    ),
     null
   )
 

--- a/modules/apim/api_management_product/output.tf
+++ b/modules/apim/api_management_product/output.tf
@@ -9,7 +9,7 @@ output "product_id" {
 }
 
 output "policy_id" {
-  value       = azurerm_api_management_product_policy.apim[0].id
+  value       = one(azurerm_api_management_product_policy.apim[*].id)
   description = "The ID of the API Management Product Policy."
 }
 


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have added example(s) inside the [./examples/] folder
- [x] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Fixes issues introduced at https://github.com/aztfmod/terraform-azurerm-caf/pull/1488:
- Policy count condition has to ensure that it is not null to create 1
- Output referencing the count with star to avoid failure if no policy is created (therefore there is no [0] element)
- New `xml_file` argument to pass the content referencing a file instead of using in two different ways the same argument

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
