### PR TITLE
Revert AKS maintenance window settings

### DIFF
--- a/modules/compute/aks/aks.tf
+++ b/modules/compute/aks/aks.tf
@@ -297,17 +297,17 @@ resource "azurerm_kubernetes_cluster" "aks" {
   local_account_disabled = try(var.settings.local_account_disabled, false)
 
   dynamic "maintenance_window" {
-    for_each = can(var.settings.maintenance_window) ? [1] : []
+    for_each = try(var.settings.maintenance_window, null) == null ? [] : [1]
     content {
       dynamic "allowed" {
-        for_each = can(maintenance_window.value.allowed) ? [1] : []
+        for_each = var.settings.maintenance_window.allowed == null ? [] : [1]
         content {
           day   = var.settings.maintenance_window.allowed.day
           hours = var.settings.maintenance_window.allowed.hours
         }
       }
       dynamic "not_allowed" {
-        for_each = can(var.settings.maintenance_window.not_allowed) ? [1] : []
+        for_each = var.settings.maintenance_window.not_allowed == null ? [] : [1]
         content {
           end   = var.settings.maintenance_window.not_allowed.end
           start = var.settings.maintenance_window.not_allowed.start

--- a/modules/compute/aks/aks.tf
+++ b/modules/compute/aks/aks.tf
@@ -300,14 +300,14 @@ resource "azurerm_kubernetes_cluster" "aks" {
     for_each = try(var.settings.maintenance_window, null) == null ? [] : [1]
     content {
       dynamic "allowed" {
-        for_each = var.settings.maintenance_window.allowed == null ? [] : [1]
+        for_each = try(var.settings.maintenance_window.allowed, null) == null ? [] : [1]
         content {
           day   = var.settings.maintenance_window.allowed.day
           hours = var.settings.maintenance_window.allowed.hours
         }
       }
       dynamic "not_allowed" {
-        for_each = var.settings.maintenance_window.not_allowed == null ? [] : [1]
+        for_each = try(var.settings.maintenance_window.not_allowed, null) == null ? [] : [1]
         content {
           end   = var.settings.maintenance_window.not_allowed.end
           start = var.settings.maintenance_window.not_allowed.start


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [X] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Reverting changes in aks `maintenance_window` dynamic block with previous `try` function.

`can` function introduces errors if value is null or not specified.

`not_allowed = null` - can function returns `true`
```
    maintenance_window = {
      not_allowed = null
      allowed = {
        day = "Saturday"
        hours = [
          8,
          9,
          10,
          11,
          12
        ]
      }
    }

│ Error: Attempt to get attribute from null value
│ 
│   on .terraform/modules/caf/modules/compute/aks/aks.tf line 312, in resource "azurerm_kubernetes_cluster" "aks":
│  312:           end   = var.settings.maintenance_window.not_allowed.end
│     ├────────────────
│     │ var.settings.maintenance_window.not_allowed is null
│ 
│ This value is null, so it does not have any attributes.
╵
╷
│ Error: Attempt to get attribute from null value
│ 
│   on .terraform/modules/caf/modules/compute/aks/aks.tf line 313, in resource "azurerm_kubernetes_cluster" "aks":
│  313:           start = var.settings.maintenance_window.not_allowed.start
│     ├────────────────
│     │ var.settings.maintenance_window.not_allowed is null
│ 
│ This value is null, so it does not have any attributes.
```

not specified

```
    maintenance_window = {
      allowed = {
        day = "Saturday"
        hours = [
          8,
          9,
          10,
          11,
          12
        ]
      }
    }

│ Error: Unsupported attribute
│ 
│   on .terraform/modules/caf/modules/compute/aks/aks.tf line 310, in resource "azurerm_kubernetes_cluster" "aks":
│  310:         for_each = var.settings.maintenance_window.not_allowed == null ? [] : [1]
│     ├────────────────
│     │ var.settings.maintenance_window is object with 1 attribute "allowed"
│ 
│ This object does not have an attribute named "not_allowed".
```

When both settings are specified, there's an odd behaviour

```
    maintenance_window = {
      not_allowed = {
        start = "2021-11-26T03:00:00Z"
        end   = "2021-11-30T12:00:00Z"
      }
      allowed = {
        day = "Saturday"
        hours = [
          8,
          9,
          10,
          11,
          12
        ]
      }
    }

Plan:
      ~ maintenance_window {
          - allowed {
              - day   = "Saturday" -> null
              - hours = [
                  - 8,
                  - 9,
                  - 10,
                  - 11,
                  - 12,
                ] -> null
            }

          + not_allowed {
              + end   = "2021-11-30T12:00:00Z"
              + start = "2021-11-26T03:00:00Z"
            }
        }
```

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
