### PR TITLE
Fix mariadb server minimal tls version enforced

### DIFF
--- a/modules/databases/mariadb_server/server.tf
+++ b/modules/databases/mariadb_server/server.tf
@@ -10,14 +10,15 @@ resource "azurerm_mariadb_server" "mariadb" {
   storage_mb = var.settings.storage_mb
   version    = var.settings.version
 
-  auto_grow_enabled             = try(var.settings.auto_grow_enabled, true)
-  backup_retention_days         = try(var.settings.backup_retention_days, null)
-  geo_redundant_backup_enabled  = try(var.settings.geo_redundant_backup_enabled, null)
-  public_network_access_enabled = try(var.settings.public_network_access_enabled, false)
-  ssl_enforcement_enabled       = try(var.settings.ssl_enforcement_enabled, true)
-  create_mode                   = try(var.settings.create_mode, "Default")
-  creation_source_server_id     = try(var.settings.creation_source_server_id, null)
-  tags                          = local.tags
+  auto_grow_enabled                = try(var.settings.auto_grow_enabled, true)
+  backup_retention_days            = try(var.settings.backup_retention_days, null)
+  geo_redundant_backup_enabled     = try(var.settings.geo_redundant_backup_enabled, null)
+  public_network_access_enabled    = try(var.settings.public_network_access_enabled, false)
+  ssl_enforcement_enabled          = try(var.settings.ssl_enforcement_enabled, true)
+  ssl_minimal_tls_version_enforced = try(var.settings.ssl_minimal_tls_version_enforced, "TLSEnforcementDisabled")
+  create_mode                      = try(var.settings.create_mode, "Default")
+  creation_source_server_id        = try(var.settings.creation_source_server_id, null)
+  tags                             = local.tags
 }
 
 # Generate mariadb server random admin password if not provided in the attribute administrator_login_password

--- a/modules/databases/mariadb_server/server.tf
+++ b/modules/databases/mariadb_server/server.tf
@@ -15,7 +15,7 @@ resource "azurerm_mariadb_server" "mariadb" {
   geo_redundant_backup_enabled     = try(var.settings.geo_redundant_backup_enabled, null)
   public_network_access_enabled    = try(var.settings.public_network_access_enabled, false)
   ssl_enforcement_enabled          = try(var.settings.ssl_enforcement_enabled, true)
-  ssl_minimal_tls_version_enforced = try(var.settings.ssl_minimal_tls_version_enforced, "TLSEnforcementDisabled")
+  ssl_minimal_tls_version_enforced = try(var.settings.ssl_minimal_tls_version_enforced, "TLS1_2")
   create_mode                      = try(var.settings.create_mode, "Default")
   creation_source_server_id        = try(var.settings.creation_source_server_id, null)
   tags                             = local.tags


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

azurerm 3.56.0 defaults `ssl_minimal_tls_version_enforced` to "TLS1_2" causing an issue if you want values other than the default.

This PR allows you to specify other values. Possible values are [TLSEnforcementDisabled, TLS1_0, TLS1_1, and TLS1_2](https://registry.terraform.io/providers/hashicorp/azurerm/3.56.0/docs/resources/mariadb_server#ssl_minimal_tls_version_enforced). 

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
