### PR TITLE
Fix subscription tagging

### DIFF
--- a/modules/subscriptions/subscriptions.tf
+++ b/modules/subscriptions/subscriptions.tf
@@ -21,7 +21,7 @@ resource "azurerm_subscription" "sub" {
   subscription_id   = try(var.settings.subscription_id, null) != null ? var.settings.subscription_id : null
   billing_scope_id  = try(var.settings.billing_scope_id, null) == null ? try(data.azurerm_billing_enrollment_account_scope.sub.0.id, data.azurerm_billing_mca_account_scope.sub.0.id, null) : var.settings.billing_scope_id
   workload          = try(var.settings.workload, null)
-  tags              = try(var.settings.tags, null)
+  tags              = try(var.tags, null)
 
   lifecycle {
     ignore_changes = [

--- a/modules/subscriptions/variables.tf
+++ b/modules/subscriptions/variables.tf
@@ -15,3 +15,8 @@ variable "global_settings" {
 variable "diagnostics" {
   default = {}
 }
+
+variable "tags" {
+  description = "(Required) Map of tags to be applied to the resource"
+  type        = map(any)
+}

--- a/subscriptions.tf
+++ b/subscriptions.tf
@@ -9,6 +9,7 @@ module "subscriptions" {
   settings         = each.value
   client_config    = local.client_config
   diagnostics      = local.combined_diagnostics
+  tags             = merge(var.tags, lookup(each.value, "tags", {}))
 }
 
 module "subscription_billing_role_assignments" {


### PR DESCRIPTION
# [Issue-id 1565](https://github.com/aztfmod/terraform-azurerm-caf/issues/1565)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

We found that although tags were defined and rendered into a tags.tfvars.json file to be pickedup by the Rover, the tags were never applied to subscriptions being created. The tags however were applied as expected on other resources provisioned using this module

## Does this introduce a breaking change

- [ ] YES
- [x] NO

## Testing

- Created several new subscriptions and tags were applied
-  Overloading of a global tag works as expected
- Re-applying the config on subscriptions that had no tags received the (new) tags 
