### PR TITLE
- support private endpoint using private link resource alias

### DIFF
--- a/examples/networking/private_links/endpoints/external_resource/configuration.tfvars
+++ b/examples/networking/private_links/endpoints/external_resource/configuration.tfvars
@@ -1,0 +1,18 @@
+private_endpoints = {
+  ingress_test = {  
+    #lz_key     = ""
+    vnet_key   = "vnet"
+    subnet_keys = ["private_endpoints"]
+    external_resources = {
+      ingress_link = {
+        name       = "aks-ingress"
+        resource_group_key = "rg"
+        private_service_connection = {
+          name                 = "aks-ingress-psc"
+          is_manual_connection = false
+          resource_alias = "somerandomlink.westeurope.azure.privatelinkservice"
+        }
+      }
+    }
+  }
+}

--- a/modules/networking/private_links/endpoints/private_endpoint/private_endpoint.tf
+++ b/modules/networking/private_links/endpoints/private_endpoint/private_endpoint.tf
@@ -20,9 +20,10 @@ resource "azurerm_private_endpoint" "pep" {
 
   private_service_connection {
     name                           = format("%s-%s", var.settings.private_service_connection.name, replace(each.key, " ", "-"))
-    private_connection_resource_id = var.resource_id
+    private_connection_resource_id = each.key == "external_resources" ? null : var.resource_id
+    private_connection_resource_alias = each.key == "external_resources" ? var.settings.private_service_connection.resource_alias : null
     is_manual_connection           = try(var.settings.private_service_connection.is_manual_connection, false)
-    subresource_names              = [each.key]
+    subresource_names              = each.key == "external_resources" ? [] : [each.key]
     request_message                = try(var.settings.private_service_connection.request_message, null)
   }
 

--- a/modules/networking/private_links/endpoints/subnet/external_resources.tf
+++ b/modules/networking/private_links/endpoints/subnet/external_resources.tf
@@ -1,0 +1,17 @@
+module "external_resources" {
+  source = "../private_endpoint"
+  for_each = {
+    for key, value in try(var.private_endpoints.external_resources, {}) : key => value
+  }
+  global_settings     = var.global_settings
+  client_config       = var.client_config
+  settings            = each.value
+  resource_id         = null
+  subresource_names   = ["external_resources"]
+  subnet_id           = var.subnet_id
+  private_dns         = var.private_dns
+  name                = try(each.value.name, each.key)
+  resource_group_name = can(each.value.resource_group_key) ? var.resource_groups[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.resource_group_key].name : var.vnet_resource_group_name
+  location            = var.vnet_location # The private endpoint must be deployed in the same region as the virtual network.
+  base_tags           = var.base_tags
+}


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have added example(s) inside the [./examples/] folder
- [] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

I would like the possibility to create private endpoint external private link resources using private_connection_resource_alias. It is useful connect pls link created from aks annotations for example.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

an example added in the example folder. but I could not provide any valid private link resource alias to test.
