### PR TITLE
change naming for win vm back to 15 chars

### DIFF
--- a/modules/compute/virtual_machine/vm_windows.tf
+++ b/modules/compute/virtual_machine/vm_windows.tf
@@ -16,7 +16,7 @@ resource "azurecaf_name" "windows_computer_name" {
   for_each = local.os_type == "windows" ? var.settings.virtual_machine_settings : {}
 
   name          = try(each.value.computer_name, each.value.name)
-  resource_type = "azurerm_windows_virtual_machine"
+  resource_type = "azurerm_virtual_machine"
   prefixes      = var.global_settings.prefixes
   random_length = var.global_settings.random_length
   clean_input   = true


### PR DESCRIPTION
# [1522](https://github.com/aztfmod/terraform-azurerm-caf/issues/1522)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [x ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
