### PR TITLE
Add ip_configuration block to private endpoints

### DIFF
--- a/.github/workflows/standalone-networking.json
+++ b/.github/workflows/standalone-networking.json
@@ -22,6 +22,7 @@
     "networking/pip_prefix/100-simple-pip-prefix",
     "networking/private_dns_vnet_link/100_pvtdns_vnetlink",
     "networking/private_dns/100-private-dns-vnet-links",
+    "networking/private_endpoint",
     "networking/private_links/endpoints/centralized",
     "networking/virtual_network/100-import-rg",
     "networking/virtual_network/100-simple-vnet-subnets-nsgs",

--- a/examples/networking/private_endpoint/README.md
+++ b/examples/networking/private_endpoint/README.md
@@ -1,0 +1,19 @@
+You can test this module outside of a landingzone using
+
+```bash
+sudo terraform init
+
+terraform [plan|apply|destroy] \
+  -var-file ../configuration.tfvars \
+  -var-file ../keyvaults.tfvars \
+  -var-file ../nsg_definitions.tfvars \
+  -var-file ../virtual_networks.tfvars \
+  -var-file ../public_ip_addresses.tfvars \
+  -var-file ../virtual_machines.tfvars
+
+
+```
+
+sudo terraform plan -var-file examples/networking/private_endpoint/configuration.tfvars
+
+sudo terraform plan -var-file configuration.tfvars

--- a/examples/networking/private_endpoint/configuration.tfvars
+++ b/examples/networking/private_endpoint/configuration.tfvars
@@ -1,0 +1,29 @@
+
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "southeastasia"
+  }
+}
+
+name = "stgtest"
+
+resource_group_name = "my-rg"
+location            = "australiaeast"
+
+subnet_id = "/subscriptions/.../some/subnet/id"
+
+settings = {
+  private_service_connection = {
+    name                 = "stgtest"
+    is_manual_connection = false
+    subresource_names    = ["blob"]
+  }
+
+  ip_configuration = {
+    name               = "pep-name"
+    private_ip_address = "192.168.1.10"
+    subresource_name   = "Blob"
+    member_name        = "Blob"
+  }
+}

--- a/examples/networking/private_endpoint/configuration.tfvars
+++ b/examples/networking/private_endpoint/configuration.tfvars
@@ -55,7 +55,7 @@ keyvaults = {
 
         ip_configuration = {
           name               = "kv01_rg1-name"
-          private_ip_address = "10.150.100.70"
+          private_ip_address = "10.150.100.140"
           subresource_name   = "vault"
           member_name        = "default"
         }

--- a/examples/networking/private_endpoint/configuration.tfvars
+++ b/examples/networking/private_endpoint/configuration.tfvars
@@ -53,11 +53,19 @@ keyvaults = {
           subresource_names    = ["vault"]
         }
 
-        ip_configuration = {
-          name               = "kv01_rg1-name"
-          private_ip_address = "10.150.100.140"
-          subresource_name   = "vault"
-          member_name        = "default"
+        ip_configurations = {
+          static1= {          
+            name               = "kv01_rg1-name1"
+            private_ip_address = "10.150.100.140"
+            subresource_name   = "vault"
+            member_name        = "default"
+          }
+          static2 = {
+            name               = "kv01_rg1-name2"
+            private_ip_address = "10.150.100.150"
+            subresource_name   = "vault"
+            member_name        = "default2"
+          }
         }
 
         # private_dns = {

--- a/examples/networking/private_endpoint/configuration.tfvars
+++ b/examples/networking/private_endpoint/configuration.tfvars
@@ -15,7 +15,7 @@ resource_groups = {
 keyvaults = {
 
   #
-  # Keyvault with private endpoint enabled and configured with a static ip
+  # Keyvault with private endpoint enabled and configured with two static ips
   #
   kv01_rg1 = {
     name               = "certificates"

--- a/examples/networking/private_endpoint/configuration.tfvars
+++ b/examples/networking/private_endpoint/configuration.tfvars
@@ -1,29 +1,92 @@
-
 global_settings = {
   default_region = "region1"
   regions = {
-    region1 = "southeastasia"
+    region1 = "australiaeast"
   }
 }
 
-name = "stgtest"
-
-resource_group_name = "my-rg"
-location            = "australiaeast"
-
-subnet_id = "/subscriptions/.../some/subnet/id"
-
-settings = {
-  private_service_connection = {
-    name                 = "stgtest"
-    is_manual_connection = false
-    subresource_names    = ["blob"]
+resource_groups = {
+  kv_region1 = {
+    name   = "keyvault-rg1"
+    region = "region1"
   }
+}
 
-  ip_configuration = {
-    name               = "pep-name"
-    private_ip_address = "192.168.1.10"
-    subresource_name   = "Blob"
-    member_name        = "Blob"
+keyvaults = {
+
+  #
+  # Keyvault with private endpoint enabled and configured with a static ip
+  #
+  kv01_rg1 = {
+    name               = "certificates"
+    resource_group_key = "kv_region1"
+    sku_name           = "premium"
+
+    creation_policies = {
+      logged_in_user = {
+        secret_permissions      = ["Set", "Get", "List", "Delete", "Purge"]
+        certificate_permissions = ["ManageContacts", "ManageIssuers"]
+      }
+    }
+
+    network = {
+      bypass         = "AzureServices"
+      default_action = "Deny"
+    }
+
+    private_endpoints = {
+      # Require enforce_private_link_endpoint_network_policies set to true on the subnet
+      private-link1 = {
+        name               = "keyvault-certificates"
+        vnet_key           = "vnet_security"
+        subnet_key         = "private_link"
+        resource_group_key = "kv_region1"
+        # if the private_endpoint must be deployed in a remote resource group
+        # resource_group = {
+        #   lz_key = ""
+        #   key    = ""
+        # }
+
+        private_service_connection = {
+          name                 = "keyvault-certificates"
+          is_manual_connection = false
+          subresource_names    = ["vault"]
+        }
+
+        ip_configuration = {
+          name               = "kv01_rg1-name"
+          private_ip_address = "10.150.100.70"
+          subresource_name   = "vault"
+          member_name        = "default"
+        }
+
+        # private_dns = {
+        #   lz_key = ""
+        #   keys   = ["vaultcore"]
+        # }
+      }
+    }
+  }
+}
+
+vnets = {
+  vnet_security = {
+    resource_group_key = "kv_region1"
+    vnet = {
+      name          = "keyvaults"
+      address_space = ["10.150.100.0/24"]
+    }
+    subnets = {
+      keyvault_endpoints = {
+        name              = "keyvault"
+        cidr              = ["10.150.100.64/26"]
+        service_endpoints = ["Microsoft.KeyVault"]
+      }
+      private_link = {
+        name                                           = "private-links"
+        cidr                                           = ["10.150.100.128/26"]
+        enforce_private_link_endpoint_network_policies = true
+      }
+    }
   }
 }

--- a/modules/networking/private_endpoint/private_endpoint.tf
+++ b/modules/networking/private_endpoint/private_endpoint.tf
@@ -43,7 +43,7 @@ resource "azurerm_private_endpoint" "pep" {
   }
 
   dynamic "ip_configuration" {
-    for_each = can(var.settings.ip_configuration) ? [var.settings.ip_configuration] : []
+    for_each = try(var.settings.ip_configurations, {})
 
     content {
       name               = ip_configuration.value.name

--- a/modules/networking/private_endpoint/private_endpoint.tf
+++ b/modules/networking/private_endpoint/private_endpoint.tf
@@ -42,4 +42,13 @@ resource "azurerm_private_endpoint" "pep" {
     }
   }
 
+  dynamic "ip_configuration" {
+    for_each = can(var.settings.ip_configuration) ? [var.settings.ip_configuration] : []
+
+    content {
+      name = lookup(ip_configuration.value, "name")
+      private_ip_address = ip_configuration.value.private_ip_address
+    }
+  }  
+
 }

--- a/modules/networking/private_endpoint/private_endpoint.tf
+++ b/modules/networking/private_endpoint/private_endpoint.tf
@@ -49,7 +49,7 @@ resource "azurerm_private_endpoint" "pep" {
       name               = ip_configuration.value.name
       private_ip_address = ip_configuration.value.private_ip_address
       subresource_name   = lookup(ip_configuration.value, "subresource_name", null)
-      member_name        = lookup(ip_configuration.value, "member_name ", null)
+      member_name        = lookup(ip_configuration.value, "member_name", null)
     }
   }
 

--- a/modules/networking/private_endpoint/private_endpoint.tf
+++ b/modules/networking/private_endpoint/private_endpoint.tf
@@ -46,11 +46,11 @@ resource "azurerm_private_endpoint" "pep" {
     for_each = can(var.settings.ip_configuration) ? [var.settings.ip_configuration] : []
 
     content {
-      name = ip_configuration.value.name
+      name               = ip_configuration.value.name
       private_ip_address = ip_configuration.value.private_ip_address
-      subresource_name = lookup(ip_configuration.value, "subresource_name", null)
-      member_name  = lookup(ip_configuration.value, "member_name ", null)
+      subresource_name   = lookup(ip_configuration.value, "subresource_name", null)
+      member_name        = lookup(ip_configuration.value, "member_name ", null)
     }
-  }  
+  }
 
 }

--- a/modules/networking/private_endpoint/private_endpoint.tf
+++ b/modules/networking/private_endpoint/private_endpoint.tf
@@ -46,8 +46,10 @@ resource "azurerm_private_endpoint" "pep" {
     for_each = can(var.settings.ip_configuration) ? [var.settings.ip_configuration] : []
 
     content {
-      name = lookup(ip_configuration.value, "name")
+      name = ip_configuration.value.name
       private_ip_address = ip_configuration.value.private_ip_address
+      subresource_name = lookup(ip_configuration.value, "subresource_name", null)
+      member_name  = lookup(ip_configuration.value, "member_name ", null)
     }
   }  
 


### PR DESCRIPTION
# [Issue-1689](https://github.com/aztfmod/terraform-azurerm-caf/issues/1689)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [X] I have added example(s) inside the [./examples/] folder
- [X] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [X] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [X] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Currently, it is not possible to define a static IP-address for private endpoints by defining the `ip_configuration` block, which is supported in the [Private-Endpoint Terraform Resource >3.21.0](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.0/docs/resources/private_endpoint#ip_configuration).
This PR enables reading the `ip_configuration` from the settings property.

## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
