### PR TITLE
Fix managed_rules exclusion

### DIFF
--- a/examples/app_gateway/102-waf-policy/waf.tfvars
+++ b/examples/app_gateway/102-waf-policy/waf.tfvars
@@ -66,7 +66,7 @@ application_gateway_waf_policies = {
     }
 
     managed_rules = {
-      exclusion = {
+      exclusions = {
         ex1 = {
           match_variable          = "RequestHeaderNames"
           selector                = "x-company-secret-header"

--- a/examples/webapps/appservice/109-appservice-appgw/waf.tfvars
+++ b/examples/webapps/appservice/109-appservice-appgw/waf.tfvars
@@ -62,7 +62,7 @@ application_gateway_waf_policies = {
     }
 
     managed_rules = {
-      exclusion = {
+      exclusions = {
         ex1 = {
           match_variable          = "RequestHeaderNames"
           selector                = "x-company-secret-header"

--- a/modules/networking/application_gateway_waf_policies/waf_policy.tf
+++ b/modules/networking/application_gateway_waf_policies/waf_policy.tf
@@ -48,7 +48,7 @@ resource "azurerm_web_application_firewall_policy" "wafpolicy" {
     for_each = try(var.settings.managed_rules, {}) != {} ? [1] : []
     content {
       dynamic "exclusion" {
-        for_each = try(var.settings.managed_rules.exclusion, {})
+        for_each = try(var.settings.managed_rules.exclusions, {})
         content {
           match_variable          = exclusion.value.match_variable
           selector                = try(exclusion.value.selector, null)

--- a/modules/networking/application_gateway_waf_policies/waf_policy.tf
+++ b/modules/networking/application_gateway_waf_policies/waf_policy.tf
@@ -48,7 +48,7 @@ resource "azurerm_web_application_firewall_policy" "wafpolicy" {
     for_each = try(var.settings.managed_rules, {}) != {} ? [1] : []
     content {
       dynamic "exclusion" {
-        for_each = try(var.settings.managed_rules.exclusions, {})
+        for_each = try(var.settings.managed_rules.exclusion, {})
         content {
           match_variable          = exclusion.value.match_variable
           selector                = try(exclusion.value.selector, null)


### PR DESCRIPTION
# [Fix managed_rules exclusion](https://github.com/aztfmod/terraform-azurerm-caf/issues/1662)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Code was ignored before.

Removing the plural fix the issue

```
...
    managed_rules = {
      exclusion = {
        ex1 = {
          match_variable          = "RequestHeaderNames"
          selector                = "x-company-secret-header"
          selector_match_operator = "Equals"
        }
        ex2 = {
          match_variable          = "RequestCookieNames"
          selector                = "yyy"
          selector_match_operator = "EndsWith"
        }
        ex3 = {
          match_variable          = "RequestCookieNames"
          selector                = "xxx"
          selector_match_operator = "StartsWith"
        }
      }
...
```

```
  # module.solution.module.application_gateway_waf_policies["wp1"].azurerm_web_application_firewall_policy.wafpolicy will be updated in-place
  ~ resource "azurerm_web_application_firewall_policy" "wafpolicy" {
        id                  = "/subscriptions/xxxx/resourceGroups/rg-weu-01/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/waf-weu-001"
        name                = "waf-weu-001"
        tags                = {
            "deployment_module" = "CAF"
            "deployment_type"   = "Terraform"
            "environment"       = "dev"
            "level"             = "level2"
            "module"            = "application_gateway_waf_policies"
            "project"           = "xxx"
            "resource_env"      = "dev"
            "rover_version"     = "aztfmod/rover:1.4.6-2305.1701"
        }
        # (4 unchanged attributes hidden)

      ~ managed_rules {
          + exclusion {
              + match_variable          = "RequestHeaderNames"
              + selector                = "x-company-secret-header"
              + selector_match_operator = "Equals"
            }
          + exclusion {
              + match_variable          = "RequestCookieNames"
              + selector                = "yyy"
              + selector_match_operator = "EndsWith"
            }
          + exclusion {
              + match_variable          = "RequestCookieNames"
              + selector                = "xxx"
              + selector_match_operator = "StartsWith"
            }

            # (1 unchanged block hidden)
        }

        # (3 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
