### PR TITLE
Add variable types for VWAN Hub Module

### DIFF
--- a/modules/networking/virtual_wan/virtual_hub/variables.tf
+++ b/modules/networking/virtual_wan/virtual_hub/variables.tf
@@ -6,10 +6,24 @@ variable "prefix" {
 
 variable "global_settings" {
   description = "global settings"
+  // Only set keys required in this module
+  type = object({
+    use_slug = optional(bool)
+    random_length = optional(number)
+    prefixes = optional(list(string))
+    passthrough = optional(bool)
+  })
 }
 
 variable "virtual_hub_config" {
   description = "core_networking"
+  type = object({
+    hub_name = string
+    firewall_name = optional(string)
+    p2s_config = optional(any)
+    s2s_config = optional(any)
+    er_config = optional(any)
+  })
 }
 
 variable "location" {


### PR DESCRIPTION
Allow passing in TF variables as environment-variables. This is an incremental specification of the `global_settings`, thereby helping to reduce type-mismatches between dependent modules.

# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
