### PR TITLE
Add support to upload blob content + improvements

### DIFF
--- a/diagnostics.tf
+++ b/diagnostics.tf
@@ -34,6 +34,7 @@ module "diagnostic_storage_accounts" {
   resource_group_name = can(each.value.resource_group.name) || can(each.value.resource_group_name) ? try(each.value.resource_group.name, each.value.resource_group_name) : null
   location            = try(local.global_settings.regions[each.value.region], null)
   base_tags           = local.global_settings.inherit_tags
+  var_folder_path     = var.var_folder_path
 }
 
 resource "azurerm_storage_account_customer_managed_key" "diasacmk" {

--- a/examples/storage_accounts/100-simple-storage-account-blob-container/configuration.tfvars
+++ b/examples/storage_accounts/100-simple-storage-account-blob-container/configuration.tfvars
@@ -8,7 +8,7 @@ global_settings = {
 
 provider_azurerm_features_keyvault = {
   // set to true to cleanup the CI
-  purge_soft_delete_on_destroy = true
+  purge_soft_delete_on_destroy = false
 }
 
 resource_groups = {

--- a/examples/storage_container/101-storage_container/configuration.tfvars
+++ b/examples/storage_container/101-storage_container/configuration.tfvars
@@ -25,11 +25,62 @@ storage_accounts = {
 
 
 storage_containers = {
-  sc1 = {
-    name = "sc1"
+  scripts = {
+    name = "scripts"
     storage_account = {
       key = "sa1"
     }
     container_access_type = "private"
+  }
+}
+
+
+role_mapping = {
+  built_in_role_mapping = {
+    storage_containers = {
+      scripts = {
+        "Storage Blob Data Contributor" = {
+          logged_in = {
+            keys = ["user"]
+          }
+        }
+      }
+    }
+  }
+}
+
+# Attributes available https://www.terraform.io/docs/providers/azurerm/r/storage_blob.html
+storage_account_blobs = {
+  devops_runtime_docker = {
+    storage_account_key = "sa1"
+    storage_container = {
+      key = "scripts"
+    }
+    name = "devops_runtime_docker.sh"
+    #
+    # Note this source path has to be the full path or
+    # the relative path to the module variable var_folder_path
+    # So when running terraform add -var var_folder_path={base path of the source attribute}
+    #
+    source = "scripts/devops_runtime_docker.sh"
+
+    delay = {
+      create_duration = "30s"
+    }
+  }
+  devops_runtime_docker_by_content = {
+    storage_account_key = "sa1"
+    storage_container = {
+      key = "scripts"
+    }
+    name           = "devops_runtime_docker_content.sh"
+    source_content = <<-EOF
+    #!/bin/bash
+    echo "Hello world"
+    EOF
+
+    delay = {
+      create_duration = "30s"
+    }
   }
 }

--- a/examples/storage_container/101-storage_container/scripts/devops_runtime_docker.sh
+++ b/examples/storage_container/101-storage_container/scripts/devops_runtime_docker.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
+sudo sh -c 'echo -e "[azure-cli]
+name=Azure CLI
+baseurl=https://packages.microsoft.com/yumrepos/azure-cli
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.microsoft.com/keys/microsoft.asc" > /etc/yum.repos.d/azure-cli.repo'
+sudo yum -y install azure-cli
+
+sudo yum install -y yum-utils device-mapper-persistent-data lvm2
+sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+sudo yum makecache fast
+sudo yum install -y docker-ce
+sudo systemctl daemon-reload
+sudo systemctl enable docker
+sudo service docker start
+sudo docker --version
+
+sudo az login --identity
+
+az acr login --name ${7}
+sudo docker pull "${7}/${5}"
+
+for agent_num in $(seq 1 ${6}); do
+    name="${4}-${agent_num}"
+    sudo docker run -d -v /var/run/docker.sock:/var/run/docker.sock --name ${name} -e AZP_URL=${1} -e AZP_TOKEN=${2} -e AZP_POOL="${3}" -e AZP_AGENT_NAME="${name}" "${7}/${5}"
+done

--- a/modules/storage_account/blob/module.tf
+++ b/modules/storage_account/blob/module.tf
@@ -11,9 +11,15 @@ resource "azurerm_storage_blob" "blob" {
   access_tier            = try(var.settings.access_tier, "Hot")
   content_type           = try(var.settings.content_type, null)
   content_md5            = try(var.settings.content_md5, null)
-  source                 = try(var.settings.source, null)
-  source_content         = try(var.settings.source_content, null)
-  source_uri             = try(var.settings.source_uri, null)
-  parallelism            = try(var.settings.parallelism, 8)
-  metadata               = try(var.settings.metadata, null)
+  source = can(var.settings.source) || can(fileexists(format("%s/%s", var.var_folder_path, var.settings.source))) ? try(
+    format("%s/%s", var.var_folder_path, var.settings.source),
+    var.settings.source
+  ) : null
+  source_content = can(var.settings.source_content) || can(fileexists(format("%s/%s", var.var_folder_path, var.settings.source_content))) ? try(
+    file(format("%s/%s", var.var_folder_path, var.settings.source_content)),
+    var.settings.source_content
+  ) : null
+  source_uri  = try(var.settings.source_uri, null)
+  parallelism = try(var.settings.parallelism, 8)
+  metadata    = try(var.settings.metadata, null)
 }

--- a/modules/storage_account/blob/output.tf
+++ b/modules/storage_account/blob/output.tf
@@ -7,3 +7,8 @@ output "url" {
   description = "The URL of the blob"
   value       = azurerm_storage_blob.blob.url
 }
+
+output "rbac_id" {
+  description = "The ID of the Storage Blob for role_mapping"
+  value       = azurerm_storage_blob.blob.id
+}

--- a/modules/storage_account/blob/variables.tf
+++ b/modules/storage_account/blob/variables.tf
@@ -1,3 +1,4 @@
 variable "storage_account_name" {}
 variable "storage_container_name" {}
 variable "settings" {}
+variable "var_folder_path" {}

--- a/modules/storage_account/container/storage_blob.tf
+++ b/modules/storage_account/container/storage_blob.tf
@@ -6,4 +6,5 @@ module "blob" {
   storage_account_name   = var.storage_account_name
   storage_container_name = var.settings.name
   settings               = each.value
+  var_folder_path        = var.var_folder_path
 }

--- a/modules/storage_account/container/variables.tf
+++ b/modules/storage_account/container/variables.tf
@@ -1,2 +1,3 @@
 variable "settings" {}
 variable "storage_account_name" {}
+variable "var_folder_path" {}

--- a/modules/storage_account/storage_account.tf
+++ b/modules/storage_account/storage_account.tf
@@ -227,6 +227,7 @@ module "container" {
 
   storage_account_name = azurerm_storage_account.stg.name
   settings             = each.value
+  var_folder_path      = var.var_folder_path
 }
 
 module "data_lake_filesystem" {

--- a/modules/storage_account/variables.tf
+++ b/modules/storage_account/variables.tf
@@ -62,3 +62,5 @@ variable "diagnostics" {
 variable "managed_identities" {
   default = {}
 }
+
+variable "var_folder_path" {}

--- a/roles.tf
+++ b/roles.tf
@@ -99,6 +99,7 @@ locals {
   # Nested objects that must be processed after the services_roles
   services_roles_deferred = {
     storage_containers = local.combined_objects_storage_containers
+    logged_in          = local.logged_in
   }
 
   services_roles = {

--- a/storage_account_blobs.tf
+++ b/storage_account_blobs.tf
@@ -6,7 +6,7 @@ resource "time_sleep" "delay" {
   depends_on = [azurerm_role_assignment.for_deferred]
   for_each   = local.storage.storage_account_blobs
 
-  create_duration = "300s"
+  create_duration = try(each.value.dealy.create_duration, "300s")
 }
 
 module "storage_account_blobs" {
@@ -16,8 +16,9 @@ module "storage_account_blobs" {
 
 
   storage_account_name   = module.storage_accounts[each.value.storage_account_key].name
-  storage_container_name = each.value.storage_container_name
+  storage_container_name = can(each.value.storage_container_name) ? each.value.storage_container_name : local.combined_objects_storage_containers[try(each.value.storage_container.lz_key, local.client_config.landingzone_key)][each.value.storage_container.key].name
   settings               = each.value
+  var_folder_path        = var.var_folder_path
 }
 
 output "storage_account_blobs" {

--- a/storage_accounts.tf
+++ b/storage_accounts.tf
@@ -16,6 +16,7 @@ module "storage_accounts" {
   private_endpoints         = try(each.value.private_endpoints, {})
   recovery_vaults           = local.combined_objects_recovery_vaults
   storage_account           = each.value
+  var_folder_path           = var.var_folder_path
   vnets                     = local.combined_objects_networking
 
   base_tags           = local.global_settings.inherit_tags

--- a/storage_container.tf
+++ b/storage_container.tf
@@ -5,6 +5,7 @@ module "storage_containers" {
 
   settings             = each.value
   storage_account_name = can(each.value.storage_account.name) ? each.value.storage_account.name : local.combined_objects_storage_accounts[try(each.value.storage_account.lz_key, local.client_config.landingzone_key)][try(each.value.storage_account.key, each.value.storage_account_key)].name
+  var_folder_path      = var.var_folder_path
 }
 output "storage_containers" {
   value = module.storage_containers

--- a/variables.tf
+++ b/variables.tf
@@ -418,5 +418,5 @@ variable "resource_provider_registration" {
 }
 variable "aadb2c" {
   description = "Configuration object - AAD B2C resources"
-  default = {}
+  default     = {}
 }


### PR DESCRIPTION
# Add support to upload blob content + improvements

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

This PR is updating an end-to-end scenario on how to upload a file into a blob block or to set content of the blob using the heredoc format.

Add support in the configuration file to be relative to the var_folder_path module variable

```
rover \
  -lz /tf/caf/examples \
  -var-folder /tf/caf/aztfmod/examples/storage_container/101-storage_container \
  -var var_folder_path="/tf/caf/aztfmod/examples/storage_container/101-storage_container" \
  -tfstate example_101.tfstate \
  -p ${TF_DATA_DIR}/example.tfplan -a plan
```

```

# Attributes available https://www.terraform.io/docs/providers/azurerm/r/storage_blob.html
storage_account_blobs = {
  devops_runtime_docker = {
    storage_account_key = "sa1"
    storage_container = {
      key = "scripts"
    }
    name = "devops_runtime_docker.sh"
    #
    # Note this source path has to be the full path or
    # the relative path to the module variable var_folder_path
    # So when running terraform add -var var_folder_path={base path of the source attribute}
    #
    source = "scripts/devops_runtime_docker.sh"

    delay = {
      create_duration = "30s"
    }
  }
  devops_runtime_docker_by_content = {
    storage_account_key = "sa1"
    storage_container = {
      key = "scripts"
    }
    name           = "devops_runtime_docker_content.sh"
    source_content = <<-EOF
    #!/bin/bash
    echo "Hello world"
    EOF

    delay = {
      create_duration = "30s"
    }
  }
}

```

```tfvars

# Set the permission to the storage container

role_mapping = {
  built_in_role_mapping = {
    storage_containers = {
      scripts = {
        "Storage Blob Data Contributor" = {
          logged_in = {
            keys = ["user"]
          }
        }
      }
    }
  }
}

#
# Create the storage account and the storage containers
#
storage_accounts = {
  sa1 = {
    name                     = "sa1"
    resource_group_key       = "test"
    account_kind             = "BlobStorage"
    account_tier             = "Standard"
    account_replication_type = "LRS"
  }
}



storage_containers = {
  scripts = {
    name = "scripts"
    storage_account = {
      key = "sa1"
    }
    container_access_type = "private"
  }
}
```

## Does this introduce a breaking change

- [ ] YES
- [ ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
