### PR TITLE
Allow threat_intel_mode in azurerm_firewall to be set when referencing a virtual_hub

### DIFF
--- a/modules/networking/firewall/module.tf
+++ b/modules/networking/firewall/module.tf
@@ -21,7 +21,7 @@ resource "azurerm_firewall" "fw" {
   sku_name            = try(var.settings.sku_name, "AZFW_VNet")
   sku_tier            = try(var.settings.sku_tier, "Standard")
   tags                = local.tags
-  threat_intel_mode   = try(var.settings.virtual_hub, null) != null ? "" : try(var.settings.threat_intel_mode, "Alert")
+  threat_intel_mode   = try(var.settings.threat_intel_mode, "Alert")
   zones               = try(var.settings.zones, null)
 
   ## direct subnet_id reference


### PR DESCRIPTION
# [1672](https://github.com/aztfmod/terraform-azurerm-caf/issues/1672)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

`azurerm_firewall` forced `threat_intel_mode` to empty string if `virtual_hub` is specified. This is not required anymore in azurerm provider 3.56.0.

This PR is to allow setting the `threat_intel_mode` even if the `virtual_hub` is specified.

These changes are required in order to successfully `terraform plan` an Azure Firewall in a virtual hub. Without it we are blocked.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
