### PR TITLE
Added owners argument for spn

### DIFF
--- a/modules/azuread/applications/module.tf
+++ b/modules/azuread/applications/module.tf
@@ -113,6 +113,9 @@ resource "azuread_service_principal" "app" {
   application_id               = azuread_application.app.application_id
   app_role_assignment_required = try(var.settings.app_role_assignment_required, false)
   tags                         = try(var.settings.tags, null)
+  owners = [
+    var.client_config.object_id
+  ]
 }
 
 resource "azuread_service_principal_password" "pwd" {


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/1723)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

azuread_service_principal  does not have owners argument defined. It can't rotate (delete and create) credentials as the user/identity created the SPN does not have ownership of that and if try to add that (ownership) manually it would delete that in the next run.
The password rotation works if use Application Administrator privileges which obviously is not according to least privilege model.
<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
