### PR TITLE
Change default MySQL Flexible username

### DIFF
--- a/examples/mysql_flexible_server/100-simple-mysql-flexible/configuration.tfvars
+++ b/examples/mysql_flexible_server/100-simple-mysql-flexible/configuration.tfvars
@@ -27,7 +27,7 @@ mysql_flexible_server = {
     }
 
     # Auto-generated administrator credentials stored in azure keyvault when not set (recommended).
-    #administrator_username  = "psqladmin"
+    #administrator_username  = "mysqladmin"
     #administrator_password  = "ComplxP@ssw0rd!"
     keyvault = {
       key = "mysql_region1" # (Required) when auto-generated administrator credentials needed.

--- a/examples/mysql_flexible_server/101-delegated-subnet-with-fw-rule/configuration.tfvars
+++ b/examples/mysql_flexible_server/101-delegated-subnet-with-fw-rule/configuration.tfvars
@@ -34,7 +34,7 @@ mysql_flexible_server = {
       # lz_key = ""                           # Set the lz_key if the resource group is remote.
     }
     # Auto-generated administrator credentials stored in azure keyvault when not set (recommended).
-    #administrator_username  = "psqladminss"
+    #administrator_username  = "mysqladmin"
     #administrator_password  = "ComplxP@ssw0rd!!"
 
     vnet = {

--- a/examples/mysql_flexible_server/102-advanced-mysql-flexible/configuration.tfvars
+++ b/examples/mysql_flexible_server/102-advanced-mysql-flexible/configuration.tfvars
@@ -28,7 +28,7 @@ mysql_flexible_server = {
     }
 
     # Auto-generated administrator credentials stored in azure keyvault when not set (recommended).
-    # administrator_username  = "psqladmin"
+    # administrator_username  = "mysqladmin"
     # administrator_password  = "ComplxP@ssw0rd!"
     keyvault = {
       key = "mysql_region1" # (Required) when auto-generated.

--- a/modules/databases/mysql_flexible_server/server.tf
+++ b/modules/databases/mysql_flexible_server/server.tf
@@ -24,7 +24,7 @@ resource "azurerm_mysql_flexible_server" "mysql" {
   point_in_time_restore_time_in_utc = try(var.settings.create_mode, "PointInTimeRestore") == "PointInTimeRestore" ? try(var.settings.point_in_time_restore_time_in_utc, null) : null
   source_server_id                  = try(var.settings.create_mode, "PointInTimeRestore") == "PointInTimeRestore" ? try(var.settings.source_server_id, null) : null
 
-  administrator_login          = try(var.settings.create_mode, "Default") == "Default" ? try(var.settings.administrator_username, "psqladmin") : null
+  administrator_login          = try(var.settings.create_mode, "Default") == "Default" ? try(var.settings.administrator_username, "mysqladmin") : null
   administrator_password       = try(var.settings.create_mode, "Default") == "Default" ? try(var.settings.administrator_password, azurerm_key_vault_secret.mysql_administrator_password.0.value) : null
   geo_redundant_backup_enabled = try(var.settings.geo_redundant_backup_enabled, false)
   backup_retention_days        = try(var.settings.backup_retention_days, null)
@@ -73,7 +73,7 @@ resource "azurerm_key_vault_secret" "mysql_administrator_username" {
   count = lookup(var.settings, "keyvault", null) == null ? 0 : 1
 
   name         = format("%s-mysql-administrator-username", azurecaf_name.mysql_flexible_server.result)
-  value        = try(var.settings.administrator_username, "psqladmin")
+  value        = try(var.settings.administrator_username, "mysqladmin")
   key_vault_id = var.remote_objects.keyvault_id
 
   lifecycle {


### PR DESCRIPTION
# No Issue

## PR Checklist

---

- [x] I have added example(s) inside the [./examples/] folder
- **N/A** I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

The default username for the MySQL Flexible server was `psqladmin`, presumably left over
when copied from the PostgreSQL Flexible server example.  
This is true both for the provided examples, and when using a keyvault.

Afraid this might confuse somebody..

## Does this introduce a breaking change

- [ ] YES
- [x] NO
