### PR TITLE
Add sftp_enabled argument for storage account

### DIFF
--- a/examples/storage_accounts/102-storage-account-advanced-options/configuration.tfvars
+++ b/examples/storage_accounts/102-storage-account-advanced-options/configuration.tfvars
@@ -22,6 +22,7 @@ storage_accounts = {
     min_tls_version          = "TLS1_2"    # Possible values are TLS1_0, TLS1_1, and TLS1_2. Defaults to TLS1_0 for new storage accounts.
     allow_blob_public_access = false
     is_hns_enabled           = false
+    sftp_enabled             = false       #SFTP support requires is_hns_enabled set to true
 
     # Enable this block, if you have a valid domain name
     # custom_domain = {

--- a/modules/storage_account/storage_account.tf
+++ b/modules/storage_account/storage_account.tf
@@ -32,7 +32,7 @@ resource "azurerm_storage_account" "stg" {
   location                          = local.location
   min_tls_version                   = try(var.storage_account.min_tls_version, "TLS1_2")
   is_hns_enabled                    = try(var.storage_account.is_hns_enabled, false)
-  sftp_enabled                      = try(var.storage_account.sftp_enabled, false)
+  sftp_enabled                      = try(var.storage_account.sftp_enabled, null)
   nfsv3_enabled                     = try(var.storage_account.nfsv3_enabled, false)
   queue_encryption_key_type         = try(var.storage_account.queue_encryption_key_type, null)
   resource_group_name               = local.resource_group_name

--- a/modules/storage_account/storage_account.tf
+++ b/modules/storage_account/storage_account.tf
@@ -32,6 +32,7 @@ resource "azurerm_storage_account" "stg" {
   location                          = local.location
   min_tls_version                   = try(var.storage_account.min_tls_version, "TLS1_2")
   is_hns_enabled                    = try(var.storage_account.is_hns_enabled, false)
+  sftp_enabled                      = try(var.storage_account.sftp_enabled, false)
   nfsv3_enabled                     = try(var.storage_account.nfsv3_enabled, false)
   queue_encryption_key_type         = try(var.storage_account.queue_encryption_key_type, null)
   resource_group_name               = local.resource_group_name


### PR DESCRIPTION
## PR Checklist

---

- [x] I have added example(s) inside the [./examples/] folder
- [x] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Add sftp support on storage account

## Does this introduce a breaking change

- [ ] YES
- [x] NO

## Testing

```
global_settings = {
  default_region = "region1"
  regions = {
    region1 = "australiaeast"
  }
}

resource_groups = {
  test = {
    name = "test"
  }
}

# https://docs.microsoft.com/en-us/azure/storage/
storage_accounts = {
  sa1 = {
    name                     = "sa1dev"
    resource_group_key       = "test"
    account_kind             = "StorageV2" #Valid options are BlobStorage, BlockBlobStorage, FileStorage, Storage and StorageV2. Defaults to StorageV2
    account_tier             = "Standard"  #Valid options are Standard and Premium. For BlockBlobStorage and FileStorage accounts only Premium is valid
    account_replication_type = "LRS"       # https://docs.microsoft.com/en-us/azure/storage/common/storage-redundancy
    min_tls_version          = "TLS1_2"    # Possible values are TLS1_0, TLS1_1, and TLS1_2. Defaults to TLS1_0 for new storage accounts.
    allow_blob_public_access = false
    is_hns_enabled           = true
    sftp_enabled             = true       #SFTP support requires is_hns_enabled set to true

    # Enable this block, if you have a valid domain name
    # custom_domain = {
    #   name          = "any-valid-domain.name" #will be validated by Azure
    #   use_subdomain = true
    # }

    enable_system_msi = {
      type = "SystemAssigned"
    }

    blob_properties = {
      cors_rule = {
        # https://docs.microsoft.com/en-us/rest/api/storageservices/cross-origin-resource-sharing--cors--support-for-the-azure-storage-services
        allowed_headers    = ["x-ms-meta-data*", "x-ms-meta-target*", "x-ms-meta-abc"]
        allowed_methods    = ["POST", "GET"]
        allowed_origins    = ["http://www.contoso.com", "http://www.fabrikam.com"]
        exposed_headers    = ["x-ms-meta-*"]
        max_age_in_seconds = "200"
      }
    }

    delete_retention_policy = {
      days = "7"
    }

    # queue_properties = {
    #   cors_rule = {
    #     # https://docs.microsoft.com/en-us/rest/api/storageservices/cross-origin-resource-sharing--cors--support-for-the-azure-storage-services
    #     allowed_headers    = ["x-ms-meta-data*", "x-ms-meta-target*", "x-ms-meta-abc"]
    #     allowed_methods    = ["POST", "GET"]
    #     allowed_origins    = ["http://www.contoso.com", "http://www.fabrikam.com"]
    #     exposed_headers    = ["x-ms-meta-*"]
    #     max_age_in_seconds = "200"
    #   }
    # }

    logging = {
      delete                = true
      read                  = true
      write                 = true
      version               = true
      retention_policy_days = "7"
    }

    minute_metrics = {
      enabled               = true
      version               = true
      include_apis          = true
      retention_policy_days = "7"
    }

    hour_metrics = {
      enabled               = true
      version               = true
      include_apis          = true
      retention_policy_days = "7"
    }

    static_website = { # supported only with BlockBlobStorage and StorageV2
      index_document     = "index.html"
      error_404_document = "error.html"
    }

    tags = {
      environment = "dev"
      team        = "IT"
    }
    containers = {
      dev = {
        name = "random"
      }
    }
  }
}
```


