### PR TITLE
bug: aks admin group ignored when ids are used

### DIFF
--- a/aks_clusters.tf
+++ b/aks_clusters.tf
@@ -17,7 +17,7 @@ module "aks_clusters" {
   settings            = each.value
   vnets               = local.combined_objects_networking
 
-  admin_group_object_ids = try(each.value.admin_groups.azuread_group_keys, null) == null ? null : try(
+  admin_group_object_ids = try(each.value.admin_groups, null) == null ? null : try(
     each.value.admin_groups.ids,
     [
       for group_key in try(each.value.admin_groups.azuread_groups.keys, {}) : local.combined_objects_azuread_groups[local.client_config.landingzone_key][group_key].id


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/1562)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

AKS admin_group block was expected to accept ids (object id of azure group(created outside caf or in a landingzone which deployment do not have access to)) and group key. at the moment only the existence group key is checked and if not exists null is returned, ignoring ids. existence of block admin_groups should be evaluated in my opinion

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
