### PR TITLE
fix: support multiple dimension block in monitor metric alert

### DIFF
--- a/examples/monitoring/103-monitor_metric_alert/configuration.tfvars
+++ b/examples/monitoring/103-monitor_metric_alert/configuration.tfvars
@@ -107,9 +107,16 @@ monitor_metric_alert = {
       threshold        = 50
 
       dimension = {
-        name     = "ApiName"
-        operator = "Include"
-        values   = ["*"]
+        api = {
+          name     = "ApiName"
+          operator = "Include"
+          values   = ["*"]
+        }
+        serverbusy = {
+          name     = "ResponseType"
+          operator = "Include"
+          values   = ["ServerBusyError"]
+        }
       }
     }
 

--- a/modules/monitoring/monitor_metric_alert/module.tf
+++ b/modules/monitoring/monitor_metric_alert/module.tf
@@ -28,7 +28,7 @@ resource "azurerm_monitor_metric_alert" "mma" {
       operator         = try(criteria.value.operator, null)
       threshold        = try(criteria.value.threshold, null)
       dynamic "dimension" {
-        for_each = try(var.settings.dimension, null) != null ? [var.settings.dimension] : []
+        for_each = try(criteria.value.dimension, {})
         content {
           name     = try(dimension.value.name, null)
           operator = try(dimension.value.operator, null)
@@ -47,7 +47,7 @@ resource "azurerm_monitor_metric_alert" "mma" {
       operator          = try(dynamic_criteria.value.operator, null)
       alert_sensitivity = try(dynamic_criteria.value.alert_sensitivity, null)
       dynamic "dimension" {
-        for_each = try(var.settings.dimension, null) != null ? [var.settings.dimension] : []
+        for_each = try(dynamic_criteria.value.dimension, {})
         content {
           name     = try(dimension.value.name, null)
           operator = try(dimension.value.operator, null)


### PR DESCRIPTION
## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have added example(s) inside the [./examples/] folder
- [x] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [x] YES
- [ ] NO

existing configuration only support single optional block for dimension. 

      dimension = {
        name     = "ApiName"
        operator = "Include"
        values   = ["*"]
      }

the fix shall support one or more dimension block. below is a random example.

    dimension = {
      api = {
        name     = "ApiName"
        operator = "Include"
        values   = ["*"]
      }
      server_status = {
        name     = "ResponseType"
        operator = "Include"
        values   = ["ServerBusyError"]
      }
    }


## Testing

updated example set examples/monitoring/103-monitor_metric_alert/configuration.tfvars

