### PR TITLE
Fixed issues related to url path map and url path map rule creation errors

### DIFF
--- a/examples/app_gateway/301-agw-v1/agw_application.tfvars
+++ b/examples/app_gateway/301-agw-v1/agw_application.tfvars
@@ -94,14 +94,18 @@ application_gateway_applications_v1 = {
 
     url_path_rules = {
       rule1 = {
-        name             = "rule1-demo"
-        url_path_map_key = "demo"
-        paths            = "/test/rule1/*"
+        name              = "rule1-demo"
+        url_path_map_key  = "demo"
+        paths             = "/test/rule1/*"
+        backend_pool_key  = "demo"
+        http_settings_key = "demo"
       }
       rule2 = {
-        name             = "rule2-demo"
-        url_path_map_key = "demo"
-        paths            = "/test/rule2/*"
+        name              = "rule2-demo"
+        url_path_map_key  = "demo"
+        paths             = "/test/rule2/*"
+        backend_pool_key  = "demo"
+        http_settings_key = "demo"
       }
     }
 

--- a/examples/app_gateway/302-listener-ssl-policy/agw_application.tfvars
+++ b/examples/app_gateway/302-listener-ssl-policy/agw_application.tfvars
@@ -92,14 +92,18 @@ application_gateway_applications_v1 = {
 
     url_path_rules = {
       rule1 = {
-        name             = "rule1-demo"
-        url_path_map_key = "demo"
-        paths            = "/test/rule1/*"
+        name              = "rule1-demo"
+        url_path_map_key  = "demo"
+        paths             = "/test/rule1/*"
+        backend_pool_key  = "demo"
+        http_settings_key = "demo"
       }
       rule2 = {
-        name             = "rule2-demo"
-        url_path_map_key = "demo"
-        paths            = "/test/rule2/*"
+        name              = "rule2-demo"
+        url_path_map_key  = "demo"
+        paths             = "/test/rule2/*"
+        backend_pool_key  = "demo"
+        http_settings_key = "demo"
       }
     }
 

--- a/modules/networking/application_gateway_application/scripts/set_resource.sh
+++ b/modules/networking/application_gateway_application/scripts/set_resource.sh
@@ -151,8 +151,8 @@ case "${RESOURCE}" in
          --name ${NAME} ${certfile}${keyvaultsecretid}
         ;;
     PATHMAP)
-        addresspool=$([ -z "${ADDRESS_POOL}" ] && echo "" || echo "--address-pool ${ADDRESS_POOL} ")
-        httpsettings=$([ -z "${HTTP_SETTINGS}" ] && echo "" || echo "--http-settings ${HTTP_SETTINGS} ")
+        addresspool=$([ -z "${ADDRESS_POOL}" ] && echo "" || echo "--address-pool ${ADDRESS_POOL} --default-address-pool ${ADDRESS_POOL} ")
+        httpsettings=$([ -z "${HTTP_SETTINGS}" ] && echo "" || echo "--http-settings ${HTTP_SETTINGS} --default-http-settings ${HTTP_SETTINGS} ")
         redirectconfig=$([ -z "${REDIRECT_CONFIG}" ] && echo "" || echo "--redirect-config ${REDIRECT_CONFIG} ")
         rewriteruleset=$([ -z "${REWRITE_RULE_SET}" ] && echo "" || echo "--rewrite-rule-set ${REWRITE_RULE_SET} ")
         rulename=$([ -z "${RULE_NAME}" ] && echo "" || echo "--rule-name ${RULE_NAME} ")

--- a/modules/networking/application_gateway_application/url_path_map.tf
+++ b/modules/networking/application_gateway_application/url_path_map.tf
@@ -20,8 +20,8 @@ resource "null_resource" "set_url_path_map" {
       APPLICATION_GATEWAY_ID   = var.application_gateway.id
       NAME                     = each.value.name
       PATHS                    = each.value.paths
-      ADDRESS_POOL             = try(var.settings.backend_pools[each.value.backend_pool_key].name, null)
-      HTTP_SETTINGS            = try(var.settings.http_settings[each.value.http_settings_key].name, null)
+      ADDRESS_POOL             = var.settings.backend_pools[each.value.backend_pool_key].name
+      HTTP_SETTINGS            = var.settings.http_settings[each.value.http_settings_key].name
       REDIRECT_CONFIG          = try(each.value.redirect_config, null)
       REWRITE_RULE_SET         = try(var.settings.rewrite_rule_sets[each.value.rewrite_rule_set_key].name, null)
       RULE_NAME                = try(each.value.rule_name, null)

--- a/modules/networking/application_gateway_application/url_path_rule.tf
+++ b/modules/networking/application_gateway_application/url_path_rule.tf
@@ -21,8 +21,8 @@ resource "null_resource" "set_url_path_rule" {
       NAME                     = each.value.name
       PATHS                    = each.value.paths
       PATHMAPNAME              = var.settings.url_path_maps[each.value.url_path_map_key].name
-      ADDRESS_POOL             = try(var.settings.backend_pools[each.value.backend_pool_key].name, null)
-      HTTP_SETTINGS            = try(var.settings.http_settings[each.value.http_settings_key].name, null)
+      ADDRESS_POOL             = var.settings.backend_pools[each.value.backend_pool_key].name
+      HTTP_SETTINGS            = var.settings.http_settings[each.value.http_settings_key].name
       REDIRECT_CONFIG          = try(each.value.redirect_config, null)
       REWRITE_RULE_SET         = try(var.settings.rewrite_rule_sets[each.value.rewrite_rule_set_key].name, null)
       WAF_POLICY               = try(each.value.waf_policy, null)


### PR DESCRIPTION
# [1614](https://github.com/aztfmod/terraform-azurerm-caf/issues/1614)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

deployment fails while creating url path map.
ERROR: (ApplicationGatewayUrlPathMapMustSpecifyDefaultBackendHttpSettings) and keeps retrying till timeout.
Reason: new Azcli version makes 2 parameters mandatory in the command "az network application-gateway url-path-map create"
--default-address-pool
--default-http-settings

deployment fails while creating url path map rule fails since configuration does not provide. 
command: az network application-gateway url-path-map rule create.
reason: example configuration did not provide the below details. Worked earlier since it was not mandatory to provide the below arguments in earlier version of azcli but in the latest version of azcli, it is mandatory.
--address-pool
--http-settings
fix: updated configuration to add the http_settings_key and backend_pool_key in v1 examples.

## Does this introduce a breaking change

- [ ] YES
- [ ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
