### PR TITLE
Add support for vnet resource id in vnet link

### DIFF
--- a/networking_private_dns.tf
+++ b/networking_private_dns.tf
@@ -56,7 +56,7 @@ module "private_dns_vnet_links" {
   base_tags          = {}
   global_settings    = local.global_settings
   client_config      = local.client_config
-  virtual_network_id = local.combined_objects_networking[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.vnet_key].id
+  virtual_network_id = can(each.value.virtual_network_id) ? each.value.virtual_network_id : local.combined_objects_networking[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.vnet_key].id  
   private_dns        = local.combined_objects_private_dns
   settings           = each.value
 }


### PR DESCRIPTION
This is required when you want to link launchpad vnet to the HUB at level2 and link level2 private_dns_zones. Consider to implement vnet propagation in the same way as launchpad identities

# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [X] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [X] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
