### PR TITLE
Allow set threat_intel_mode to be null

### DIFF
--- a/modules/networking/firewall/module.tf
+++ b/modules/networking/firewall/module.tf
@@ -21,7 +21,7 @@ resource "azurerm_firewall" "fw" {
   sku_name            = try(var.settings.sku_name, "AZFW_VNet")
   sku_tier            = try(var.settings.sku_tier, "Standard")
   tags                = local.tags
-  threat_intel_mode   = try(var.settings.threat_intel_mode, "Alert")
+  threat_intel_mode   = try(var.settings.threat_intel_mode, null)
   zones               = try(var.settings.zones, null)
 
   ## direct subnet_id reference


### PR DESCRIPTION
# [1672](https://github.com/aztfmod/terraform-azurerm-caf/issues/1672)

Related to merged PR #1673 (sorry for changing it again)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

The previous version which failed over the value to 'Alert' can make the terraform apply fail depending on the sku_tier (will fail with Standard sku). Now the user is responsible to set the correct mode and can also omit this parameter in order to apply successfully the firewall.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

terraform plan and apply of azurerm_firewall with the `virtual_hub` parameter and without the `threat_intel_mode`.
