### PR TITLE
Create before destroy for azuread

### DIFF
--- a/modules/azuread/applications/module.tf
+++ b/modules/azuread/applications/module.tf
@@ -128,7 +128,7 @@ resource "azuread_service_principal_password" "pwd" {
   }
 
   lifecycle {
-    create_before_destroy = false
+    #create_before_destroy = false
   }
 }
 

--- a/modules/azuread/credentials/password.tf
+++ b/modules/azuread/credentials/password.tf
@@ -11,7 +11,7 @@ resource "azuread_application_password" "key" {
   }
 
   lifecycle {
-    create_before_destroy = true
+    #create_before_destroy = true
   }
 }
 
@@ -28,7 +28,7 @@ resource "azuread_application_password" "key0" {
   }
 
   lifecycle {
-    create_before_destroy = true
+    #create_before_destroy = true
   }
 }
 
@@ -44,7 +44,7 @@ resource "azuread_application_password" "key1" {
   }
 
   lifecycle {
-    create_before_destroy = true
+    #create_before_destroy = true
   }
 }
 

--- a/modules/azuread/service_principal_password/module.tf
+++ b/modules/azuread/service_principal_password/module.tf
@@ -8,7 +8,7 @@ resource "azuread_service_principal_password" "pwd" {
   }
 
   lifecycle {
-    create_before_destroy = false
+    #create_before_destroy = false
   }
 }
 


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description
When renaming an existing NSG that is already associated with a subnet, the results of the apply shows creating first before destroying when the correct behavior is to destroy then create. This results in the apply failing with the error that complains that the subnet already exists and needs to be imported into Terraform for management.

aztfmod version is int-5.7.0 and terraform version is 1.4.6

 ```
│ Error: A resource with the ID "/subscriptions/xxxxx/resourceGroups/exampleRG1/providers/Microsoft.Network/virtualNetworks/xxxxx/subnets/xxxxxx" already exists - to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for "azurerm_subnet_network_security_group_association" for more information.
 ```

Commenting out the **create_before_destroy** in modules/azuread/credentials/password.tf , modules/azuread/service_principal_password/module.tf and modules/azuread/applications/module.tf helps to resolve the issue

The relevant code used is below. Just change the name of the NSG from **my_appgw_nsg** to another name, and do plan and apply to recreate the issue.

**main.tf**
 ```
terraform {
  required_providers {
    azurerm = {
      source = "hashicorp/azurerm"
    }
  }
}

provider "azurerm" {
  features {}
}

provider "azurerm" {
  features {}
  skip_provider_registration = true
  alias                      = "vhub"
}

module "caf" {
  # source = "aztfmod/caf/azurerm"
  # version = "~>5.5.0"
  # version = "5.7.0"
  source = "git::https://github.com/aztfmod/terraform-azurerm-caf.git?ref=int-5.7.0"

  providers = {
    azurerm.vhub = azurerm.vhub
  }

  global_settings = var.global_settings
  resource_groups = var.resource_groups
  networking = {
	vnets = var.vnets
	network_security_group_definition = var.network_security_group_definition
  }
}
 ```


**terraform.auto.tfvars**
 ```
global_settings = {
  default_region = "region1"
  regions = {
    region1 = "australiaeast"
  }
  passthrough = true
}

resource_groups = {
  ntwk = {
    name   = "exampleRG1"
    region = "region1"
  }
}

vnets = {
  earth = {
    resource_group_key = "ntwk"
    vnet = {
      name          = "earthvnet"
      address_space = ["10.0.0.0/16", "10.1.0.0/16"]
    }
    subnets = {

      appgw = {
        name    = "appgwsubnet"
        cidr    = ["10.0.0.0/24"]
        nsg_key = "appgw_nsg"
      }
    }
  }
}

network_security_group_definition = {
  appgw_nsg = {
    resource_group_key = "ntwk"
    name               = "my_appgw_nsg"

    nsg = [
      {
        name                         = "AllowIntraSubnetTraffic"
        priority                     = "4095"
        direction                    = "Inbound"
        access                       = "Allow"
        protocol                     = "*"
        source_port_range            = "*"
        destination_port_range       = "*"
        source_address_prefixes      = ["10.0.0.0/24"]
        destination_address_prefixes = ["10.0.0.0/24"]
      },
      {
        name                         = "DenyInterSubnetTraffic"
        priority                     = "4096"
        direction                    = "Inbound"
        access                       = "Deny"
        protocol                     = "*"
        source_port_range            = "*"
        destination_port_range       = "*"
        source_address_prefixes      = ["10.0.0.0/24", "10.1.0.0/24"]
        destination_address_prefixes = ["10.0.0.0/24", "10.1.0.0/24"]
      }
    ]
  }
}
 ```

**variables.tf**
 ```
variable "global_settings" {
  default = {}
}
variable "resource_groups" {
  default = {}
}
variable "vnets" {
  default = {}
}
variable "network_security_group_definition" {
  default = {}
}
 ```





<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [ ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
