### PR TITLE
Add single_placement_group and overprovision for win vmss

### DIFF
--- a/modules/compute/virtual_machine_scale_set/vmss_windows.tf
+++ b/modules/compute/virtual_machine_scale_set/vmss_windows.tf
@@ -72,12 +72,14 @@ resource "azurerm_windows_virtual_machine_scale_set" "vmss" {
   custom_data                  = try(each.value.custom_data, null) == null ? null : filebase64(format("%s/%s", path.cwd, each.value.custom_data))
   eviction_policy              = try(each.value.eviction_policy, null)
   max_bid_price                = try(each.value.max_bid_price, null)
+  overprovision                = try(each.value.overprovision, null)
   priority                     = try(each.value.priority, null)
   provision_vm_agent           = try(each.value.provision_vm_agent, true)
   proximity_placement_group_id = can(each.value.proximity_placement_group_key) || can(each.value.proximity_placement_group.key) ? var.proximity_placement_groups[try(var.client_config.landingzone_key, var.client_config.landingzone_key)][try(each.value.proximity_placement_group_key, each.value.proximity_placement_group.key)].id : try(each.value.proximity_placement_group_id, each.value.proximity_placement_group.id, null)
   scale_in_policy              = try(each.value.scale_in_policy, null)
   zone_balance                 = try(each.value.zone_balance, null)
   zones                        = try(each.value.zones, null)
+  single_placement_group       = try(each.value.single_placement_group, null)
   upgrade_mode                 = try(each.value.upgrade_mode, null)
   # for future releases
   # enable_automatic_updates     = each.value.automatic_os_upgrade_policy.enable_automatic_os_upgrade == true ? false : true


### PR DESCRIPTION
# [1503](https://github.com/aztfmod/terraform-azurerm-caf/issues/1503)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [X] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [X] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

- Add missing options single_placement_group and overprovision for win vmss

## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
