### PR TITLE
Add Azure AD application reference to app service authentication

### DIFF
--- a/.github/workflows/standalone-scenarios.json
+++ b/.github/workflows/standalone-scenarios.json
@@ -246,6 +246,7 @@
     "webapps/appservice/106-appservice-diagnostics",
     "webapps/appservice/107-appservice-private",
     "webapps/appservice/109-appservice-appgw",
+    "webapps/appservice/110-appservice-auth",
     "webapps/function_app/101-function_app-private",
     "webapps/function_app/102-function_app-linux",
     "webapps/function_app/103-function_app-windows",

--- a/app_services.tf
+++ b/app_services.tf
@@ -6,29 +6,32 @@ module "app_services" {
   depends_on = [module.networking]
   for_each   = local.webapp.app_services
 
-  name                 = each.value.name
-  client_config        = local.client_config
-  location             = can(local.global_settings.regions[each.value.region]) ? local.global_settings.regions[each.value.region] : local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].location
-  resource_group_name  = can(each.value.resource_group.name) || can(each.value.resource_group_name) ? try(each.value.resource_group.name, each.value.resource_group_name) : local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group_key, each.value.resource_group.key)].name
-  app_service_plan_id  = can(each.value.app_service_plan_id) ? each.value.app_service_plan_id : local.combined_objects_app_service_plans[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.app_service_plan_key].id
-  settings             = each.value.settings
-  identity             = try(each.value.identity, null)
-  connection_strings   = try(each.value.connection_strings, {})
-  app_settings         = try(each.value.app_settings, null)
-  slots                = try(each.value.slots, {})
-  global_settings      = local.global_settings
-  dynamic_app_settings = try(each.value.dynamic_app_settings, {})
-  combined_objects     = local.dynamic_app_settings_combined_objects
-  base_tags            = try(local.global_settings.inherit_tags, false) ? try(local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].tags, {}) : {}
-  application_insight  = try(each.value.application_insight_key, null) == null ? null : module.azurerm_application_insights[each.value.application_insight_key]
-  diagnostic_profiles  = try(each.value.diagnostic_profiles, null)
-  diagnostics          = local.combined_diagnostics
-  storage_accounts     = local.combined_objects_storage_accounts
-  tags                 = try(each.value.tags, null)
-  private_endpoints    = try(each.value.private_endpoints, {})
-  vnets                = local.combined_objects_networking
-  subnet_id            = can(each.value.subnet_id) || can(each.value.vnet_key) == false ? try(each.value.subnet_id, null) : local.combined_objects_networking[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
-  private_dns          = local.combined_objects_private_dns
+  name                                = each.value.name
+  client_config                       = local.client_config
+  location                            = can(local.global_settings.regions[each.value.region]) ? local.global_settings.regions[each.value.region] : local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].location
+  resource_group_name                 = can(each.value.resource_group.name) || can(each.value.resource_group_name) ? try(each.value.resource_group.name, each.value.resource_group_name) : local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group_key, each.value.resource_group.key)].name
+  app_service_plan_id                 = can(each.value.app_service_plan_id) ? each.value.app_service_plan_id : local.combined_objects_app_service_plans[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.app_service_plan_key].id
+  settings                            = each.value.settings
+  identity                            = try(each.value.identity, null)
+  connection_strings                  = try(each.value.connection_strings, {})
+  app_settings                        = try(each.value.app_settings, null)
+  slots                               = try(each.value.slots, {})
+  global_settings                     = local.global_settings
+  dynamic_app_settings                = try(each.value.dynamic_app_settings, {})
+  combined_objects                    = local.dynamic_app_settings_combined_objects
+  base_tags                           = try(local.global_settings.inherit_tags, false) ? try(local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].tags, {}) : {}
+  application_insight                 = try(each.value.application_insight_key, null) == null ? null : module.azurerm_application_insights[each.value.application_insight_key]
+  diagnostic_profiles                 = try(each.value.diagnostic_profiles, null)
+  diagnostics                         = local.combined_diagnostics
+  storage_accounts                    = local.combined_objects_storage_accounts
+  tags                                = try(each.value.tags, null)
+  private_endpoints                   = try(each.value.private_endpoints, {})
+  vnets                               = local.combined_objects_networking
+  subnet_id                           = can(each.value.subnet_id) || can(each.value.vnet_key) == false ? try(each.value.subnet_id, null) : local.combined_objects_networking[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+  private_dns                         = local.combined_objects_private_dns
+  azuread_applications                = local.combined_objects_azuread_applications
+  azuread_service_principal_passwords = local.combined_objects_azuread_service_principal_passwords
+
 }
 
 output "app_services" {

--- a/examples/webapps/appservice/110-appservice-auth/configuration.tfvars
+++ b/examples/webapps/appservice/110-appservice-auth/configuration.tfvars
@@ -1,0 +1,87 @@
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "australiaeast"
+  }
+}
+
+resource_groups = {
+  webapp_simple = {
+    name   = "webapp-simple"
+    region = "region1"
+  }
+}
+
+azuread_applications = {
+  test_client = {
+    useprefix        = true
+    application_name = "test-client"
+    reply_urls       = ["https://example.azurewebsites.net/.auth/login/aad/callback"]
+  }
+}
+
+azuread_service_principals = {
+  sp1 = {
+    azuread_application = {
+      key = "test_client"
+    }
+    app_role_assignment_required = true
+  }
+}
+
+azuread_service_principal_passwords = {
+  sp1 = {
+    azuread_service_principal = {
+      key = "sp1"
+    }
+    password_policy = {
+      length         = 250
+      special        = false
+      upper          = true
+      number         = true
+      expire_in_days = 10
+      rotation = {
+        mins = 3
+      }
+    }
+  }
+}
+
+# By default asp1 will inherit from the resource group location
+app_service_plans = {
+  asp1 = {
+    resource_group_key = "webapp_simple"
+    name               = "asp-simple"
+
+    sku = {
+      tier = "Standard"
+      size = "S1"
+    }
+  }
+}
+
+app_services = {
+  webapp1 = {
+    resource_group_key   = "webapp_simple"
+    name                 = "webapp-simple"
+    app_service_plan_key = "asp1"
+
+    app_settings = {
+      "WEBSITE_NODE_DEFAULT_VERSION" = "6.9.1"
+    }
+
+    settings = {
+      enabled = true
+
+      auth_settings = {
+        enabled                       = true
+        unauthenticated_client_action = "RedirectToLoginPage"
+        issuer                        = "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000"
+        active_directory = {
+          client_id_key     = "test_client"
+          client_secret_key = "sp1"
+        }
+      }
+    }
+  }
+}

--- a/modules/webapps/appservice/module.tf
+++ b/modules/webapps/appservice/module.tf
@@ -126,8 +126,8 @@ resource "azurerm_app_service" "app_service" {
         for_each = lookup(var.settings.auth_settings, "active_directory", {}) != {} ? [1] : []
 
         content {
-          client_id         = var.settings.auth_settings.active_directory.client_id
-          client_secret     = lookup(var.settings.auth_settings.active_directory, "client_secret", null)
+          client_id         = can(var.settings.auth_settings.active_directory.client_id_key) ? var.azuread_applications[try(var.settings.auth_settings.active_directory.client_id_lz_key, var.client_config.landingzone_key)][var.settings.auth_settings.active_directory.client_id_key].application_id : var.settings.auth_settings.active_directory.client_id
+          client_secret     = can(var.settings.auth_settings.active_directory.client_secret_key) ? var.azuread_service_principal_passwords[try(var.settings.auth_settings.active_directory.client_secret_lz_key, var.client_config.landingzone_key)][var.settings.auth_settings.active_directory.client_secret_key].service_principal_password : try(var.settings.auth_settings.active_directory.client_secret, null)
           allowed_audiences = lookup(var.settings.auth_settings.active_directory, "allowed_audiences", null)
         }
       }

--- a/modules/webapps/appservice/variables.tf
+++ b/modules/webapps/appservice/variables.tf
@@ -74,3 +74,5 @@ variable "vnets" {}
 variable "subnet_id" {}
 variable "private_endpoints" {}
 variable "private_dns" {}
+variable "azuread_applications" {}
+variable "azuread_service_principal_passwords" {}


### PR DESCRIPTION
To add Azure AD authentication to app service, we need to reference an existing azuread_application and service_principal_password

# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/1189)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have added example(s) inside the [./examples/] folder
- [x] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
