### PR TITLE
App Gateway: configure default ssl policy and ssl profile selection with listener

### DIFF
--- a/examples/app_gateway/210-agw-with-keyvault/application.tfvars
+++ b/examples/app_gateway/210-agw-with-keyvault/application.tfvars
@@ -18,6 +18,7 @@ application_gateway_applications = {
         front_end_port_key             = "443"
         host_name                      = "demoapp1.cafdemo.com"
         request_routing_rule_key       = "default"
+        ssl_profile_key                = "profile1"
         keyvault_certificate = {
           certificate_key = "demoapp1.cafdemo.com"
           // To use manual uploaded cert

--- a/examples/app_gateway/210-agw-with-keyvault/application_gateways.tfvars
+++ b/examples/app_gateway/210-agw-with-keyvault/application_gateways.tfvars
@@ -33,6 +33,11 @@ application_gateways = {
       }
     }
 
+    ssl_policy = {
+      policy_type = "Predefined"
+      policy_name = "AppGwSslPolicy20220101S"
+    }
+
     front_end_ip_configurations = {
       public = {
         name          = "public"

--- a/modules/networking/application_gateway/application_gateway.tf
+++ b/modules/networking/application_gateway/application_gateway.tf
@@ -48,21 +48,29 @@ resource "azurerm_application_gateway" "agw" {
     subnet_id = local.ip_configuration["gateway"].subnet_id
   }
 
+  ssl_policy {
+    disabled_protocols   = try(var.settings.ssl_policy.disabled_protocols, null)
+    policy_type          = try(var.settings.ssl_policy.policy_type, null)
+    policy_name          = try(var.settings.ssl_policy.policy_name, null)
+    cipher_suites        = try(var.settings.ssl_policy.cipher_suites, null)
+    min_protocol_version = try(var.settings.ssl_policy.min_protocol_version, null)
+  }
+
   dynamic "ssl_profile" {
     for_each = try(var.settings.ssl_profiles, {})
     content {
       name                             = ssl_profile.value.name
-      trusted_client_certificate_names = try(ssl_profile.trusted_client_certificate_names, null)
-      verify_client_cert_issuer_dn     = try(ssl_profile.verify_client_cert_issuer_dn, null)
+      trusted_client_certificate_names = try(ssl_profile.value.trusted_client_certificate_names, null)
+      verify_client_cert_issuer_dn     = try(ssl_profile.value.verify_client_cert_issuer_dn, null)
 
       dynamic "ssl_policy" {
         for_each = try(ssl_profile.value.ssl_policy, null) == null ? [] : [1]
         content {
-          disabled_protocols   = try(ssl_policy.value.disabled_protocols, null)
-          policy_type          = try(ssl_policy.value.policy_type, null)
-          policy_name          = try(ssl_policy.value.policy_name, null)
-          cipher_suites        = try(ssl_policy.value.cipher_suites, null)
-          min_protocol_version = try(ssl_policy.value.min_protocol_version, null)
+          disabled_protocols   = try(ssl_profile.value.ssl_policy.disabled_protocols, null)
+          policy_type          = try(ssl_profile.value.ssl_policy.policy_type, null)
+          policy_name          = try(ssl_profile.value.ssl_policy.policy_name, null)
+          cipher_suites        = try(ssl_profile.value.ssl_policy.cipher_suites, null)
+          min_protocol_version = try(ssl_profile.value.ssl_policy.min_protocol_version, null)
         }
       }
     }
@@ -111,6 +119,7 @@ resource "azurerm_application_gateway" "agw" {
       require_sni                    = try(http_listener.value.require_sni, false)
       ssl_certificate_name           = try(try(try(http_listener.value.keyvault_certificate_request.key, http_listener.value.keyvault_certificate.certificate_key), data.azurerm_key_vault_certificate.manual_certs[http_listener.key].name), null)
       firewall_policy_id             = try(var.application_gateway_waf_policies[try(http_listener.value.waf_policy.lz_key, var.client_config.landingzone_key)][http_listener.value.waf_policy.key].id, null)
+      ssl_profile_name               = try(var.settings.ssl_profiles[http_listener.value.ssl_profile_key].name, null)
     }
   }
 


### PR DESCRIPTION
## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have added example(s) inside the [./examples/] folder
- [x] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

ability to configure ssl profile in http listener, and set default ssl policy for app gateway. 

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

updated example code in 210-agw-with-keyvault
