### PR TITLE
Fix webhook_url logic, variable should not be required

### DIFF
--- a/modules/compute/virtual_machine/shutdown_schedule.tf
+++ b/modules/compute/virtual_machine/shutdown_schedule.tf
@@ -12,6 +12,6 @@ resource "azurerm_dev_test_global_vm_shutdown_schedule" "enabled" {
     enabled         = try(var.settings.shutdown_schedule.notification_settings.enabled, null)
     time_in_minutes = try(var.settings.shutdown_schedule.notification_settings.time_in_minutes, null)
     email           = try(var.settings.shutdown_schedule.notification_settings.email, null)
-    webhook_url     = try(var.settings.shutdown_schedule.notification_settings.enabled, false) ? var.settings.shutdown_schedule.notification_settings.webhook_url : try(var.settings.shutdown_schedule.notification_settings.webhook_url, null)
+    webhook_url     = try(var.settings.shutdown_schedule.notification_settings.enabled, false) ? try(var.settings.shutdown_schedule.notification_settings.webhook_url, null) : null
   }
 }


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

webhook_url logic make the variable required, should not be required in tfvars.

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [X] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [X] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
