### PR TITLE
Fix/recovery vault private endpoint

### DIFF
--- a/modules/recovery_vault/private_endpoints.tf
+++ b/modules/recovery_vault/private_endpoints.tf
@@ -16,6 +16,7 @@ module "private_endpoint" {
   settings            = each.value
   subresource_names   = ["AzureSiteRecovery"]
   global_settings     = var.global_settings
+  tags                = local.tags
   base_tags           = var.base_tags
   private_dns         = var.private_dns
   client_config       = var.client_config

--- a/modules/recovery_vault/private_endpoints.tf
+++ b/modules/recovery_vault/private_endpoints.tf
@@ -16,7 +16,7 @@ module "private_endpoint" {
   settings            = each.value
   subresource_names   = ["AzureSiteRecovery"]
   global_settings     = var.global_settings
-  base_tags           = local.tags
+  base_tags           = var.base_tags
   private_dns         = var.private_dns
   client_config       = var.client_config
 }


### PR DESCRIPTION
## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have added example(s) inside the [./examples/] folder
- [x] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

This fixes a bug when creating a private endpoint for recovery vault. The wrong variable type is passed (`base_tags`) to the private endpoint module, example of error you can get:

```
╷
│ Error: Invalid value for input variable
│ 
│   on /home/vscode/.terraform.cache/vvd/modules/solution/modules/recovery_vault/private_endpoints.tf line 19, in module "private_endpoint":
│   19:   base_tags           = local.tags
│ 
│ The given value is not suitable for module.solution.module.recovery_vaults["asr1"].module.private_endpoint["prv1"].var.base_tags declared at /home/vscode/.terraform.cache/vvd/modules/solution/modules/networking/private_endpoint/variables.tf:27,1-21: bool required.
╵
```

## Does this introduce a breaking change

- [ ] YES
- [x] NO
