### PR TITLE
Fix the keyvault request that gets password from keyvault by using valid uri 

### DIFF
--- a/keyvault_certificate_requests.tf
+++ b/keyvault_certificate_requests.tf
@@ -6,8 +6,9 @@ module "keyvault_certificate_requests" {
   depends_on = [module.keyvault_certificate_issuers, module.domain_name_registrations]
   source     = "./modules/security/keyvault_certificate_request"
   for_each   = local.security.keyvault_certificate_requests
-
+  
   keyvault_id               = can(each.value.keyvault_id) ? each.value.keyvault_id : local.combined_objects_keyvaults[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.keyvault_key].id
+  keyvault_uri              = can(each.value.keyvault_uri) ? each.value.keyvault_uri : local.combined_objects_keyvaults[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.keyvault_key].vault_uri
   cert_secret_name          = can(each.value.cert_secret_name) || can(each.value.cert_password_key) == false ? try(each.value.cert_secret_name, null) : var.security.dynamic_keyvault_secrets[each.value.keyvault_key][each.value.cert_password_key].secret_name
   certificate_issuers       = try(var.security.keyvault_certificate_issuers, {})
   settings                  = each.value

--- a/modules/security/keyvault_certificate_request/global_sign.tf
+++ b/modules/security/keyvault_certificate_request/global_sign.tf
@@ -5,7 +5,7 @@ data "external" "password" {
     "bash", "-c",
     format(
       "az keyvault secret show --id '%s'secrets/'%s' --query '{value: value}' -o json",
-      var.keyvault_id,
+      var.keyvault_uri,
       var.cert_secret_name
     )
   ]

--- a/modules/security/keyvault_certificate_request/output.tf
+++ b/modules/security/keyvault_certificate_request/output.tf
@@ -4,6 +4,9 @@ output "id" {
 output "keyvault_id" {
   value = var.keyvault_id
 }
+output "keyvault_uri" {
+  value = var.keyvault_uri
+}
 output "secret_id" {
   value = azurerm_key_vault_certificate.csr.secret_id
 }

--- a/modules/security/keyvault_certificate_request/variables.tf
+++ b/modules/security/keyvault_certificate_request/variables.tf
@@ -2,6 +2,7 @@ variable "certificate_issuers" {
   default = {}
 }
 variable "keyvault_id" {}
+variable "keyvault_uri" {}
 variable "settings" {}
 variable "domain_name_registrations" {
   default = {}


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/1742)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [X] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Code
```
keyvault_certificate_requests = {
  csr0 = {
    name         = "csr-with-globalsign"
    lz_key       = "cert_lz"
    keyvault_key = "cert_kv"

    # if issuer_key_or_name != self, then cert_secret_name is needed with (keyvault_uri or cert_password_key)
    cert_password_key = "kv-issuer-password-key"
    cert_secret_name  = "kv-issuer-password" # reference to keyvault secrets name 
    certificate_policy = {
      issuer_key_or_name  = "cert_kv_issuer_0"

      exportable          = true
      key_size            = 4096 // value can be 2048, 3072 or 4096
      key_type            = "RSA"
      reuse_key           = false
      renewal_action      = "AutoRenew"
      lifetime_percentage = 90
      # days_before_expiry  = 10
      content_type = "application/x-pkcs12" // application/x-pem-file
      x509_certificate_properties = {
        subject            = "CN=yourdomaingoeshere"
        validity_in_months = 1
        key_usage          = ["keyCertSign"]
        subject_alternative_names = {
          dns_names = []
          emails    = []
          upns      = []
        }
      }
    }
  }
}
```
