### PR TITLE
Fix SQL MI regressions

### DIFF
--- a/modules/databases/mssql_managed_database_v1/var/settings/srtdays.tf
+++ b/modules/databases/mssql_managed_database_v1/var/settings/srtdays.tf
@@ -1,9 +1,9 @@
 variable "short_term_retention_days" {
-  description = "short_term_retention_days .The backup retention period in days. This is how many days Point-in-Time Restore will be supported. Value must be atleast 1"
-  nullable    = false
+  description = "short_term_retention_days (Optional) .The backup retention period in days. This is how many days Point-in-Time Restore will be supported. Value must be atleast 1"
+  nullable    = true
 
   validation {
-    condition = var.short_term_retention_days >= 1
+    condition = var.short_term_retention_day == null ? true : var.short_term_retention_days >= 1
 
     error_message = format("Not supported value: '%s'. \nAdjust your configuration file with a supported value of 1 or more days", var.short_term_retention_days)
   }

--- a/modules/databases/mssql_managed_instance/managed_instance.tf
+++ b/modules/databases/mssql_managed_instance/managed_instance.tf
@@ -10,7 +10,7 @@ resource "azurecaf_name" "mssqlmi" {
 
 resource "azurerm_resource_group_template_deployment" "mssqlmi" {
 
-  name                = "mssqlmi"
+  name                = azurecaf_name.mssqlmi.result
   resource_group_name = var.resource_group_name
 
   template_content = file(local.arm_filename)


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

```hcl
resource "azurerm_resource_group_template_deployment" "mssqlmi" {
	      ~ id                  = "/subscriptions/xxxx/resourceGroups/yyyy/providers/Microsoft.Resources/deployments/sql-prd02" -> (known after apply)
	      ~ name                = "sql-prd02" -> "mssqlmi" # forces replacement
```
This PR addresses a regression that was forcing the SQL MI to be destroyed and recreated
It was also preventing multiple SQL mi instances to be deployed in the same resource group.

It also fixes in the SQL MI V1 a condition when short_term_retention_days is not set in the configuration file to create a SQL MI Database (V1)

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have added example(s) inside the [./examples/] folder
- [x] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
