### PR TITLE
fix: source and source_content parsing

### DIFF
--- a/examples/storage_container/101-storage_container/configuration.tfvars
+++ b/examples/storage_container/101-storage_container/configuration.tfvars
@@ -5,6 +5,8 @@ global_settings = {
   }
 }
 
+var_folder_path = "storage_container/101-storage_container"
+
 resource_groups = {
   test = {
     name = "rg1"

--- a/modules/storage_account/blob/module.tf
+++ b/modules/storage_account/blob/module.tf
@@ -34,13 +34,11 @@ resource "random_id" "md5" {
 locals {
   md5_content = local.source != null ? filebase64sha512(local.source) : sha512(local.source_content)
 
-  source = can(var.settings.source) || can(fileexists(format("%s/%s", var.var_folder_path, var.settings.source))) ? try(
-    format("%s/%s", var.var_folder_path, var.settings.source),
-    var.settings.source
-  ) : null
+  _source_var_folder_path = can(format("%s/%s", var.var_folder_path, var.settings.source)) ? fileexists(format("%s/%s", var.var_folder_path, var.settings.source)) ? format("%s/%s", var.var_folder_path, var.settings.source) : null : null
 
-  source_content = can(var.settings.source_content) || can(fileexists(format("%s/%s", var.var_folder_path, var.settings.source_content))) ? try(
-    file(format("%s/%s", var.var_folder_path, var.settings.source_content)),
-    var.settings.source_content
-  ) : null
+  _source_direct = can(var.settings.source) ? var.settings.source : null
+
+  source = can(coalesce(local._source_var_folder_path, local._source_direct)) ? coalesce(local._source_var_folder_path, local._source_direct) : null
+
+  source_content = can(var.settings.source_content) ? var.settings.source_content : null
 }


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/1761)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

azurerm_storage_blob creation was failing, when var_folder_path is set to "" ( which is the default )

Splitting up the file checks for var_folder_path and without var_folder_path. Checking for the existence of a file using var.var_folder_path/var.settings.source, otherwise using var.settings.source if set.

Removed fileexists check from source_content, as source_content is not meant to hold a file system path.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
