### PR TITLE
Fix: Ability to add a member to a group located in a different landin…

### DIFF
--- a/azuread_groups.tf
+++ b/azuread_groups.tf
@@ -41,7 +41,7 @@ module "azuread_groups_membership" {
   client_config              = local.client_config
   group_key                  = each.key
   settings                   = each.value
-  group_id                   = try(module.azuread_groups[each.key].id, local.combined_objects_azuread_groups[each.value.group_lz_key][each.key].id)
+  group_id                   = try(module.azuread_groups[each.key].id, local.combined_objects_azuread_groups[each.value.group_lz_key][each.key].id, null)
   azuread_groups             = local.combined_objects_azuread_groups
   azuread_service_principals = local.combined_objects_azuread_service_principals
   managed_identities         = local.combined_objects_managed_identities


### PR DESCRIPTION
There is regression since the following PR https://github.com/aztfmod/terraform-azurerm-caf/pull/1164
This fix has been proposed by @arne21a in the PR link above but never been implemented.

## Description

Unable to add a member in an azure AD group located on a different landing zone
The following example used to work:

```
azuread_groups_membership = {
  caf_purview_service_accounts = { # ad group key
    managed_identities = {
      management_purview_identity = {
        group_lz_key = "identity"
        keys   = ["management_purview_identity"]
      }
    }
  }
}

```

Here is the error returned:
```
 Error: Error in function call
│
│   on /home/vscode/.terraform.cache/pildev/rover_jobs/20230711140815095838079/modules/solution/azuread_groups.tf line 44, in module "azuread_groups_membership":
│   44:   group_id                   = try(module.azuread_groups[each.key].id, local.combined_objects_azuread_groups[each.value.group_lz_key][each.key].id)
│     ├────────────────
│     │ while calling try(expressions...)
│     │ each.key is "caf_purview_service_accounts"
│     │ each.value is object with 1 attribute "managed_identities"
│     │ local.combined_objects_azuread_groups is object with 5 attributes
│     │ module.azuread_groups is object with no attributes
│
│ Call to function "try" failed: no expression succeeded:
│ - Invalid index (at /home/vscode/.terraform.cache/pildev/rover_jobs/20230711140815095838079/modules/solution/azuread_groups.tf:44,57-67)
│   The given key does not identify an element in this collection value.
│ - Unsupported attribute (at /home/vscode/.terraform.cache/pildev/rover_jobs/20230711140815095838079/modules/solution/azuread_groups.tf:44,120-133)
│   This object does not have an attribute named "group_lz_key".
│
│ At least one expression must produce a successful result.
```

## Does this introduce a breaking change

- [ ] YES
- [x ] NO


