### PR TITLE
fix: Corrects and standardizes usage of account_lz_key across module

### DIFF
--- a/cosmos_db_roles.tf
+++ b/cosmos_db_roles.tf
@@ -22,7 +22,7 @@ module "cosmosdb_custom_roles" {
   account_name = (
     can(each.value.account.name) || can(each.value.account_name) ?
     try(each.value.account.name, each.value.account_name) :
-    local.combined_objects_cosmos_dbs[try(each.value.account.lz_key, local.client_config.landingzone_key)][try(each.value.account_key, each.value.account.key)].name
+    local.combined_objects_cosmos_dbs[try(each.value.account_lz_key, local.client_config.landingzone_key)][try(each.value.account_key, each.value.account.key)].name
   )
   assignable_scopes  = local.cosmos_db_assignable_scopes[each.key]
   permissions        = each.value.permissions
@@ -34,7 +34,7 @@ module "cosmosdb_custom_roles" {
 resource "azurerm_cosmosdb_sql_role_assignment" "cosmos_account" {
   for_each = local.cosmosdb_account_roles
 
-  account_name = local.combined_objects_cosmos_dbs[try(each.value.account.lz_key, local.client_config.landingzone_key)][try(each.value.account_key, each.value.account.key)].name
+  account_name = local.combined_objects_cosmos_dbs[try(each.value.account_lz_key, local.client_config.landingzone_key)][try(each.value.account_key, each.value.account.key)].name
   resource_group_name = (
     try(each.value.resource_group.name, null) != null || try(each.value.resource_group_name, null) != null ?
     try(each.value.resource_group.name, each.value.resource_group_name) :
@@ -76,7 +76,7 @@ resource "azurerm_cosmosdb_sql_role_assignment" "cosmos_sql_database" {
     try(each.value.resource_group.name, each.value.resource_group_name) :
     local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group_key, each.value.resource_group.key)].name
   )
-  account_name = local.combined_objects_cosmos_dbs[try(each.value.account.lz_key, local.client_config.landingzone_key)][try(each.value.account_key, each.value.account.key)].name
+  account_name = local.combined_objects_cosmos_dbs[try(each.value.account_lz_key, local.client_config.landingzone_key)][try(each.value.account_key, each.value.account.key)].name
   principal_id = (
     each.value.object_id_resource_type == "object_ids" ?
     each.value.object_id_key_resource : each.value.object_id_lz_key == null ?
@@ -112,7 +112,7 @@ resource "azurerm_cosmosdb_sql_role_assignment" "cosmos_sql_container" {
     try(each.value.resource_group.name, each.value.resource_group_name) :
     local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group_key, each.value.resource_group.key)].name
   )
-  account_name = local.combined_objects_cosmos_dbs[try(each.value.account.lz_key, local.client_config.landingzone_key)][try(each.value.account_key, each.value.account.key)].name
+  account_name = local.combined_objects_cosmos_dbs[try(each.value.account_lz_key, local.client_config.landingzone_key)][try(each.value.account_key, each.value.account.key)].name
   principal_id = (
     each.value.object_id_resource_type == "object_ids" ?
     each.value.object_id_key_resource : each.value.object_id_lz_key == null ?


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->
When attempting to provision a cosmosdb_role_mapping for a cosmosdb_accounts provisioned in another lz the existing functionality does not support the ability to access the specified lz from the key setup described and documented. When attempting to specify the lz_key in the configuration data structure it does not get used and instead the module code makes reference to a non-existent account.key that is not used or consumed by the module.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
Provision a Cosmos DB Account in one LZ and then attempt to set the data-plane rbac assignment in another LZ without using a custom role.