### PR TITLE
Backports the introduction of naming resources with user supplied suf…

### DIFF
--- a/bastion_service.tf
+++ b/bastion_service.tf
@@ -9,6 +9,7 @@ resource "azurecaf_name" "host" {
   name          = try(each.value.name, "")
   resource_type = "azurerm_bastion_host"
   prefixes      = local.global_settings.prefixes
+  suffixes      = local.global_settings.suffixes
   random_length = local.global_settings.random_length
   clean_input   = true
   passthrough   = local.global_settings.passthrough

--- a/documentation/conventions.md
+++ b/documentation/conventions.md
@@ -86,6 +86,7 @@ resource "azurecaf_name" "caf_name_vnet" {
   name          = var.settings.vnet.name
   resource_type = "azurerm_virtual_network"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough
@@ -108,7 +109,7 @@ Documentation for all supported field is provided in the [documentation here](ht
 
 ### CEC2: Using global_settings configuration object
 
-An object called ```global_settings``` is created and used by the module. It governs the creation of resources based on a set of common criteria (naming convention, prefixes, region of the deployment, name of the environment, tags inheritance settings, etc.), the content of this object is defined in ```locals.tf``` of the root module. The content of this variable can be customized when the module is called in order to inherit and shared the configuration settings consistently across landing zones.
+An object called ```global_settings``` is created and used by the module. It governs the creation of resources based on a set of common criteria (naming convention, prefixes, suffixes, region of the deployment, name of the environment, tags inheritance settings, etc.), the content of this object is defined in ```locals.tf``` of the root module. The content of this variable can be customized when the module is called in order to inherit and shared the configuration settings consistently across landing zones.
 
 The default content is:
 
@@ -117,6 +118,7 @@ The default content is:
     prefix             = local.prefix
     prefix_with_hyphen = local.prefix == "" ? "" : "${local.prefix}-"
     prefix_start_alpha = local.prefix == "" ? "" : "${random_string.alpha1.result}${local.prefix}"
+    suffixes           = local.suffixes
     default_region     = lookup(var.global_settings, "default_region", "region1")
     environment        = lookup(var.global_settings, "environment", var.environment)
     random_length      = try(var.global_settings.random_length, 0)

--- a/locals.tf
+++ b/locals.tf
@@ -216,6 +216,7 @@ locals {
     prefix             = try(var.global_settings.prefix, null)
     prefix_with_hyphen = try(var.global_settings.prefix_with_hyphen, format("%s-", try(var.global_settings.prefix, try(var.global_settings.prefixes[0], random_string.prefix.0.result))))
     prefixes           = try(var.global_settings.prefix, null) == "" ? null : try([var.global_settings.prefix], try(var.global_settings.prefixes, [random_string.prefix.0.result]))
+    suffixes           = try(var.global_settings.suffixes, null)
     random_length      = try(var.global_settings.random_length, 0)
     regions            = try(var.global_settings.regions, null)
     tags               = try(var.global_settings.tags, null)

--- a/modules/analytics/databricks_workspace/workspace.tf
+++ b/modules/analytics/databricks_workspace/workspace.tf
@@ -5,6 +5,7 @@ resource "azurecaf_name" "wp" {
   name          = var.settings.name
   resource_type = "azurerm_databricks_workspace"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/analytics/machine_learning/compute_instance/compute_instance.tf
+++ b/modules/analytics/machine_learning/compute_instance/compute_instance.tf
@@ -5,6 +5,7 @@ resource "azurecaf_name" "ci" {
   # TODO: create resource type to match the required value: Compute name is invalid. It can include letters, digits and dashes. It must start with a letter, end with a letter or digit, and be between 3 and 24 characters in length
   #resource_type = "azurerm_linux_virtual_machine"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/analytics/machine_learning/workspace.tf
+++ b/modules/analytics/machine_learning/workspace.tf
@@ -2,6 +2,7 @@
 resource "azurecaf_name" "ws" {
   name          = var.settings.name
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   resource_type = "azurerm_machine_learning_workspace"
   random_length = var.global_settings.random_length
   clean_input   = true

--- a/modules/analytics/machine_learning_compute_instance/module.tf
+++ b/modules/analytics/machine_learning_compute_instance/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "mlci" {
   name          = var.settings.name
   resource_type = "azurerm_machine_learning_compute_instance"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/analytics/synapse/spark_pool/spark_pool.tf
+++ b/modules/analytics/synapse/spark_pool/spark_pool.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "sparkpool" {
   name          = var.settings.name
   resource_type = "azurerm_synapse_spark_pool"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/analytics/synapse/sql_pool/sql_pool.tf
+++ b/modules/analytics/synapse/sql_pool/sql_pool.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "sqlpool" {
   name          = var.settings.name
   resource_type = "azurerm_synapse_spark_pool"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/analytics/synapse/workspace.tf
+++ b/modules/analytics/synapse/workspace.tf
@@ -3,6 +3,7 @@ resource "azurecaf_name" "ws" {
   name          = var.settings.name
   resource_type = "azurerm_synapse_workspace"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/apim/api_management/module.tf
+++ b/modules/apim/api_management/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "apim" {
   name          = var.settings.name
   resource_type = "azurerm_api_management"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/apim/api_management_api/module.tf
+++ b/modules/apim/api_management_api/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "apim" {
   name          = var.settings.name
   resource_type = "azurerm_api_management_api"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/apim/api_management_api_operation_tag/module.tf
+++ b/modules/apim/api_management_api_operation_tag/module.tf
@@ -4,6 +4,7 @@ resource "azurecaf_name" "apim" {
   name          = var.settings.name
   resource_type = "azurerm_api_management_api_operation_tag"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/apim/api_management_backend/module.tf
+++ b/modules/apim/api_management_backend/module.tf
@@ -3,6 +3,7 @@ resource "azurecaf_name" "apim" {
   name          = var.settings.name
   resource_type = "azurerm_api_management_backend"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/apim/api_management_certificate/module.tf
+++ b/modules/apim/api_management_certificate/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "apim" {
   name          = var.settings.name
   resource_type = "azurerm_api_management_certificate"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/apim/api_management_gateway/module.tf
+++ b/modules/apim/api_management_gateway/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "apim" {
   name          = var.settings.name
   resource_type = "azurerm_api_management_gateway"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/apim/api_management_group/module.tf
+++ b/modules/apim/api_management_group/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "apim" {
   name          = var.settings.name
   resource_type = "azurerm_api_management_group"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/apim/api_management_logger/module.tf
+++ b/modules/apim/api_management_logger/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "apim" {
   name          = var.settings.name
   resource_type = "azurerm_api_management_logger"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/app_insights/module.tf
+++ b/modules/app_insights/module.tf
@@ -3,6 +3,7 @@ resource "azurecaf_name" "appis" {
   name          = var.name
   resource_type = "azurerm_application_insights"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/app_insights/standard_web_test/module.tf
+++ b/modules/app_insights/standard_web_test/module.tf
@@ -2,6 +2,7 @@ data "azurecaf_name" "appiwt" {
   name          = var.name
   resource_type = "azurerm_application_insights_web_test"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/app_insights/web_test/module.tf
+++ b/modules/app_insights/web_test/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "appiwt" {
   name          = var.name
   resource_type = "azurerm_application_insights_web_test"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/automation/automation_runbook/module.tf
+++ b/modules/automation/automation_runbook/module.tf
@@ -4,6 +4,7 @@
 #   name          = var.settings.name
 #   resource_type = "azurerm_automation_runbook"
 #   prefixes      = var.global_settings.prefixes
+#   suffixes      = var.global_settings.suffixes
 #   random_length = var.global_settings.random_length
 #   clean_input   = true
 #   passthrough   = var.global_settings.passthrough

--- a/modules/automation/automation_schedule/module.tf
+++ b/modules/automation/automation_schedule/module.tf
@@ -3,6 +3,7 @@ resource "azurecaf_name" "automation_schedule" {
   name          = var.settings.name
   resource_type = "azurerm_automation_schedule"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/automation/module.tf
+++ b/modules/automation/module.tf
@@ -3,6 +3,7 @@ resource "azurecaf_name" "auto_account" {
   name          = var.settings.name
   resource_type = "azurerm_automation_account"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/azuread/users/user.tf
+++ b/modules/azuread/users/user.tf
@@ -1,6 +1,7 @@
 locals {
   global_settings = {
     prefixes      = lookup(var.settings, "useprefix", null) == true ? try(var.settings.global_settings.prefixes, var.global_settings.prefixes) : []
+    suffixes      = lookup(var.settings, "usesuffixes", null) == true ? try(var.settings.global_settings.suffixes, var.global_settings.suffixes) : []
     random_length = try(var.settings.global_settings.random_length, var.global_settings.random_length)
     passthrough   = try(var.settings.global_settings.passthrough, var.global_settings.passthrough)
     use_slug      = try(var.settings.global_settings.use_slug, var.global_settings.use_slug)
@@ -18,6 +19,7 @@ resource "azurecaf_name" "account" {
   resource_type = "azurerm_resource_group"
   #TODO: need to be changed to appropriate resource (no caf reference for now)
   prefixes      = local.global_settings.prefixes
+  suffixes      = local.global_settings.suffixes
   random_length = local.global_settings.random_length
   clean_input   = true
   passthrough   = local.global_settings.passthrough

--- a/modules/backup_vault/backup_vault.tf
+++ b/modules/backup_vault/backup_vault.tf
@@ -4,6 +4,7 @@ resource "azurecaf_name" "bckp" {
   name          = var.settings.backup_vault_name
   resource_type = "azurerm_data_protection_backup_vault"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/backup_vault/backup_vault_policy_blob_storage/backup_vault_policy.tf
+++ b/modules/backup_vault/backup_vault_policy_blob_storage/backup_vault_policy.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "backup_vault_policy" {
   name          = var.settings.policy_name
   resource_type = "azurerm_data_protection_backup_policy_blob_storage"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/backup_vault/backup_vault_policy_disk/backup_vault_policy.tf
+++ b/modules/backup_vault/backup_vault_policy_disk/backup_vault_policy.tf
@@ -3,6 +3,7 @@ resource "azurecaf_name" "backup_vault_policy" {
   name          = var.settings.policy_name
   resource_type = "azurerm_data_protection_backup_policy_disk"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/cognitive_services/cognitive_services_account/cognitive_service_account.tf
+++ b/modules/cognitive_services/cognitive_services_account/cognitive_service_account.tf
@@ -1,6 +1,7 @@
 resource "azurecaf_name" "service" {
   name          = var.settings.name
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   resource_type = "azurerm_cognitive_account"
   random_length = var.global_settings.random_length
   clean_input   = true

--- a/modules/communication/communication_services/module.tf
+++ b/modules/communication/communication_services/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "acs" {
   name          = var.settings.name
   resource_type = "azurerm_communication_service"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/compute/aks/aks.tf
+++ b/modules/compute/aks/aks.tf
@@ -5,6 +5,7 @@ resource "azurecaf_name" "aks" {
   name          = var.settings.name
   resource_type = "azurerm_kubernetes_cluster"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough
@@ -15,6 +16,7 @@ resource "azurecaf_name" "default_node_pool" {
   name          = var.settings.default_node_pool.name
   resource_type = "aks_node_pool_linux"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough
@@ -29,6 +31,7 @@ resource "azurecaf_name" "rg_node" {
   name          = var.settings.node_resource_group_name
   resource_type = "azurerm_resource_group"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/compute/availability_set/availability_set.tf
+++ b/modules/compute/availability_set/availability_set.tf
@@ -15,6 +15,7 @@ resource "azurecaf_name" "avset" {
   name          = var.settings.name
   resource_type = "azurerm_availability_set"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/compute/azure_redhat_openshift/aro.tf
+++ b/modules/compute/azure_redhat_openshift/aro.tf
@@ -4,6 +4,7 @@ resource "azurecaf_name" "aro_cluster" {
   name          = var.settings.name
   resource_type = "azurerm_redhat_openshift_cluster"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough
@@ -14,6 +15,7 @@ resource "azurecaf_name" "aro_domain" {
   name          = var.settings.cluster_profile.domain
   resource_type = "azurerm_redhat_openshift_domain"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough
@@ -25,6 +27,7 @@ resource "azurecaf_name" "aro_res_rg" {
   name          = var.settings.cluster_profile.resource_group.name
   resource_type = "azurerm_resource_group"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/compute/batch/batch_account/account.tf
+++ b/modules/compute/batch/batch_account/account.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "account" {
   name          = var.settings.name
   resource_type = "azurerm_batch_account"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/compute/batch/batch_application/application.tf
+++ b/modules/compute/batch/batch_application/application.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "application" {
   name          = var.settings.name
   resource_type = "azurerm_batch_application"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/compute/batch/batch_pool/pool.tf
+++ b/modules/compute/batch/batch_pool/pool.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "pool" {
   name          = var.settings.name
   resource_type = "azurerm_batch_pool"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/compute/container_group/container_group.tf
+++ b/modules/compute/container_group/container_group.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "acg" {
   name          = var.settings.name
   resource_type = "azurerm_containerGroups"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/compute/container_registry/registry.tf
+++ b/modules/compute/container_registry/registry.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "acr" {
   name          = var.name
   resource_type = "azurerm_container_registry"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/compute/dedicated_host_groups/module.tf
+++ b/modules/compute/dedicated_host_groups/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "dhg" {
   name          = var.settings.name
   resource_type = "azurerm_dedicated_host_group"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/compute/dedicated_hosts/module.tf
+++ b/modules/compute/dedicated_hosts/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "dh" {
   name          = var.settings.name
   resource_type = "azurerm_dedicated_host"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/compute/proximity_placement_group/proximity_placement_group.tf
+++ b/modules/compute/proximity_placement_group/proximity_placement_group.tf
@@ -4,6 +4,7 @@ resource "azurecaf_name" "ppg" {
   name          = var.name
   resource_type = "azurerm_proximity_placement_group"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/compute/virtual_machine/network_interface.tf
+++ b/modules/compute/virtual_machine/network_interface.tf
@@ -32,6 +32,7 @@ resource "azurecaf_name" "nic" {
   name          = each.value.name
   resource_type = "azurerm_network_interface"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/compute/virtual_machine/vm_disk.tf
+++ b/modules/compute/virtual_machine/vm_disk.tf
@@ -4,6 +4,7 @@ resource "azurecaf_name" "disk" {
   name          = each.value.name
   resource_type = "azurerm_managed_disk"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/compute/virtual_machine/vm_legacy.tf
+++ b/modules/compute/virtual_machine/vm_legacy.tf
@@ -5,6 +5,7 @@ resource "azurecaf_name" "legacy" {
   name          = each.value.name
   resource_type = "azurerm_virtual_machine"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough
@@ -20,6 +21,7 @@ resource "azurecaf_name" "legacy_computer_name" {
   name          = try(each.value.computer_name, each.value.name)
   resource_type = "azurerm_virtual_machine"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/compute/virtual_machine/vm_linux.tf
+++ b/modules/compute/virtual_machine/vm_linux.tf
@@ -12,6 +12,7 @@ resource "azurecaf_name" "linux" {
   name          = each.value.name
   resource_type = "azurerm_linux_virtual_machine"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough
@@ -27,6 +28,7 @@ resource "azurecaf_name" "linux_computer_name" {
   name          = try(each.value.computer_name, each.value.name)
   resource_type = "azurerm_linux_virtual_machine"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough
@@ -40,6 +42,7 @@ resource "azurecaf_name" "os_disk_linux" {
   name          = try(each.value.os_disk.name, null)
   resource_type = "azurerm_managed_disk"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/compute/virtual_machine/vm_windows.tf
+++ b/modules/compute/virtual_machine/vm_windows.tf
@@ -5,6 +5,7 @@ resource "azurecaf_name" "windows" {
   name          = each.value.name
   resource_type = "azurerm_windows_virtual_machine"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough
@@ -18,6 +19,7 @@ resource "azurecaf_name" "windows_computer_name" {
   name          = try(each.value.computer_name, each.value.name)
   resource_type = "azurerm_windows_virtual_machine"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough
@@ -31,6 +33,7 @@ resource "azurecaf_name" "os_disk_windows" {
   name          = try(each.value.os_disk.name, null)
   resource_type = "azurerm_managed_disk"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/compute/virtual_machine_scale_set/vmss_linux.tf
+++ b/modules/compute/virtual_machine_scale_set/vmss_linux.tf
@@ -12,6 +12,7 @@ resource "azurecaf_name" "linux" {
   name          = each.value.name
   resource_type = "azurerm_virtual_machine_scale_set"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough
@@ -26,6 +27,7 @@ resource "azurecaf_name" "linux_computer_name_prefix" {
   name          = try(each.value.computer_name_prefix, each.value.name)
   resource_type = "azurerm_virtual_machine_scale_set"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough
@@ -42,6 +44,7 @@ resource "azurecaf_name" "linux_nic" {
   name          = try(each.value.name, null)
   resource_type = "azurerm_network_interface"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough
@@ -55,6 +58,7 @@ resource "azurecaf_name" "os_disk_linux" {
   name          = try(each.value.os_disk.name, null)
   resource_type = "azurerm_managed_disk"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/compute/virtual_machine_scale_set/vmss_windows.tf
+++ b/modules/compute/virtual_machine_scale_set/vmss_windows.tf
@@ -5,6 +5,7 @@ resource "azurecaf_name" "windows" {
   name          = each.value.name
   resource_type = "azurerm_virtual_machine_scale_set"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough
@@ -19,6 +20,7 @@ resource "azurecaf_name" "windows_computer_name_prefix" {
   name          = try(each.value.computer_name_prefix, each.value.name)
   resource_type = "azurerm_vm_windows_computer_name_prefix"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough
@@ -36,6 +38,7 @@ resource "azurecaf_name" "windows_nic" {
   name          = try(each.value.name, null)
   resource_type = "azurerm_network_interface"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough
@@ -50,6 +53,7 @@ resource "azurecaf_name" "os_disk_windows" {
   name          = try(each.value.os_disk.name, null)
   resource_type = "azurerm_managed_disk"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/compute/vmware_clusters/module.tf
+++ b/modules/compute/vmware_clusters/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "vwc" {
   name          = var.settings.name
   resource_type = "azurerm_vmware_cluster"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/compute/vmware_express_route_authorizations/module.tf
+++ b/modules/compute/vmware_express_route_authorizations/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "vwera" {
   name          = var.settings.name
   resource_type = "azurerm_vmware_express_route_authorization"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/compute/vmware_private_clouds/module.tf
+++ b/modules/compute/vmware_private_clouds/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "vwpc" {
   name          = var.settings.name
   resource_type = "azurerm_vmware_private_cloud"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/compute/wvd_application_group/virtual_desktop_application_group.tf
+++ b/modules/compute/wvd_application_group/virtual_desktop_application_group.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "dag" {
   name          = var.settings.name
   resource_type = "azurerm_virtual_desktop_application_group"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/compute/wvd_host_pool/virtual_desktop_host_pool.tf
+++ b/modules/compute/wvd_host_pool/virtual_desktop_host_pool.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "wvdpool" {
   name          = var.settings.name
   resource_type = "azurerm_virtual_desktop_host_pool"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/compute/wvd_workspace/virtual_desktop_workspace.tf
+++ b/modules/compute/wvd_workspace/virtual_desktop_workspace.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "wvdws" {
   name          = var.settings.name
   resource_type = "azurerm_virtual_desktop_workspace"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/consumption_budget/resource_group/resource_group_budget.tf
+++ b/modules/consumption_budget/resource_group/resource_group_budget.tf
@@ -1,6 +1,7 @@
 resource "azurecaf_name" "this_name" {
   name          = var.settings.name
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   resource_type = "azurerm_consumption_budget_resource_group"
   random_length = var.global_settings.random_length
   clean_input   = true

--- a/modules/consumption_budget/subscription/subscription_budget.tf
+++ b/modules/consumption_budget/subscription/subscription_budget.tf
@@ -1,6 +1,7 @@
 resource "azurecaf_name" "this_name" {
   name          = var.settings.name
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   resource_type = "azurerm_consumption_budget_subscription"
   random_length = var.global_settings.random_length
   clean_input   = true

--- a/modules/data_factory/data_factory/module.tf
+++ b/modules/data_factory/data_factory/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "df" {
   name          = var.settings.name
   resource_type = "azurerm_data_factory"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/data_factory/data_factory_integration_runtime_azure_ssis/module.tf
+++ b/modules/data_factory/data_factory_integration_runtime_azure_ssis/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "dfiras" {
   name          = var.settings.name
   resource_type = "azurerm_data_factory" #"azurerm_data_factory_integration_runtime_azure_ssis"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/data_factory/data_factory_integration_runtime_self_hosted/module.tf
+++ b/modules/data_factory/data_factory_integration_runtime_self_hosted/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "dfirsh" {
   name          = var.settings.name
   resource_type = "azurerm_data_factory" #"azurerm_data_factory_integration_runtime_self_hosted"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/data_factory/data_factory_pipeline/module.tf
+++ b/modules/data_factory/data_factory_pipeline/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "pipeline" {
   name          = var.settings.name
   resource_type = "azurerm_data_factory_pipeline"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/data_factory/data_factory_trigger_schedule/module.tf
+++ b/modules/data_factory/data_factory_trigger_schedule/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "schedule" {
   name          = var.settings.name
   resource_type = "azurerm_data_factory_pipeline"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/data_factory/datasets/azure_blob/module.tf
+++ b/modules/data_factory/datasets/azure_blob/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "dataset" {
   name          = var.settings.name
   resource_type = "azurerm_data_factory" #"azurerm_data_factory_dataset_azure_blob"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/data_factory/datasets/cosmosdb_sqlapi/module.tf
+++ b/modules/data_factory/datasets/cosmosdb_sqlapi/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "dataset" {
   name          = var.settings.name
   resource_type = "azurerm_data_factory" #"azurerm_data_factory_dataset_azure_blob"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/data_factory/datasets/delimited_text/module.tf
+++ b/modules/data_factory/datasets/delimited_text/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "dataset" {
   name          = var.settings.name
   resource_type = "azurerm_data_factory" #"azurerm_data_factory_dataset_azure_blob"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/data_factory/datasets/http/module.tf
+++ b/modules/data_factory/datasets/http/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "dataset" {
   name          = var.settings.name
   resource_type = "azurerm_data_factory" #"azurerm_data_factory_dataset_azure_blob"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/data_factory/datasets/json/module.tf
+++ b/modules/data_factory/datasets/json/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "dataset" {
   name          = var.settings.name
   resource_type = "azurerm_data_factory" #"azurerm_data_factory_dataset_azure_blob"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/data_factory/datasets/mysql/module.tf
+++ b/modules/data_factory/datasets/mysql/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "dataset" {
   name          = var.settings.name
   resource_type = "azurerm_data_factory" #"azurerm_data_factory_dataset_mysql"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/data_factory/datasets/postgresql/module.tf
+++ b/modules/data_factory/datasets/postgresql/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "dataset" {
   name          = var.settings.name
   resource_type = "azurerm_data_factory" #"azurerm_data_factory_dataset_mysql"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/data_factory/datasets/sql_server_table/module.tf
+++ b/modules/data_factory/datasets/sql_server_table/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "dataset" {
   name          = var.settings.name
   resource_type = "azurerm_data_factory" #"azurerm_data_factory_dataset_sql_server_table"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/data_factory/linked_services/azure_blob_storage/module.tf
+++ b/modules/data_factory/linked_services/azure_blob_storage/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "lsabs" {
   name          = var.settings.name
   resource_type = "azurerm_data_factory_linked_service_azure_blob_storage" #azurerm_data_factory_linked_service_azure_blob_storage
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/data_factory/linked_services/azure_databricks/module.tf
+++ b/modules/data_factory/linked_services/azure_databricks/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "dflsad" {
   name          = var.settings.name
   resource_type = "azurerm_data_factory_linked_service_azure_databricks"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/data_factory/linked_services/azure_file_storage/module.tf
+++ b/modules/data_factory/linked_services/azure_file_storage/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "dataset" {
   name          = var.settings.name
   resource_type = "azurerm_data_factory_linked_service_azure_file_storage"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/data_factory/linked_services/azure_function/module.tf
+++ b/modules/data_factory/linked_services/azure_function/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "dataset" {
   name          = var.settings.name
   resource_type = "azurerm_data_factory_linked_service_azure_file_storage"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/data_factory/linked_services/azure_sql_database/module.tf
+++ b/modules/data_factory/linked_services/azure_sql_database/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "dataset" {
   name          = var.settings.name
   resource_type = "azurerm_data_factory_linked_service_azure_file_storage"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/data_factory/linked_services/cosmosdb/module.tf
+++ b/modules/data_factory/linked_services/cosmosdb/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "linked_service_cosmosdb" {
   name          = var.settings.name
   resource_type = "azurerm_data_factory" #"azurerm_data_factory_dataset_azure_blob"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/data_factory/linked_services/data_lake_storage_gen2/module.tf
+++ b/modules/data_factory/linked_services/data_lake_storage_gen2/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "linked" {
   name          = var.settings.name
   resource_type = "azurerm_data_factory_linked_service_data_lake_storage_gen2"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/data_factory/linked_services/key_vault/module.tf
+++ b/modules/data_factory/linked_services/key_vault/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "linked" {
   name          = var.settings.name
   resource_type = "azurerm_data_factory_linked_service_key_vault"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/data_factory/linked_services/mysql/module.tf
+++ b/modules/data_factory/linked_services/mysql/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "dataset" {
   name          = var.settings.name
   resource_type = "azurerm_data_factory" #"azurerm_data_factory_dataset_azure_blob"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/data_factory/linked_services/postgresql/module.tf
+++ b/modules/data_factory/linked_services/postgresql/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "linked" {
   name          = var.settings.name
   resource_type = "azurerm_data_factory_linked_service_postgresql"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/data_factory/linked_services/sftp/module.tf
+++ b/modules/data_factory/linked_services/sftp/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "dataset" {
   name          = var.settings.name
   resource_type = "azurerm_data_factory" #"azurerm_data_factory_dataset_azure_blob"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/data_factory/linked_services/sql_server/module.tf
+++ b/modules/data_factory/linked_services/sql_server/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "linked" {
   name          = var.settings.name
   resource_type = "azurerm_data_factory_linked_service_sql_server"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/data_factory/linked_services/web/module.tf
+++ b/modules/data_factory/linked_services/web/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "linked_service_web" {
   name          = var.settings.name
   resource_type = "azurerm_data_factory" #"azurerm_data_factory_linked_service_web"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/databases/app_config/app_config.tf
+++ b/modules/databases/app_config/app_config.tf
@@ -4,6 +4,7 @@ resource "azurecaf_name" "app_config" {
   name          = var.name
   resource_type = "azurerm_app_configuration"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/databases/app_config/settings/app_config_setting.tf
+++ b/modules/databases/app_config/settings/app_config_setting.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "settings" {
   name          = format("app-config-%s", var.config_name)
   resource_type = "azurerm_template_deployment"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/databases/cosmos_dbs/cosmosdb_account.tf
+++ b/modules/databases/cosmos_dbs/cosmosdb_account.tf
@@ -2,6 +2,7 @@
 resource "azurecaf_name" "cdb" {
   name          = var.settings.name
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   resource_type = "azurerm_cosmosdb_account"
   random_length = var.global_settings.random_length
   clean_input   = true

--- a/modules/databases/data_explorer/kusto_attached_database_configurations/module.tf
+++ b/modules/databases/data_explorer/kusto_attached_database_configurations/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "kusto" {
   name          = var.settings.name
   resource_type = "azurerm_kusto_cluster" #azurerm_kusto_attached_database_configuration
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/databases/data_explorer/kusto_cluster_customer_managed_keys/module.tf
+++ b/modules/databases/data_explorer/kusto_cluster_customer_managed_keys/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "kusto" {
   name          = var.settings.name
   resource_type = "azurerm_kusto_cluster" #azurerm_kusto_cluster_customer_managed_key
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/databases/data_explorer/kusto_cluster_principal_assignments/module.tf
+++ b/modules/databases/data_explorer/kusto_cluster_principal_assignments/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "kusto" {
   name          = var.settings.name
   resource_type = "azurerm_kusto_cluster" #azurerm_kusto_cluster_principal_assignment
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/databases/data_explorer/kusto_clusters/module.tf
+++ b/modules/databases/data_explorer/kusto_clusters/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "kusto" {
   name          = var.settings.name
   resource_type = "azurerm_kusto_cluster"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/databases/data_explorer/kusto_database_principal_assignments/module.tf
+++ b/modules/databases/data_explorer/kusto_database_principal_assignments/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "kusto" {
   name          = var.settings.name
   resource_type = "azurerm_kusto_cluster" #azurerm_kusto_database_principal_assignment
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/databases/data_explorer/kusto_databases/module.tf
+++ b/modules/databases/data_explorer/kusto_databases/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "kusto" {
   name          = var.settings.name
   resource_type = "azurerm_kusto_cluster" #azurerm_kusto_database
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/databases/data_explorer/kusto_eventgrid_data_connections/module.tf
+++ b/modules/databases/data_explorer/kusto_eventgrid_data_connections/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "kusto" {
   name          = var.settings.name
   resource_type = "azurerm_kusto_cluster" #azurerm_kusto_eventgrid_data_connection
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/databases/data_explorer/kusto_eventhub_data_connections/module.tf
+++ b/modules/databases/data_explorer/kusto_eventhub_data_connections/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "kusto" {
   name          = var.settings.name
   resource_type = "azurerm_kusto_cluster" #azurerm_kusto_eventhub_data_connection
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/databases/data_explorer/kusto_iothub_data_connections/module.tf
+++ b/modules/databases/data_explorer/kusto_iothub_data_connections/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "kusto" {
   name          = var.settings.name
   resource_type = "azurerm_kusto_cluster" #azurerm_kusto_eventhub_data_connection
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/databases/database_migration_project/dmp.tf
+++ b/modules/databases/database_migration_project/dmp.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "dmp" {
   name          = var.settings.name
   resource_type = "azurerm_database_migration_project"
   prefixes      = var.global_settings.prefix
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/databases/database_migration_service/dms.tf
+++ b/modules/databases/database_migration_service/dms.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "dms" {
   name          = var.settings.name
   resource_type = "azurerm_database_migration_service"
   prefixes      = var.global_settings.prefix
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/databases/mariadb_server/server.tf
+++ b/modules/databases/mariadb_server/server.tf
@@ -74,6 +74,7 @@ resource "azurecaf_name" "mariadb" {
   name          = var.settings.name
   resource_type = "azurerm_mariadb_server"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/databases/mssql_database/database.tf
+++ b/modules/databases/mssql_database/database.tf
@@ -3,6 +3,7 @@ resource "azurecaf_name" "mssqldb" {
   name          = var.settings.name
   resource_type = "azurerm_mssql_database"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/databases/mssql_elastic_pool/elastic_pool.tf
+++ b/modules/databases/mssql_elastic_pool/elastic_pool.tf
@@ -3,6 +3,7 @@ resource "azurecaf_name" "elasticpool" {
   name          = var.settings.name
   resource_type = "azurerm_mssql_database" //elastic pool naming restriction identical to db
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/databases/mssql_managed_database/managed_database.tf
+++ b/modules/databases/mssql_managed_database/managed_database.tf
@@ -3,6 +3,7 @@ resource "azurecaf_name" "manageddb" {
   name          = var.settings.name
   resource_type = "azurerm_mssql_database"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/databases/mssql_managed_instance/failover_group/mi_failover_group.tf
+++ b/modules/databases/mssql_managed_instance/failover_group/mi_failover_group.tf
@@ -3,6 +3,7 @@ resource "azurecaf_name" "mifailover" {
   name          = var.settings.name
   resource_type = "azurerm_mssql_server" //TODO: add support for sql failover group
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/databases/mssql_managed_instance/managed_instance.tf
+++ b/modules/databases/mssql_managed_instance/managed_instance.tf
@@ -3,6 +3,7 @@ resource "azurecaf_name" "mssqlmi" {
   name          = var.settings.name
   resource_type = "azurerm_mssql_server" //TODO: add support for sql mi
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/databases/mssql_server/failover_group/failover_group.tf
+++ b/modules/databases/mssql_server/failover_group/failover_group.tf
@@ -3,6 +3,7 @@ resource "azurecaf_name" "failover_group" {
   name          = var.settings.name
   resource_type = "azurerm_mssql_server" //TODO: add support for sql failover group
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/databases/mssql_server/server.tf
+++ b/modules/databases/mssql_server/server.tf
@@ -52,6 +52,7 @@ resource "azurecaf_name" "mssql" {
   name          = var.settings.name
   resource_type = "azurerm_sql_server"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/databases/mysql_flexible_server/database.tf
+++ b/modules/databases/mysql_flexible_server/database.tf
@@ -10,6 +10,7 @@ resource "azurecaf_name" "mysql_flexible_database" {
   name          = each.value.name
   resource_type = "azurerm_mysql_flexible_server_database"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/databases/mysql_flexible_server/firewall_rule.tf
+++ b/modules/databases/mysql_flexible_server/firewall_rule.tf
@@ -4,6 +4,7 @@ resource "azurecaf_name" "mysql_flexible_firewall_rule" {
   name          = each.value.name
   resource_type = "azurerm_mysql_flexible_server_firewall_rule"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/databases/mysql_flexible_server/server.tf
+++ b/modules/databases/mysql_flexible_server/server.tf
@@ -3,6 +3,7 @@ resource "azurecaf_name" "mysql_flexible_server" {
   name          = var.settings.name
   resource_type = "azurerm_mysql_flexible_server"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/databases/mysql_server/server.tf
+++ b/modules/databases/mysql_server/server.tf
@@ -36,6 +36,7 @@ resource "azurecaf_name" "mysql" {
   name          = var.settings.name
   resource_type = "azurerm_mysql_server"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/databases/postgresql_flexible_server/database.tf
+++ b/modules/databases/postgresql_flexible_server/database.tf
@@ -4,6 +4,7 @@ resource "azurecaf_name" "postgresql_flexible_server_database" {
   name          = each.value.name
   resource_type = "azurerm_postgresql_flexible_server_database"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/databases/postgresql_flexible_server/firewall_rule.tf
+++ b/modules/databases/postgresql_flexible_server/firewall_rule.tf
@@ -4,6 +4,7 @@ resource "azurecaf_name" "postgresql_flexible_server_firewall_rule" {
   name          = each.value.name
   resource_type = "azurerm_postgresql_flexible_server_firewall_rule"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/databases/postgresql_flexible_server/server.tf
+++ b/modules/databases/postgresql_flexible_server/server.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "postgresql_flexible_server" {
   name          = var.settings.name
   resource_type = "azurerm_postgresql_flexible_server"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/databases/postgresql_server/server.tf
+++ b/modules/databases/postgresql_server/server.tf
@@ -37,6 +37,7 @@ resource "azurecaf_name" "postgresql" {
   name          = var.settings.name
   resource_type = "azurerm_postgresql_server"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/event_hubs/consumer_groups/consumer_groups.tf
+++ b/modules/event_hubs/consumer_groups/consumer_groups.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "evhcg_name" {
   name          = var.settings.name
   resource_type = "azurerm_eventhub_consumer_group"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/event_hubs/hubs/auth_rules/auth_rules.tf
+++ b/modules/event_hubs/hubs/auth_rules/auth_rules.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "evh_rule" {
   name          = var.settings.rule_name
   resource_type = "azurerm_eventhub_authorization_rule"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/event_hubs/hubs/event_hub.tf
+++ b/modules/event_hubs/hubs/event_hub.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "evhub" {
   name          = var.settings.name
   resource_type = "azurerm_eventhub"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/event_hubs/namespaces/auth_rules/auth_rules.tf
+++ b/modules/event_hubs/namespaces/auth_rules/auth_rules.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "evh_ns_rule_name" {
   name          = var.settings.rule_name
   resource_type = "azurerm_eventhub_namespace_authorization_rule"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/event_hubs/namespaces/event_hub_namespaces.tf
+++ b/modules/event_hubs/namespaces/event_hub_namespaces.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "evh" {
   name          = var.settings.name
   resource_type = "azurerm_eventhub_namespace"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/identity/active_directory_domain_service/module.tf
+++ b/modules/identity/active_directory_domain_service/module.tf
@@ -3,6 +3,7 @@ resource "azurecaf_name" "aadds" {
   name          = var.settings.name
   resource_type = "azurerm_data_factory"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough
@@ -13,6 +14,7 @@ resource "azurecaf_name" "aadds" {
 #   name          = var.settings.name
 #   resource_type = "azurerm_active_directory_domain_service"
 #   prefixes      = var.global_settings.prefixes
+#   suffixes      = var.global_settings.suffixes
 #   random_length = var.global_settings.random_length
 #   clean_input   = true
 #   passthrough   = var.global_settings.passthrough

--- a/modules/iot/digital_twins/digital_twins_endpoint_eventgrid/module.tf
+++ b/modules/iot/digital_twins/digital_twins_endpoint_eventgrid/module.tf
@@ -3,6 +3,7 @@ resource "azurecaf_name" "adteg" {
   name          = var.name
   resource_type = "azurerm_digital_twins_endpoint_eventgrid"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/iot/digital_twins/digital_twins_endpoint_eventhub/module.tf
+++ b/modules/iot/digital_twins/digital_twins_endpoint_eventhub/module.tf
@@ -3,6 +3,7 @@ resource "azurecaf_name" "adteh" {
   name          = var.name
   resource_type = "azurerm_digital_twins_endpoint_eventhub"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/iot/digital_twins/digital_twins_endpoint_servicebus/module.tf
+++ b/modules/iot/digital_twins/digital_twins_endpoint_servicebus/module.tf
@@ -3,6 +3,7 @@ resource "azurecaf_name" "adtsb" {
   name          = var.name
   resource_type = "azurerm_digital_twins_endpoint_servicebus"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/iot/digital_twins/digital_twins_instance/module.tf
+++ b/modules/iot/digital_twins/digital_twins_instance/module.tf
@@ -4,6 +4,7 @@ resource "azurecaf_name" "adt" {
   name          = var.name
   resource_type = "azurerm_digital_twins_instance"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/log_analytics/workspace.tf
+++ b/modules/log_analytics/workspace.tf
@@ -3,6 +3,7 @@ resource "azurecaf_name" "law" {
   name          = var.log_analytics.name
   resource_type = "azurerm_log_analytics_workspace"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/logic_app/action_custom/module.tf
+++ b/modules/logic_app/action_custom/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "laac" {
   name          = var.settings.name
   resource_type = "azurerm_logic_app_action_custom"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/logic_app/action_http/module.tf
+++ b/modules/logic_app/action_http/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "laah" {
   name          = var.settings.name
   resource_type = "azurerm_logic_app_action_http"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/logic_app/integration_account/module.tf
+++ b/modules/logic_app/integration_account/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "ia" {
   name          = var.settings.name
   resource_type = "azurerm_logic_app_integration_account"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/logic_app/integration_service_environment/module.tf
+++ b/modules/logic_app/integration_service_environment/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "ise" {
   name          = var.settings.name
   resource_type = "azurerm_integration_service_environment"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/logic_app/standard/module.tf
+++ b/modules/logic_app/standard/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "logic_app_standard_name" {
   name          = var.settings.name
   resource_type = "azurerm_logic_app_workflow"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/logic_app/trigger_custom/module.tf
+++ b/modules/logic_app/trigger_custom/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "latc" {
   name          = var.settings.name
   resource_type = "azurerm_logic_app_trigger_custom"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/logic_app/trigger_http_request/module.tf
+++ b/modules/logic_app/trigger_http_request/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "laachr" {
   name          = var.settings.name
   resource_type = "azurerm_logic_app_trigger_http_request"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/logic_app/trigger_recurrence/module.tf
+++ b/modules/logic_app/trigger_recurrence/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "latr" {
   name          = var.settings.name
   resource_type = "azurerm_logic_app_trigger_recurrence"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/logic_app/workflow/module.tf
+++ b/modules/logic_app/workflow/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "la" {
   name          = var.settings.name
   resource_type = "azurerm_logic_app_workflow"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/messaging/eventgrid/eventgrid_domain/module.tf
+++ b/modules/messaging/eventgrid/eventgrid_domain/module.tf
@@ -3,6 +3,7 @@ resource "azurecaf_name" "egd" {
   name          = var.settings.name
   resource_type = "azurerm_eventgrid_domain"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/messaging/eventgrid/eventgrid_domain_topic/module.tf
+++ b/modules/messaging/eventgrid/eventgrid_domain_topic/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "egdt" {
   name          = var.settings.name
   resource_type = "azurerm_eventgrid_domain_topic"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/messaging/eventgrid/eventgrid_event_subscription/module.tf
+++ b/modules/messaging/eventgrid/eventgrid_event_subscription/module.tf
@@ -3,6 +3,7 @@ resource "azurecaf_name" "eges" {
   name          = var.settings.name
   resource_type = "azurerm_eventgrid_event_subscription"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/messaging/eventgrid/eventgrid_topic/module.tf
+++ b/modules/messaging/eventgrid/eventgrid_topic/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "egt" {
   name          = var.settings.name
   resource_type = "azurerm_eventgrid_topic"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/messaging/servicebus/namespace/namespace.tf
+++ b/modules/messaging/servicebus/namespace/namespace.tf
@@ -4,6 +4,7 @@ resource "azurecaf_name" "namespace" {
   name          = var.settings.name
   resource_type = "azurerm_servicebus_namespace"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/messaging/servicebus/namespace/namespace_auth_rule/namespace_auth_rule.tf
+++ b/modules/messaging/servicebus/namespace/namespace_auth_rule/namespace_auth_rule.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "namespace_auth_rule" {
   name          = var.settings.name
   resource_type = "azurerm_servicebus_namespace_authorization_rule"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/messaging/servicebus/queue/queue.tf
+++ b/modules/messaging/servicebus/queue/queue.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "queue" {
   name          = var.settings.name
   resource_type = "azurerm_servicebus_queue"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/messaging/servicebus/queue/queue_auth_rule/queue_auth_rule.tf
+++ b/modules/messaging/servicebus/queue/queue_auth_rule/queue_auth_rule.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "queue_auth_rule" {
   name          = var.settings.name
   resource_type = "azurerm_servicebus_queue_authorization_rule"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/messaging/servicebus/topic/subscription/subscription.tf
+++ b/modules/messaging/servicebus/topic/subscription/subscription.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "servicebus_subscription" {
   name          = var.settings.name
   resource_type = "azurerm_servicebus_subscription"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/messaging/servicebus/topic/subscription/subscription_rule/correlation_filter/correlation_filter.tf
+++ b/modules/messaging/servicebus/topic/subscription/subscription_rule/correlation_filter/correlation_filter.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "subscription_rule" {
   name          = var.settings.name
   resource_type = "azurerm_servicebus_subscription_rule"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/messaging/servicebus/topic/subscription/subscription_rule/sql_filter/sql_filter.tf
+++ b/modules/messaging/servicebus/topic/subscription/subscription_rule/sql_filter/sql_filter.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "subscription_rule" {
   name          = var.settings.name
   resource_type = "azurerm_servicebus_subscription_rule"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/messaging/servicebus/topic/topic.tf
+++ b/modules/messaging/servicebus/topic/topic.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "topic" {
   name          = var.settings.name
   resource_type = "azurerm_servicebus_topic"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/messaging/servicebus/topic/topic_auth_rule/topic_auth_rule.tf
+++ b/modules/messaging/servicebus/topic/topic_auth_rule/topic_auth_rule.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "topic_auth_rule" {
   name          = var.settings.name
   resource_type = "azurerm_servicebus_topic_authorization_rule"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/messaging/signalr_service/signalr_service.tf
+++ b/modules/messaging/signalr_service/signalr_service.tf
@@ -3,6 +3,7 @@ resource "azurecaf_name" "signalr_service" {
   name          = var.settings.name
   resource_type = "azurerm_signalr_service"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/messaging/web_pubsub/hub/web_pubsub_hub.tf
+++ b/modules/messaging/web_pubsub/hub/web_pubsub_hub.tf
@@ -3,6 +3,7 @@ data "azurecaf_name" "hub" {
   name          = var.settings.name
   resource_type = "azurerm_web_pubsub_hub"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/messaging/web_pubsub/web_pubsub.tf
+++ b/modules/messaging/web_pubsub/web_pubsub.tf
@@ -3,6 +3,7 @@ data "azurecaf_name" "wps" {
   name          = var.settings.name
   resource_type = "azurerm_web_pubsub"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/monitoring/log_analytics_storage_insights/module.tf
+++ b/modules/monitoring/log_analytics_storage_insights/module.tf
@@ -3,6 +3,7 @@ resource "azurecaf_name" "lasi" {
   name          = var.settings.name
   resource_type = "azurerm_log_analytics_storage_insights"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/monitoring/monitor_action_group/monitor_action_group.tf
+++ b/modules/monitoring/monitor_action_group/monitor_action_group.tf
@@ -1,6 +1,7 @@
 resource "azurecaf_name" "this_name" {
   name          = var.settings.action_group_name
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   resource_type = "azurerm_monitor_action_group"
   random_length = var.global_settings.random_length
   clean_input   = true

--- a/modules/monitoring/monitor_activity_log_alert/module.tf
+++ b/modules/monitoring/monitor_activity_log_alert/module.tf
@@ -3,6 +3,7 @@ resource "azurecaf_name" "mala" {
   name          = var.settings.name
   resource_type = "azurerm_data_factory" #"azurerm_monitor_activity_log_alert"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/monitoring/monitor_autoscale_settings/monitor_autoscale_settings.tf
+++ b/modules/monitoring/monitor_autoscale_settings/monitor_autoscale_settings.tf
@@ -1,6 +1,7 @@
 resource "azurecaf_name" "this_name" {
   name          = var.settings.name
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   resource_type = "azurerm_monitor_autoscale_setting"
   random_length = var.global_settings.random_length
   clean_input   = true

--- a/modules/monitoring/monitor_metric_alert/module.tf
+++ b/modules/monitoring/monitor_metric_alert/module.tf
@@ -3,6 +3,7 @@ resource "azurecaf_name" "mma" {
   name          = var.settings.name
   resource_type = "azurerm_data_factory" #"azurerm_monitor_metric_alert"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/monitoring/service_health_alerts/service_health_alert.tf
+++ b/modules/monitoring/service_health_alerts/service_health_alert.tf
@@ -1,6 +1,7 @@
 resource "azurecaf_name" "ag1_name" {
   name          = var.settings.action_group_name
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   resource_type = "azurerm_monitor_action_group"
   random_length = var.global_settings.random_length
   clean_input   = true
@@ -11,6 +12,7 @@ resource "azurecaf_name" "ag1_name" {
 resource "azurecaf_name" "service_health_alert_name" {
   name          = var.settings.name
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   resource_type = "azurerm_application_insights"
   random_length = var.global_settings.random_length
   clean_input   = true

--- a/modules/netapp/account.tf
+++ b/modules/netapp/account.tf
@@ -1,6 +1,7 @@
 resource "azurecaf_name" "account" {
   name          = var.settings.name
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   resource_type = "azurerm_netapp_account"
   random_length = var.global_settings.random_length
   clean_input   = true

--- a/modules/netapp/pool/pool.tf
+++ b/modules/netapp/pool/pool.tf
@@ -1,6 +1,7 @@
 resource "azurecaf_name" "pool" {
   name          = var.settings.name
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   resource_type = "azurerm_netapp_pool"
   random_length = var.global_settings.random_length
   clean_input   = true

--- a/modules/netapp/volume/volume.tf
+++ b/modules/netapp/volume/volume.tf
@@ -1,6 +1,7 @@
 resource "azurecaf_name" "volume" {
   name          = var.settings.name
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   resource_type = "azurerm_netapp_volume"
   random_length = var.global_settings.random_length
   clean_input   = true

--- a/modules/networking/application_gateway/application_gateway.tf
+++ b/modules/networking/application_gateway/application_gateway.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "agw" {
   name          = var.settings.name
   resource_type = "azurerm_application_gateway"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/application_gateway_platform/application_gateway.tf
+++ b/modules/networking/application_gateway_platform/application_gateway.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "agw" {
   name          = var.settings.name
   resource_type = "azurerm_application_gateway"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/application_security_group/module.tf
+++ b/modules/networking/application_security_group/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "asg" {
   name          = var.settings.name
   resource_type = "azurerm_application_security_group"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/cdn_endpoint/module.tf
+++ b/modules/networking/cdn_endpoint/module.tf
@@ -3,6 +3,7 @@ resource "azurecaf_name" "cdn" {
   name          = var.settings.name
   resource_type = "azurerm_cdn_endpoint"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/cdn_profile/module.tf
+++ b/modules/networking/cdn_profile/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "cdn" {
   name          = var.settings.name
   resource_type = "azurerm_cdn_profile"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/express_route_circuit/express_route.tf
+++ b/modules/networking/express_route_circuit/express_route.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "circuit" {
   name          = var.settings.name
   resource_type = "azurerm_express_route_circuit"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/firewall/module.tf
+++ b/modules/networking/firewall/module.tf
@@ -4,6 +4,7 @@ resource "azurecaf_name" "fw" {
   name          = var.name
   resource_type = "azurerm_firewall"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/firewall_application_rule_collections/application_rule_collection.tf
+++ b/modules/networking/firewall_application_rule_collections/application_rule_collection.tf
@@ -4,6 +4,7 @@ resource "azurecaf_name" "rule" {
   name          = var.azurerm_firewall_application_rule_collection_definition[each.key].name
   resource_type = "azurerm_firewall_application_rule_collection"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/firewall_nat_rule_collections/nat_rule_collection.tf
+++ b/modules/networking/firewall_nat_rule_collections/nat_rule_collection.tf
@@ -7,6 +7,7 @@ resource "azurecaf_name" "natcollection" {
   name          = var.azurerm_firewall_nat_rule_collection_definition[each.key].name
   resource_type = "azurerm_firewall_nat_rule_collection"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/firewall_network_rule_collections/network_rule_collection.tf
+++ b/modules/networking/firewall_network_rule_collections/network_rule_collection.tf
@@ -4,6 +4,7 @@ resource "azurecaf_name" "rule" {
   name          = var.azurerm_firewall_network_rule_collection_definition[each.key].name
   resource_type = "azurerm_firewall_network_rule_collection"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/firewall_policies/firewall_policy.tf
+++ b/modules/networking/firewall_policies/firewall_policy.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "fwpol" {
   name          = var.settings.name
   resource_type = "azurerm_firewall_network_rule_collection"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/firewall_policy_rule_collection_groups/firewall_policy_rule_collection_groups.tf
+++ b/modules/networking/firewall_policy_rule_collection_groups/firewall_policy_rule_collection_groups.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "polgroup" {
   name          = var.policy_settings.name
   resource_type = "azurerm_firewall_network_rule_collection"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough
@@ -17,6 +18,7 @@ resource "azurecaf_name" "application_rule" {
   name          = each.value.name
   resource_type = "azurerm_firewall_application_rule_collection"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough
@@ -32,6 +34,7 @@ resource "azurecaf_name" "network_rule" {
   name          = each.value.name
   resource_type = "azurerm_firewall_network_rule_collection"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough
@@ -47,6 +50,7 @@ resource "azurecaf_name" "nat_rule" {
   name          = each.value.name
   resource_type = "azurerm_firewall_nat_rule_collection"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/front_door/front_door.tf
+++ b/modules/networking/front_door/front_door.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "frontdoor" {
   name          = var.settings.name
   resource_type = "azurerm_frontdoor"
   prefixes      = try(var.settings.global_settings.prefixes, var.global_settings.prefixes)
+  suffixes      = try(var.settings.global_settings.suffixes, var.global_settings.suffixes)
   random_length = try(var.settings.global_settings.random_length, var.global_settings.random_length)
   clean_input   = true
   passthrough   = try(var.settings.global_settings.passthrough, var.global_settings.passthrough)

--- a/modules/networking/frontdoor_rules_engine/module.tf
+++ b/modules/networking/frontdoor_rules_engine/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "fdre" {
   name          = var.settings.name
   resource_type = "azurerm_frontdoor" #"azurerm_frontdoor_rules_engine"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/ip_group/module.tf
+++ b/modules/networking/ip_group/module.tf
@@ -4,6 +4,7 @@ resource "azurecaf_name" "ip_group" {
   name          = var.name
   resource_type = "azurerm_ip_group"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/lb/module.tf
+++ b/modules/networking/lb/module.tf
@@ -4,6 +4,7 @@ resource "azurecaf_name" "lb" {
   name          = var.settings.name
   resource_type = "azurerm_lb"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/lb_backend_address_pool/module.tf
+++ b/modules/networking/lb_backend_address_pool/module.tf
@@ -4,6 +4,7 @@ resource "azurecaf_name" "lb" {
   name          = var.settings.name
   resource_type = "azurerm_data_factory" #"azurerm_lb_backend_address_pool"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/lb_backend_address_pool_address/module.tf
+++ b/modules/networking/lb_backend_address_pool_address/module.tf
@@ -4,6 +4,7 @@ resource "azurecaf_name" "lb" {
   name          = var.settings.name
   resource_type = "azurerm_data_factory" #"azurerm_lb_backend_address_pool_address"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/lb_nat_pool/module.tf
+++ b/modules/networking/lb_nat_pool/module.tf
@@ -4,6 +4,7 @@ resource "azurecaf_name" "lb" {
   name          = var.settings.name
   resource_type = "azurerm_data_factory" #"azurerm_lb_nat_pool"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/lb_nat_rule/module.tf
+++ b/modules/networking/lb_nat_rule/module.tf
@@ -4,6 +4,7 @@ resource "azurecaf_name" "lb" {
   name          = var.settings.name
   resource_type = "azurerm_lb_nat_rule"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/lb_outbound_rule/module.tf
+++ b/modules/networking/lb_outbound_rule/module.tf
@@ -4,6 +4,7 @@ resource "azurecaf_name" "lb" {
   name          = var.settings.name
   resource_type = "azurerm_data_factory" #"azurerm_lb_outbound_rule"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/lb_probe/module.tf
+++ b/modules/networking/lb_probe/module.tf
@@ -4,6 +4,7 @@ resource "azurecaf_name" "lb" {
   name          = var.settings.name
   resource_type = "azurerm_data_factory" #"azurerm_lb_probe"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/lb_rule/module.tf
+++ b/modules/networking/lb_rule/module.tf
@@ -4,6 +4,7 @@ resource "azurecaf_name" "lb" {
   name          = var.settings.name
   resource_type = "azurerm_data_factory" #"azurerm_lb_rule"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/load_balancers/load_balancers.tf
+++ b/modules/networking/load_balancers/load_balancers.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "lb_name" {
   name          = var.settings.name
   resource_type = "azurerm_lb"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/local_network_gateways/module.tf
+++ b/modules/networking/local_network_gateways/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "lngw" {
   name          = var.settings.name
   resource_type = "azurerm_local_network_gateway"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/nat_gateways/module.tf
+++ b/modules/networking/nat_gateways/module.tf
@@ -3,6 +3,7 @@
 #   name          = var.name
 #   resource_type = "azurerm_nat_gateway"
 #   prefixes      = var.global_settings.prefixes
+#   suffixes      = var.global_settings.suffixes
 #   random_length = var.global_settings.random_length
 #   clean_input   = true
 #   passthrough   = var.global_settings.passthrough

--- a/modules/networking/network_security_group/module.tf
+++ b/modules/networking/network_security_group/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "nsg" {
   name          = var.settings.name
   resource_type = "azurerm_network_security_group"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/network_watcher/module.tf
+++ b/modules/networking/network_watcher/module.tf
@@ -3,6 +3,7 @@ resource "azurecaf_name" "netwatcher" {
   name          = var.settings.name
   resource_type = "azurerm_network_watcher"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/private-dns/virtual_network_link.tf
+++ b/modules/networking/private-dns/virtual_network_link.tf
@@ -5,6 +5,7 @@ resource "azurecaf_name" "pnetlk" {
   name          = each.value.name
   resource_type = "azurerm_private_dns_zone_virtual_network_link"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/private_dns_vnet_link/module.tf
+++ b/modules/networking/private_dns_vnet_link/module.tf
@@ -4,6 +4,7 @@ resource "azurecaf_name" "pnetlk" {
   name          = each.value.name
   resource_type = "azurerm_private_dns_zone_virtual_network_link"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/private_dns_vnet_link_v1/module.tf
+++ b/modules/networking/private_dns_vnet_link_v1/module.tf
@@ -4,6 +4,7 @@ resource "azurecaf_name" "pnetlk" {
   name          = each.value.name
   resource_type = "azurerm_private_dns_zone_virtual_network_link"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/private_endpoint/private_endpoint.tf
+++ b/modules/networking/private_endpoint/private_endpoint.tf
@@ -3,6 +3,7 @@ resource "azurecaf_name" "pep" {
   name          = var.name
   resource_type = "azurerm_private_endpoint"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/private_links/endpoints/private_endpoint/private_endpoint.tf
+++ b/modules/networking/private_links/endpoints/private_endpoint/private_endpoint.tf
@@ -3,6 +3,7 @@ resource "azurecaf_name" "pep" {
   name          = var.name
   resource_type = "azurerm_private_endpoint"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/relay_hybrid_connection/module.tf
+++ b/modules/networking/relay_hybrid_connection/module.tf
@@ -3,6 +3,7 @@ resource "azurecaf_name" "rhc" {
   name          = var.settings.name
   resource_type = "azurerm_relay_hybrid_connection"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/relay_namespace/module.tf
+++ b/modules/networking/relay_namespace/module.tf
@@ -3,6 +3,7 @@ resource "azurecaf_name" "rns" {
   name          = var.settings.name
   resource_type = "azurerm_relay_namespace"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/virtual_network/module.tf
+++ b/modules/networking/virtual_network/module.tf
@@ -4,6 +4,7 @@ resource "azurecaf_name" "caf_name_vnet" {
   name          = var.settings.vnet.name
   resource_type = "azurerm_virtual_network"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/virtual_network/nsg/module.tf
+++ b/modules/networking/virtual_network/nsg/module.tf
@@ -6,6 +6,7 @@ resource "azurecaf_name" "nsg_obj" {
   name          = try(var.network_security_group_definition[each.value.nsg_key].name, null) == null ? each.value.name : var.network_security_group_definition[each.value.nsg_key].name
   resource_type = "azurerm_network_security_group"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/virtual_network/subnet/subnet.tf
+++ b/modules/networking/virtual_network/subnet/subnet.tf
@@ -3,6 +3,7 @@ resource "azurecaf_name" "subnet" {
   name          = var.name
   resource_type = "azurerm_subnet"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = (var.name == "AzureBastionSubnet") || (var.name == "AzureFirewallSubnet") || (var.name == "GatewaySubnet") || (var.name == "RouteServerSubnet") || (var.name == "AzureFirewallManagementSubnet") ? true : var.global_settings.passthrough

--- a/modules/networking/virtual_network_gateway_connections/module.tf
+++ b/modules/networking/virtual_network_gateway_connections/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "vngw_connection" {
   name          = var.settings.name
   resource_type = "azurerm_virtual_network_gateway"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/virtual_network_gateways/module.tf
+++ b/modules/networking/virtual_network_gateways/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "vgw" {
   name          = var.settings.name
   resource_type = "azurerm_virtual_network_gateway"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/virtual_wan/virtual_hub/azure_firewall.tf
+++ b/modules/networking/virtual_wan/virtual_hub/azure_firewall.tf
@@ -5,6 +5,7 @@ resource "azurecaf_name" "virtualhub_fw" {
   name          = try(var.virtual_hub_config.firewall_name, null)
   resource_type = "azurerm_firewall"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/virtual_wan/virtual_hub/express_route_gateway.tf
+++ b/modules/networking/virtual_wan/virtual_hub/express_route_gateway.tf
@@ -5,6 +5,7 @@ resource "azurecaf_name" "er_gateway" {
   name          = try(var.virtual_hub_config.er_config.name, null)
   resource_type = "azurerm_express_route_gateway"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/virtual_wan/virtual_hub/point_to_site_gateway.tf
+++ b/modules/networking/virtual_wan/virtual_hub/point_to_site_gateway.tf
@@ -5,6 +5,7 @@ resource "azurecaf_name" "p2s_gateway" {
   name          = try(var.virtual_hub_config.p2s_config.name, null)
   resource_type = "azurerm_point_to_site_vpn_gateway"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/virtual_wan/virtual_hub/site_to_site_gateway.tf
+++ b/modules/networking/virtual_wan/virtual_hub/site_to_site_gateway.tf
@@ -5,6 +5,7 @@ resource "azurecaf_name" "s2s_gateway" {
   name          = try(var.virtual_hub_config.s2s_config.name, null)
   resource_type = "azurerm_virtual_network_gateway"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/virtual_wan/virtual_hub/virtual_hub.tf
+++ b/modules/networking/virtual_wan/virtual_hub/virtual_hub.tf
@@ -3,6 +3,7 @@ resource "azurecaf_name" "vwan_hub" {
   name          = var.virtual_hub_config.hub_name
   resource_type = "azurerm_virtual_hub"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough
@@ -40,6 +41,7 @@ resource "azurecaf_name" "spp" {
   name          = each.value.name
   resource_type = "azurerm_virtual_hub"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough
@@ -65,6 +67,7 @@ resource "azurerm_virtual_hub_security_partner_provider" "spp" {
 #   name          = each.value.name
 #   resource_type = "azurerm_virtual_hub"
 #   prefixes      = var.global_settings.prefixes
+#   suffixes      = var.global_settings.suffixes
 #   random_length = var.global_settings.random_length
 #   clean_input   = true
 #   passthrough   = var.global_settings.passthrough
@@ -87,6 +90,7 @@ resource "azurecaf_name" "hub_ip" {
   name          = each.value.name
   resource_type = "azurerm_virtual_hub"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough
@@ -110,6 +114,7 @@ resource "azurecaf_name" "bgp_con" {
   name          = each.value.name
   resource_type = "azurerm_virtual_hub"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/virtual_wan/virtual_wan.tf
+++ b/modules/networking/virtual_wan/virtual_wan.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "vwan" {
   name          = var.settings.name
   resource_type = "azurerm_virtual_wan"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/vpn_gateway_connection/module.tf
+++ b/modules/networking/vpn_gateway_connection/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "vpn_gateway_connection" {
   name          = var.settings.name
   resource_type = "azurerm_vpn_gateway_connection"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/networking/vpn_site/module.tf
+++ b/modules/networking/vpn_site/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "vpn_site" {
   name          = var.settings.name
   resource_type = "azurerm_vpn_site"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/purview/purview_accounts/module.tf
+++ b/modules/purview/purview_accounts/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "pva" {
   name          = var.settings.name
   resource_type = "azurerm_purview_account"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/recovery_vault/recovery_vault.tf
+++ b/modules/recovery_vault/recovery_vault.tf
@@ -5,6 +5,7 @@ resource "azurecaf_name" "asr_rg_vault" {
   name          = var.settings.name
   resource_type = "azurerm_recovery_services_vault"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/redis_cache/module.tf
+++ b/modules/redis_cache/module.tf
@@ -4,6 +4,7 @@ resource "azurecaf_name" "redis" {
   name          = var.redis.name
   resource_type = "azurerm_redis_cache"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/resource_group/module.tf
+++ b/modules/resource_group/module.tf
@@ -4,6 +4,7 @@ resource "azurecaf_name" "rg" {
   name          = var.resource_group_name
   resource_type = "azurerm_resource_group"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/roles/custom_roles/module.tf
+++ b/modules/roles/custom_roles/module.tf
@@ -4,6 +4,7 @@ resource "azurecaf_name" "custom_role" {
   resource_type = "azurerm_resource_group"
   #TODO: need to be changed to appropriate resource (no caf reference for now)
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/security/keyvault/keyvault.tf
+++ b/modules/security/keyvault/keyvault.tf
@@ -8,6 +8,7 @@ resource "azurecaf_name" "keyvault" {
   name          = var.settings.name
   resource_type = "azurerm_key_vault"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/security/managed_identity/managed_identity.tf
+++ b/modules/security/managed_identity/managed_identity.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "msi" {
   name          = var.name
   resource_type = "azurerm_user_assigned_identity"
   prefixes      = try(var.settings.naming_convention.prefixes, var.global_settings.prefixes)
+  suffixes      = try(var.settings.naming_convention.suffixes, var.global_settings.suffixes)
   random_length = try(var.settings.naming_convention.random_length, var.global_settings.random_length)
   clean_input   = true
   passthrough   = try(var.settings.naming_convention.passthrough, var.global_settings.passthrough)

--- a/modules/shared_image_gallery/image_definitions/Image_definitions.tf
+++ b/modules/shared_image_gallery/image_definitions/Image_definitions.tf
@@ -2,6 +2,7 @@
 resource "azurecaf_name" "image_name" {
   name          = var.settings.name
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   resource_type = "azurerm_shared_image"
   random_length = var.global_settings.random_length
   clean_input   = true

--- a/modules/shared_image_gallery/image_galleries/shared_image_gallery.tf
+++ b/modules/shared_image_gallery/image_galleries/shared_image_gallery.tf
@@ -1,6 +1,7 @@
 resource "azurecaf_name" "sig_name" {
   name          = var.settings.name
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   resource_type = "azurerm_shared_image_gallery"
   random_length = var.global_settings.random_length
   clean_input   = true

--- a/modules/storage_account/storage_account.tf
+++ b/modules/storage_account/storage_account.tf
@@ -8,6 +8,7 @@ resource "azurecaf_name" "stg" {
   name          = var.storage_account.name
   resource_type = "azurerm_storage_account"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/webapps/appservice/module.tf
+++ b/modules/webapps/appservice/module.tf
@@ -3,6 +3,7 @@ resource "azurecaf_name" "app_service" {
   name          = var.name
   resource_type = "azurerm_app_service"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/webapps/ase/module.tf
+++ b/modules/webapps/ase/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "ase" {
   name          = var.name
   resource_type = "azurerm_app_service_environment"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/webapps/asev3/module.tf
+++ b/modules/webapps/asev3/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "asev3" {
   name          = var.settings.name
   resource_type = "azurerm_app_service_environment"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/webapps/asp/module.tf
+++ b/modules/webapps/asp/module.tf
@@ -3,6 +3,7 @@ resource "azurecaf_name" "plan" {
   name          = var.settings.name
   resource_type = "azurerm_app_service_plan"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/webapps/function_app/module.tf
+++ b/modules/webapps/function_app/module.tf
@@ -3,6 +3,7 @@ resource "azurecaf_name" "plan" {
   name          = var.name
   resource_type = "azurerm_function_app"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/modules/webapps/static_site/module.tf
+++ b/modules/webapps/static_site/module.tf
@@ -2,6 +2,7 @@ resource "azurecaf_name" "static_site" {
   name          = var.name
   resource_type = "azurerm_static_site"
   prefixes      = var.global_settings.prefixes
+  suffixes      = var.global_settings.suffixes
   random_length = var.global_settings.random_length
   clean_input   = true
   passthrough   = var.global_settings.passthrough

--- a/networking.tf
+++ b/networking.tf
@@ -114,6 +114,7 @@ resource "azurecaf_name" "public_ip_addresses" {
   name          = try(each.value.name, null)
   resource_type = "azurerm_public_ip"
   prefixes      = local.global_settings.prefixes
+  suffixes      = local.global_settings.suffixes
   random_length = local.global_settings.random_length
   clean_input   = true
   passthrough   = local.global_settings.passthrough
@@ -163,6 +164,7 @@ resource "azurecaf_name" "public_ip_prefixes" {
   name          = try(each.value.name, null)
   resource_type = "azurerm_public_ip_prefix"
   prefixes      = local.global_settings.prefixes
+  suffixes      = local.global_settings.suffixes
   random_length = local.global_settings.random_length
   clean_input   = true
   passthrough   = local.global_settings.passthrough
@@ -200,6 +202,7 @@ resource "azurecaf_name" "peering" {
   name          = try(each.value.name, "")
   resource_type = "azurerm_virtual_network_peering"
   prefixes      = local.global_settings.prefixes
+  suffixes      = local.global_settings.suffixes
   random_length = local.global_settings.random_length
   clean_input   = true
   passthrough   = local.global_settings.passthrough
@@ -259,6 +262,7 @@ resource "azurecaf_name" "route_tables" {
   name          = try(each.value.name, null)
   resource_type = "azurerm_route_table"
   prefixes      = local.global_settings.prefixes
+  suffixes      = local.global_settings.suffixes
   random_length = local.global_settings.random_length
   clean_input   = true
   passthrough   = local.global_settings.passthrough
@@ -283,6 +287,7 @@ resource "azurecaf_name" "routes" {
   name          = try(each.value.name, null)
   resource_type = "azurerm_route"
   prefixes      = local.global_settings.prefixes
+  suffixes      = local.global_settings.suffixes
   random_length = local.global_settings.random_length
   clean_input   = true
   passthrough   = local.global_settings.passthrough
@@ -320,6 +325,7 @@ resource "azurecaf_name" "ddos_protection_plan" {
   name          = try(each.value.name, null)
   resource_type = "azurerm_network_ddos_protection_plan"
   prefixes      = local.global_settings.prefixes
+  suffixes      = local.global_settings.suffixes
   random_length = local.global_settings.random_length
   clean_input   = true
   passthrough   = local.global_settings.passthrough


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/1287)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [X] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [X] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Various requests (included below) have asked for the introduction of the suffixes property to allow the passing of the suffixes array to the underlying azurecaf_name resource. This PR has been created on the latest main commit.

#1294 
#867
#1287 
#274

## Does this introduce a breaking change

- [ ] YES
- [ ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
