### PR TITLE
Add service_principal_password output

### DIFF
--- a/local.remote_objects.tf
+++ b/local.remote_objects.tf
@@ -24,6 +24,7 @@ locals {
     azuread_apps                                   = try(local.combined_objects_azuread_apps, null)
     azuread_groups                                 = try(local.combined_objects_azuread_groups, null)
     azuread_service_principals                     = try(local.combined_objects_azuread_service_principals, null)
+    azuread_service_principal_passwords            = try(local.combined_objects_azuread_service_principal_passwords, null)
     azuread_users                                  = try(local.combined_objects_azuread_users, null)
     firewall_policies                              = try(local.combined_objects_azurerm_firewall_policies, null)
     firewalls                                      = try(local.combined_objects_azurerm_firewalls, null)

--- a/locals.combined_objects.tf
+++ b/locals.combined_objects.tf
@@ -28,6 +28,7 @@ locals {
   combined_objects_azuread_apps                                   = merge(tomap({ (local.client_config.landingzone_key) = module.azuread_applications }), try(var.remote_objects.azuread_apps, {}))
   combined_objects_azuread_groups                                 = merge(tomap({ (local.client_config.landingzone_key) = module.azuread_groups }), try(var.remote_objects.azuread_groups, {}))
   combined_objects_azuread_service_principals                     = merge(tomap({ (local.client_config.landingzone_key) = module.azuread_service_principals }), try(var.remote_objects.azuread_service_principals, {}))
+  combined_objects_azuread_service_principal_passwords            = merge(tomap({ (local.client_config.landingzone_key) = module.azuread_service_principal_passwords }), try(var.remote_objects.azuread_service_principal_passwords, {}))
   combined_objects_azuread_users                                  = merge(tomap({ (local.client_config.landingzone_key) = module.azuread_users }), try(var.remote_objects.azuread_users, {}))
   combined_objects_azurerm_firewall_policies                      = merge(tomap({ (local.client_config.landingzone_key) = module.azurerm_firewall_policies }), try(var.remote_objects.azurerm_firewall_policies, {}))
   combined_objects_azurerm_firewalls                              = merge(tomap({ (local.client_config.landingzone_key) = module.azurerm_firewalls }), try(var.remote_objects.azurerm_firewalls, {}))

--- a/modules/azuread/service_principal_password/output.tf
+++ b/modules/azuread/service_principal_password/output.tf
@@ -8,6 +8,9 @@ output "key_id" {
 output "service_principal_id" {
   value = azuread_service_principal_password.pwd.service_principal_id
 }
+output "service_principal_password" {
+  value = azuread_service_principal_password.pwd.value
+}
 output "end_date" {
   value = azuread_service_principal_password.pwd.end_date
 }

--- a/modules/azuread/service_principal_password/output.tf
+++ b/modules/azuread/service_principal_password/output.tf
@@ -9,7 +9,8 @@ output "service_principal_id" {
   value = azuread_service_principal_password.pwd.service_principal_id
 }
 output "service_principal_password" {
-  value = azuread_service_principal_password.pwd.value
+  value     = azuread_service_principal_password.pwd.value
+  sensitive = true
 }
 output "end_date" {
   value = azuread_service_principal_password.pwd.end_date


### PR DESCRIPTION
Add service_principal_password output to service_principal_passwords module so it could also be used by remote and dynamic secrets.

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [X] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [X] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
