### PR TITLE
Updated tag inheritance logic for resource groups

### DIFF
--- a/modules/resource_group/main.tf
+++ b/modules/resource_group/main.tf
@@ -8,14 +8,8 @@ terraform {
 }
 
 locals {
-
-  tags = var.base_tags ? merge(
+  tags = var.global_settings.inherit_tags ? merge(
     var.global_settings.tags,
-    try(var.tags, null)
-    ) : merge(
-    try(var.tags,
-    null)
-  )
-
-
+    var.tags
+    ) : var.tags
 }

--- a/modules/resource_group/module.tf
+++ b/modules/resource_group/module.tf
@@ -13,5 +13,5 @@ resource "azurecaf_name" "rg" {
 resource "azurerm_resource_group" "rg" {
   name     = azurecaf_name.rg.result
   location = var.global_settings.regions[lookup(var.settings, "region", var.global_settings.default_region)]
-  tags     = merge(local.tags, try(var.tags, null))
+  tags     = merge(local.tags, try(var.settings.tags, null))
 }

--- a/modules/resource_group/variables.tf
+++ b/modules/resource_group/variables.tf
@@ -4,13 +4,11 @@ variable "global_settings" {
 variable "tags" {
   description = "(Required) Map of tags to be applied to the resource"
   type        = map(any)
+  default     = {}
+  nullable    = false  
 }
 variable "settings" {}
 variable "resource_group_name" {
   description = "(Required) The name of the resource group where to create the resource."
   type        = string
-}
-variable "base_tags" {
-  description = "Base tags for the resource to be inherited from the resource group."
-  type        = bool
 }

--- a/resource_groups.tf
+++ b/resource_groups.tf
@@ -9,8 +9,7 @@ module "resource_groups" {
   resource_group_name = each.value.name
   settings            = each.value
   global_settings     = local.global_settings
-  tags                = merge(lookup(each.value, "tags", {}), var.tags)
-  base_tags           = local.global_settings.inherit_tags
+  tags                = var.tags
 }
 
 


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->
Resource group tag overwrite is not working correctly in int-5.7.0. When global_settings_override.inherit_tags = true and global_settings_override.passthrough = true, attempting to overwrite a specific tag with a new value at the resource group level does not work. 

The original snippet of code in landingzone.tfvars
```
global_settings_override = {
  default_region = "region1"
  regions = {
    region1 = "southeastasia"
  }
  passthrough = true
  inherit_tags = true
}

# tags at landingzone level
  tags = {
    App         = "sampleapp"
    Branch      = "dev"
    Environment = "dev"
    DataCenter  = "sea"
    Region      = "southeastasia"
    Build       = "1"
    Component   = "sampleapp"
    Name        = "customer-git-cs-dev-sandbox-sampleapp-sea-sit1"
    Portfolio   = "customer-git-cs-dev-sandbox"
    Department  = "customer-git-cs-dev"
    Application = "customer-git-cs-dev-sandbox-sampleapp"
  }
```

The snippet of code in resource_groups.tfvars to overwrite **App = sampleapp** to **App = testapp** for resource group **networking**

```
resource_groups = {
  networking = {
    name   = "customer-sandpit-app1-networking-rg"
    region = "region1"
    tags = {
      App         = "testapp"
    }
  }
}
```
**Non-working result**
![notworkingtags](https://github.com/aztfmod/terraform-azurerm-caf/assets/91816369/d581afbf-4acf-4efb-9293-9afbce212c6b)


**Working result**
![workingtags](https://github.com/aztfmod/terraform-azurerm-caf/assets/91816369/c743ab60-2226-4771-913a-2d06b5f53ef5)

The changes are made in resource_groups.tf and in modules/resource_group/main.tf , modules/resource_group/module.tf and modules/resource_group/variables.tf


## Does this introduce a breaking change

- [ ] YES
- [ x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
