### PR TITLE
Fix deprecated network_profile_id with subnet_ids

### DIFF
--- a/container_groups.tf
+++ b/container_groups.tf
@@ -18,6 +18,7 @@ module "container_groups" {
     keyvaults          = local.combined_objects_keyvaults
     managed_identities = local.combined_objects_managed_identities
     network_profiles   = local.combined_objects_network_profiles
+    networking         = local.combined_objects_networking
   }
 }
 

--- a/modules/compute/container_group/container_group.tf
+++ b/modules/compute/container_group/container_group.tf
@@ -33,7 +33,9 @@ resource "azurerm_container_group" "acg" {
   tags                = merge(local.tags, try(var.settings.tags, null))
   ip_address_type     = try(var.settings.ip_address_type, "Public")
   restart_policy      = try(var.settings.restart_policy, "Always")
-  network_profile_id  = try(var.combined_resources.network_profiles[try(var.settings.network_profile.lz_key, var.client_config.landingzone_key)][var.settings.network_profile.key].id, null)
+  subnet_ids = try(var.settings.network.subnets, null) == null ? null : [
+    for key, value in var.settings.network.subnets : can(value.subnet_id) ? value.subnet_id : var.combined_resources.networking[try(value.lz_key, var.client_config.landingzone_key)][value.vnet_key].subnets[value.subnet_key].id
+  ]
 
   dynamic "exposed_port" {
     for_each = try(var.settings.exposed_port, [])


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [X] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [X] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
