### PR TITLE
Update configv1.tfvars for 200-mi-two-regions example

### DIFF
--- a/examples/mssql_mi/200-mi-two-regions/configv1.tfvars
+++ b/examples/mssql_mi/200-mi-two-regions/configv1.tfvars
@@ -125,7 +125,7 @@ mssql_managed_instances = {
   sqlmi1 = {
     version = "v1"
     resource_group = {
-      key = "sqlmi_re1"
+      key = "sqlmi_region1"
     }
     name                = "lz-sql-mi-aztf"
     administrator_login = "adminuser"
@@ -155,7 +155,7 @@ mssql_managed_instances = {
     minimal_tls_version = "1.2"
     //networking
     networking = {
-      vnet_key   = "sqlmi_region1"
+      vnet_key   = "sqlmi_re1"
       subnet_key = "sqlmi1"
     }
     #proxy_override               = "Redirect"
@@ -215,8 +215,8 @@ mssql_managed_instances_secondary = {
     minimal_tls_version = "1.2"
     //networking
     networking = {
-      vnet_key   = "sqlmi_region1"
-      subnet_key = "sqlmi1"
+      vnet_key   = "sqlmi_region2"
+      subnet_key = "sqlmi2"
     }
     #proxy_override               = "Redirect"
     identity = {
@@ -309,18 +309,20 @@ managed_identities = {
 # }
 
 mssql_mi_failover_groups = {
-  failover-mi = {
+  sqlmi1_sqlmi2 = {
+    version            = "v1"
     resource_group_key = "sqlmi_region1"
-    name               = "failover-test"
+    name               = "sqlmi1-sqlmi2"
     primary_server = {
       mi_server_key = "sqlmi1"
     }
     secondary_server = {
       mi_server_key = "sqlmi2"
     }
-    readWriteEndpoint = {
-      failoverPolicy                         = "Automatic"
-      failoverWithDataLossGracePeriodMinutes = 60
+    readonly_endpoint_failover_policy_enabled = false
+    read_write_endpoint_failover_policy = {
+      mode          = "Automatic"
+      grace_minutes = 60
     }
   }
 }


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Updated correct values for *resource_group* key and *vnet_key* for mssql_managed_instances, *vnet_key* and *subnet_key* for *mssql_managed_instances_secondary* and updated *mssql_mi_failover_groups* to use v1, otherwise plan will fail.

## Does this introduce a breaking change

- [ ] YES
- [x ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
