### PR TITLE
Fixed custom script location priority (remote must be first)

### DIFF
--- a/modules/compute/virtual_machine_extensions/custom_script.tf
+++ b/modules/compute/virtual_machine_extensions/custom_script.tf
@@ -69,10 +69,9 @@ locals {
   protected_settings = merge(local.map_command, local.system_assigned_id, local.user_assigned_id)
 
   # fileuris
-  fileuri_sa_key  = try(var.extension.fileuri_sa_key, "")
-  fileuri_sa_path = try(var.extension.fileuri_sa_path, "")
-  fileuri_sa = local.fileuri_sa_key != "" ? try(var.storage_accounts[var.client_config.landingzone_key][var.extension.fileuri_sa_key].primary_blob_endpoint,
-  var.storage_accounts[var.extension.lz_key][var.extension.fileuri_sa_key].primary_blob_endpoint) : ""
+  fileuri_sa_key       = try(var.extension.fileuri_sa_key, "")
+  fileuri_sa_path      = try(var.extension.fileuri_sa_path, "")
+  fileuri_sa           = local.fileuri_sa_key != "" ? try(var.storage_accounts[var.extension.lz_key][var.extension.fileuri_sa_key].primary_blob_endpoint, var.storage_accounts[var.client_config.landingzone_key][var.extension.fileuri_sa_key].primary_blob_endpoint) : ""
   fileuri_sa_full_path = "${local.fileuri_sa}${local.fileuri_sa_path}"
   fileuri_sa_defined   = try(var.extension.fileuris, "")
   fileuris             = local.fileuri_sa_defined == "" ? [local.fileuri_sa_full_path] : var.extension.fileuris


### PR DESCRIPTION
## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Currently, we look for the custom script filepath inside the current landingzone first, so if we try to access a remote storage account with the same key as a local storage account, it will get ignored and the local one is picked. This PR puts the remote storage first.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
