### PR TITLE
Allow same manual cert on multiple AGW listeners

### DIFF
--- a/modules/networking/application_gateway/locals.tf
+++ b/modules/networking/application_gateway/locals.tf
@@ -78,6 +78,17 @@ locals {
     for key, value in local.listeners : [try(value.keyvault_certificate.certificate_key, [])]
   ]))
 
+  manual_certificates = {
+    for cert in distinct(
+      [
+        for key, value in local.listeners : {
+          cert_key = value.keyvault_certificate.certificate_name
+          cert_value = value.keyvault_certificate
+        } if try(value.keyvault_certificate.certificate_name, null) != null
+      ]
+    ) : cert.cert_key => cert.cert_value
+  }
+
   certificate_request_keys = distinct(flatten([
     for key, value in local.listeners : [try(value.keyvault_certificate_request.key, [])]
   ]))


### PR DESCRIPTION
Currently if you supply 2 or more app gateway backends via var.application_gateway_applications that use the same keyvault cert, you will get an error similar to the following::

```
Resource
/subscriptions//resourceGroups//providers/Microsoft.Network/applicationGateways/
has two child resources with the same name (foo-cert)
```

This commit uses a local to gather up the various certs defined in the listener blocks and make sure each is only added once.

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [ ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
