### PR TITLE
Removing GHA pipelines warnings

### DIFF
--- a/.github/workflows/standalone-regressor-tf100.yaml
+++ b/.github/workflows/standalone-regressor-tf100.yaml
@@ -38,12 +38,12 @@ jobs:
     outputs:
       matrix: ${{ steps.load_scenarios.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - id: load_scenarios
         run: |
           cases=$((
             cat ./.github/workflows/${{ github.event.inputs.scenario }}) | jq -c .)
-          echo "::set-output name=matrix::${cases}"
+          echo "matrix=${cases}" >> $GITHUB_OUTPUT
 
   testcases:
     name: test
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout with tag ${{ github.event.inputs.base_version }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.base_version }}
 
@@ -104,7 +104,7 @@ jobs:
             ${{ env.PLAN_FILE }}
 
       - name: Checkout from selected branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Terraform Init example with selected branch
         run: |

--- a/.github/workflows/standalone-tf100.yaml
+++ b/.github/workflows/standalone-tf100.yaml
@@ -34,12 +34,12 @@ jobs:
     outputs:
       matrix: ${{ steps.load_scenarios.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - id: load_scenarios
         run: |
           cases=$((
             cat ./.github/workflows/${{ github.event.inputs.scenario }}) | jq -c .)
-          echo "::set-output name=matrix::${cases}"
+          echo "matrix=${cases}" >> $GITHUB_OUTPUT
 
   testcases:
     name: test
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Create environment variables
         run: |


### PR DESCRIPTION
Removing pipelines warnings:
- Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
- The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/