### PR TITLE
Adding password to existing azuread app

### DIFF
--- a/azuread_credentials.tf
+++ b/azuread_credentials.tf
@@ -12,8 +12,8 @@ module "azuread_credentials" {
 
   resources = {
     application = {
-      id             = try(local.combined_objects_azuread_applications[try(each.value.azuread_application.lz_key, local.client_config.landingzone_key)][each.value.azuread_application.key].id, {})
-      application_id = try(local.combined_objects_azuread_applications[try(each.value.azuread_application.lz_key, local.client_config.landingzone_key)][each.value.azuread_application.key].application_id, {})
+      id             = can ( each.value.azuread_application.object_id ) ? each.value.azuread_application.object_id : local.combined_objects_azuread_applications[try(each.value.azuread_application.lz_key, local.client_config.landingzone_key)][each.value.azuread_application.key].object_id
+      application_id = can ( each.value.azuread_application.application_id ) ? each.value.azuread_application.application_id : local.combined_objects_azuread_applications[try(each.value.azuread_application.lz_key, local.client_config.landingzone_key)][each.value.azuread_application.key].application_id
     }
   }
 }


### PR DESCRIPTION
Add Password annotation to existing azure ad application.

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [X ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [X ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [X ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [ X ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
```hcl
azuread_credentials = {
  level0 = {
    type                          = "password"
    azuread_credential_policy_key = "default_policy"

    azuread_application = {
      object_id = ""
      application_id = ""
    }
    keyvaults = {
      test_client = {
        secret_prefix = "sp"
        # tenant_id     = ""
      }
    }
  }
}
```