### PR TITLE
Fix issue with try clause in virtual_machine module

### DIFF
--- a/modules/compute/virtual_machine/keyvault.tf
+++ b/modules/compute/virtual_machine/keyvault.tf
@@ -1,3 +1,3 @@
 locals {
-  keyvault = local.create_sshkeys || local.os_type == "windows" ? try(var.keyvaults[var.settings.lz_key][var.settings.keyvault_key], var.keyvaults[var.client_config.landingzone_key][var.settings.keyvault_key]) : null
+  keyvault = local.create_sshkeys || local.os_type == "windows" ? var.keyvaults[try(var.settings.keyvault.lz_key, var.settings.lz_key, var.client_config.landingzone_key)][try(var.settings.keyvault.key, var.settings.keyvault_key)] : null
 }


### PR DESCRIPTION
Terraform destroy failed when var.settings.keyvault.key was used instead of var.settings.keyvault_key

# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [X ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [X ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
