### PR TITLE
Add feature to allign Azure VM name and computer name for windows vm

### DIFF
--- a/examples/compute/virtual_machine/101-single-windows-vm/configuration.tfvars
+++ b/examples/compute/virtual_machine/101-single-windows-vm/configuration.tfvars
@@ -45,6 +45,8 @@ virtual_machines = {
     virtual_machine_settings = {
       windows = {
         name           = "example_vm2"
+        # If true, the Azure VM name will be the same as the Windows computer name. If you plan to use Azure AD login, this must be true
+        allign_azure_vm_name_with_computer_name = true
         size           = "Standard_F2"
         admin_username = "adminuser"
 

--- a/modules/compute/virtual_machine/vm_windows.tf
+++ b/modules/compute/virtual_machine/vm_windows.tf
@@ -52,7 +52,7 @@ resource "azurerm_windows_virtual_machine" "vm" {
   license_type                 = try(each.value.license_type, null)
   location                     = local.location
   max_bid_price                = try(each.value.max_bid_price, null)
-  name                         = data.azurecaf_name.windows[each.key].result
+  name                         = try(each.value.allign_azure_vm_name_with_computer_name, false) == true ? data.azurecaf_name.windows_computer_name[each.key].result : data.azurecaf_name.windows[each.key].result
   network_interface_ids        = local.nic_ids
   priority                     = try(each.value.priority, null)
   patch_mode                   = try(each.value.patch_mode, "AutomaticByOS")


### PR DESCRIPTION
This is required if you plan to use Azure AD login to Windows VM with Bastion and native client

# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [ ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
