### PR TITLE
Added support for version less certificate id (rotation) in App Gateway listener certificate.

### DIFF
--- a/azuread_credentials.tf
+++ b/azuread_credentials.tf
@@ -12,8 +12,8 @@ module "azuread_credentials" {
 
   resources = {
     application = {
-      id             = can ( each.value.azuread_application.object_id ) ? each.value.azuread_application.object_id : local.combined_objects_azuread_applications[try(each.value.azuread_application.lz_key, local.client_config.landingzone_key)][each.value.azuread_application.key].object_id
-      application_id = can ( each.value.azuread_application.application_id ) ? each.value.azuread_application.application_id : local.combined_objects_azuread_applications[try(each.value.azuread_application.lz_key, local.client_config.landingzone_key)][each.value.azuread_application.key].application_id
+      id             = can(each.value.azuread_application.object_id) ? each.value.azuread_application.object_id : local.combined_objects_azuread_applications[try(each.value.azuread_application.lz_key, local.client_config.landingzone_key)][each.value.azuread_application.key].object_id
+      application_id = can(each.value.azuread_application.application_id) ? each.value.azuread_application.application_id : local.combined_objects_azuread_applications[try(each.value.azuread_application.lz_key, local.client_config.landingzone_key)][each.value.azuread_application.key].application_id
     }
   }
 }

--- a/examples/aadb2c/100-simple-aadb2c-directory/configuration.tfvars
+++ b/examples/aadb2c/100-simple-aadb2c-directory/configuration.tfvars
@@ -23,7 +23,7 @@ aadb2c_directory = {
     data_residency_location = "United States"
     display_name            = "example-b2c-tenant"
     # Domain requires .onmicrosoft.com suffix
-    domain_name             = "100simpleaadb2cdirectory.onmicrosoft.com"
-    sku_name                = "PremiumP1"
+    domain_name = "100simpleaadb2cdirectory.onmicrosoft.com"
+    sku_name    = "PremiumP1"
   }
 }

--- a/examples/compute/kubernetes_services/104-private-cluster/aks.tfvars
+++ b/examples/compute/kubernetes_services/104-private-cluster/aks.tfvars
@@ -39,10 +39,10 @@ aks_clusters = {
 
     private_endpoints = {
       pe1 = {
-        name               = "aks-pe"
+        name = "aks-pe"
         #lz_key             = "" # for vnets created in different lz
-        vnet_key           = "spoke_devops_re1"
-        subnet_key         = "private_endpoints"
+        vnet_key   = "spoke_devops_re1"
+        subnet_key = "private_endpoints"
         private_service_connection = {
           name                 = "aks-psc"
           is_manual_connection = false

--- a/examples/data_sources/100-reference-data-source/configuration.tfvars
+++ b/examples/data_sources/100-reference-data-source/configuration.tfvars
@@ -12,7 +12,7 @@ global_settings = {
 ###############################################################################
 data_sources = {
   subscriptions = {
-    my_subscription = {  # data source key
+    my_subscription = { # data source key
       subscription_id = "11111111-1111-1111-1111-111111111111"
     }
   }

--- a/modules/networking/application_gateway_application/ssl_cert.tf
+++ b/modules/networking/application_gateway_application/ssl_cert.tf
@@ -30,7 +30,7 @@ resource "null_resource" "set_ssl_cert" {
       NAME                     = each.value.name
       CERT_FILE                = try(each.value.cert_file, null)
       CERT_PASSWORD            = try(each.value.cert_password, null)
-      KEY_VAULT_SECRET_ID      = try(data.azurerm_key_vault_certificate.manual_certs[each.key].versionless_secret_id, var.keyvault_certificates[try(each.value.keyvault.lz_key, var.client_config.landingzone_key)][each.value.keyvault.certificate_key].secret_id, var.keyvault_certificate_requests[try(each.value.keyvault.lz_key, var.client_config.landingzone_key)][each.value.certificate_request_key].secret_id, null)
+      KEY_VAULT_SECRET_ID      = try(data.azurerm_key_vault_certificate.manual_certs[each.key].versionless_secret_id, var.keyvault_certificates[try(each.value.keyvault.lz_key, var.client_config.landingzone_key)][each.value.keyvault.certificate_key].versionless_secret_id, var.keyvault_certificate_requests[try(each.value.keyvault.lz_key, var.client_config.landingzone_key)][each.value.certificate_request_key].versionless_secret_id, null)
     }
   }
 }

--- a/modules/networking/private_dns_vnet_link_v1/module.tf
+++ b/modules/networking/private_dns_vnet_link_v1/module.tf
@@ -20,7 +20,7 @@ resource "azapi_resource" "vnet_links" {
 
   tags = var.inherit_tags ? merge(
     var.global_settings.tags,
-    can(each.value.id) || can(each.value.dns_parent_id) ? {} : try(var.private_dns[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.key].base_tags,{}),
+    can(each.value.id) || can(each.value.dns_parent_id) ? {} : try(var.private_dns[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.key].base_tags, {}),
     try(var.settings.tags, {})
   ) : try(var.settings.tags, {})
 

--- a/modules/security/keyvault_certificate/output.tf
+++ b/modules/security/keyvault_certificate/output.tf
@@ -21,3 +21,7 @@ output "thumbprint" {
 output "certificate_attribute" {
   value = azurerm_key_vault_certificate.cert.certificate_attribute
 }
+
+output "versionless_secret_id" {
+  value = azurerm_key_vault_certificate.cert.versionless_secret_id
+}

--- a/modules/security/keyvault_certificate_request/global_sign.tf
+++ b/modules/security/keyvault_certificate_request/global_sign.tf
@@ -1,13 +1,13 @@
 data "azapi_resource" "password" {
-  count        = lower(var.settings.certificate_policy.issuer_key_or_name) == "self" ? 0 : 1
-  
+  count = lower(var.settings.certificate_policy.issuer_key_or_name) == "self" ? 0 : 1
+
   type      = "Microsoft.KeyVault/vaults/secrets@2022-07-01"
   parent_id = var.keyvault_id
 
   name = try(
     var.certificate_issuers[var.settings.certificate_policy.issuer_key_or_name].cert_password_key,
     var.certificate_issuers[var.settings.certificate_policy.issuer_key_or_name].cert_secret_name
-    ) # added password_secret_name for remote lz which does not output secretname
+  ) # added password_secret_name for remote lz which does not output secretname
 }
 
 locals {


### PR DESCRIPTION
# [1610](https://github.com/aztfmod/terraform-azurerm-caf/issues/1610)

Certificates referenced using a "key" in the configuration to create Application Gateway Listener Certificates use the versioned id.
This prevents the listener certificate from updating to the latest version of the certificate and support key rotation.
Added an output variable for the versionless_secret_id and referenced this property while creating the Application Gateway listener certificate.

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [ ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
