### PR TITLE
Fix the for_each loop to loop over the parameter given

### DIFF
--- a/modules/compute/aks/aks.tf
+++ b/modules/compute/aks/aks.tf
@@ -96,11 +96,11 @@ resource "azurerm_kubernetes_cluster" "aks" {
       }
     }
     dynamic "linux_os_config" {
-      for_each = try(var.settings.default_node_pool.linux_os_config, null) == null ? [] : [1]
+      for_each = try(var.settings.default_node_pool.linux_os_config, null) == null ? [] : [var.settings.default_node_pool.linux_os_config]
       content {
         swap_file_size_mb = try(linux_os_config.value.allowed_unsafe_sysctls, null)
         dynamic "sysctl_config" {
-          for_each = try(linux_os_config.value.sysctl_config, null) == null ? [] : [1]
+          for_each = try(linux_os_config.value.sysctl_config, null) == null ? [] : [linux_os_config.value.sysctl_config]
           content {
             fs_aio_max_nr                      = try(sysctl_config.value.fs_aio_max_nr, null)
             fs_file_max                        = try(sysctl_config.value.fs_file_max, null)
@@ -477,11 +477,11 @@ resource "azurerm_kubernetes_cluster_node_pool" "nodepools" {
     }
   }
   dynamic "linux_os_config" {
-    for_each = try(each.value.linux_os_config, null) == null ? [] : [1]
+    for_each = try(each.value.linux_os_config, null) == null ? [] : [each.value.linux_os_config]
     content {
       swap_file_size_mb = try(linux_os_config.value.allowed_unsafe_sysctls, null)
       dynamic "sysctl_config" {
-        for_each = try(linux_os_config.value.sysctl_config, null) == null ? [] : [1]
+        for_each = try(linux_os_config.value.sysctl_config, null) == null ? [] : [linux_os_config.value.sysctl_config]
         content {
           fs_aio_max_nr                      = try(sysctl_config.value.fs_aio_max_nr, null)
           fs_file_max                        = try(sysctl_config.value.fs_file_max, null)


### PR DESCRIPTION
# [Issue-id]https://github.com/aztfmod/terraform-azurerm-caf/issues/1780

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ x ] I have added example(s) inside the [./examples/] folder
- [ x ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ x ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ x ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

When defining a linux_os_config block on the node_pool it was not applied to the node_pool. This PR fixes this by setting the loop variable to the contents of the linux_os_config block.

## Does this introduce a breaking change

- [ ] YES
- [ x ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Adding this to each of the pools in the node_pools, and running terraform apply, it will  implement the parameters.

```
        linux_os_config       = {
          sysctl_config = {
            vm_max_map_count = 262144
          }          
        }
```

Afterwards deploy or access a prod with a shell, and do a `cat /proc/sys/vm/max_map_count` and observe that the setting has been applied.