### PR TITLE
Add CAF support for Centralized DNS Architecture. Source DNS Resolver…

### DIFF
--- a/examples/networking/virtual_network/104-vnet-dns-by-resolver/readme.md
+++ b/examples/networking/virtual_network/104-vnet-dns-by-resolver/readme.md
@@ -1,0 +1,15 @@
+# VNET with Centraliced DNS Architecture
+
+This example shows how to deploy a VNET with a centralized DNS architecture. The DNS architecture is based on the following article: https://learn.microsoft.com/en-us/azure/dns/private-resolver-architecture
+
+This example require a 2-step deployment:
+
+### Step1 deploy:
+  - The Hub VNET
+  - The DNS Resolver
+  - The Inbound DNS Resolver endpoint  
+  
+### Step2 deploy:
+  - The Spoke VNET
+  - Hub and Spoke VNET peering
+  - The custom DNS server from the DNS Inbound Resolver endpoint output in step1

--- a/examples/networking/virtual_network/104-vnet-dns-by-resolver/step1_vnet_hub_dns_resolver/configuration.tfvars
+++ b/examples/networking/virtual_network/104-vnet-dns-by-resolver/step1_vnet_hub_dns_resolver/configuration.tfvars
@@ -1,0 +1,67 @@
+
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "norwayeast"
+  }
+  passthrough = true
+}
+
+resource_groups = {
+  vnet_hub_re1 = {
+    name   = "vnet-hub-re1"
+    region = "region1"
+  }
+}
+
+private_dns_resolvers = {
+  dns_resolver1 = {
+    name               = "resolver1"
+    resource_group_key = "vnet_hub_re1"
+    region             = "norwayeast"
+    vnet = {
+      #lz_key = ""
+      key = "vnet_hub"
+      #id = ""
+    }
+  }
+}
+
+private_dns_resolver_inbound_endpoints = {
+  inbound_endpoint1 = {
+    name = "inbound-endpint1"
+    private_dns_resolver = {
+      key = "dns_resolver1"
+      #lz_key = ""
+    }
+    ip_configurations = {
+      ip_config1 = {
+        #subnet_id=""
+        vnet = {
+          # lz_key        = "examples"
+          key = "vnet_hub"
+          #id = ""
+          subnet_key = "dns_inbound"
+        }
+      }
+    }
+  }
+}
+
+vnets = {
+  vnet_hub = {
+    resource_group_key = "vnet_hub_re1"
+    vnet = {
+      name          = "virtual_machines"
+      address_space = ["10.100.100.0/24"]
+    }
+    specialsubnets = {}
+    subnets = {
+      dns_inbound = {
+        name = "dns_inbound"
+        cidr = ["10.100.100.0/28"]
+      }
+    }
+  }
+}
+

--- a/examples/networking/virtual_network/104-vnet-dns-by-resolver/step1_vnet_hub_dns_resolver/landingzone.tfvars
+++ b/examples/networking/virtual_network/104-vnet-dns-by-resolver/step1_vnet_hub_dns_resolver/landingzone.tfvars
@@ -1,0 +1,5 @@
+landingzone = {
+  backend_type        = "azurerm"
+  level               = "level2"
+  key                 = "examples_vnet_hub"
+}

--- a/examples/networking/virtual_network/104-vnet-dns-by-resolver/step2_vnet_spoke/configuration.tfvars
+++ b/examples/networking/virtual_network/104-vnet-dns-by-resolver/step2_vnet_spoke/configuration.tfvars
@@ -1,0 +1,67 @@
+resource_groups = {
+  vnet_spoke_re1 = {
+    name   = "vnet-spoke-re1"
+    region = "region1"
+  }
+}
+
+vnets = {
+  vnet_spoke = {
+    resource_group_key = "vnet_spoke_re1"
+    vnet = {
+      name          = "virtual_machines"
+      address_space = ["10.100.101.0/24"]
+
+      dns_servers_keys = {
+        dns_server_1 = {
+          resource_type = "private_dns_resolver"
+          lz_key        = "examples_vnet_hub"
+          key           = "inbound_endpoint1"
+        }
+      }
+
+    }
+    specialsubnets = {}
+    subnets = {
+      example = {
+        name = "examples"
+        cidr = ["10.100.101.0/29"]
+      }
+    }
+
+  }
+}
+
+vnet_peerings_v1 = {
+  spoke_TO_hub = {
+    name = "spoke-TO-hub"
+    from = {
+      vnet_key = "vnet_spoke"
+      # lz_key        = "examples"
+    }
+    to = {
+      vnet_key = "vnet_hub"
+      lz_key        = "examples_vnet_hub"
+    }
+    allow_virtual_network_access = true
+    allow_forwarded_traffic      = false
+    allow_gateway_transit        = false
+    use_remote_gateways          = false
+  }
+
+  hub_TO_spoke = {
+    name = "hub-TO-spoke"
+    from = {
+      vnet_key = "vnet_hub"
+      lz_key        = "examples_vnet_hub"
+    }
+    to = {
+      vnet_key = "vnet_spoke"
+      # lz_key        = "examples"
+    }
+    allow_virtual_network_access = false
+    allow_forwarded_traffic      = false
+    allow_gateway_transit        = false
+    use_remote_gateways          = false
+  }
+}

--- a/examples/networking/virtual_network/104-vnet-dns-by-resolver/step2_vnet_spoke/landingzone.tfvars
+++ b/examples/networking/virtual_network/104-vnet-dns-by-resolver/step2_vnet_spoke/landingzone.tfvars
@@ -1,0 +1,13 @@
+landingzone = {
+  backend_type        = "azurerm"
+  level               = "level2"
+  key                 = "examples_vnet_spoke"
+  global_settings_key = "examples_vnet_hub"
+  tfstates = {
+    examples_vnet_hub = {
+      tfstate   = "examples_vnet_hub.tfstate"
+      workspace = "tfstate"
+      level     = "current"
+    }
+  }
+}

--- a/modules/networking/virtual_network/module.tf
+++ b/modules/networking/virtual_network/module.tf
@@ -139,6 +139,11 @@ locals {
       for obj in try(var.settings.vnet.dns_servers_keys, {}) :
       var.remote_dns.virtual_machines[obj.lz_key][obj.key].ip_configuration[obj.nic_key].private_ip_addresses
       if contains(["virtual_machines", "virtual_machine"], obj.resource_type)
+    ],
+    [
+      for obj in try(var.settings.vnet.dns_servers_keys, {}) :
+      var.remote_dns.private_dns_resolver_inbound_endpoints[obj.lz_key][obj.key].private_ip_address
+      if contains(["private_dns_resolver_inbound_endpoints", "private_dns_resolver_inbound_endpoint","private_dns_resolver"], obj.resource_type)
     ]
   )
 }


### PR DESCRIPTION
Add support for VNET with Centraliced DNS Architecture

This update with example shows how to deploy a VNET with a centralized DNS architecture. The DNS architecture is based on the following article: https://learn.microsoft.com/en-us/azure/dns/private-resolver-architecture

This example requires a 2-step deployment:

### Step1 deploy:
  - The Hub VNET
  - The DNS Resolver
  - The Inbound DNS Resolver endpoint  
  
### Step2 deploy:
  - The Spoke VNET
  - Hub and Spoke VNET peering
  - The custom DNS server from the DNS Inbound Resolver endpoint output in step1

# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [X] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [X] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [X] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
