### PR TITLE
Add temporary_name_for_rotation support on default_node_pool

### DIFF
--- a/modules/compute/aks/aks.tf
+++ b/modules/compute/aks/aks.tf
@@ -62,6 +62,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
     os_disk_size_gb               = try(var.settings.default_node_pool.os_disk_size_gb, null)
     os_disk_type                  = try(var.settings.default_node_pool.os_disk_type, null)
     os_sku                        = try(var.settings.default_node_pool.os_sku, null)
+    temporary_name_for_rotation   = try(var.settings.default_node_pool.temporary_name_for_rotation, null)
     tags                          = merge(try(var.settings.default_node_pool.tags, {}), local.tags)
     type                          = try(var.settings.default_node_pool.type, "VirtualMachineScaleSets")
     ultra_ssd_enabled             = try(var.settings.default_node_pool.ultra_ssd_enabled, false)


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/1819)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ x ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

When changing certain parameters on the Default Node Pool, it will do a rebuild of the entire nodepool. This requires setting temporary_name_for_rotation however the AKS module does not support this.

This PR adds the possibility of setting this and it will then build a new temporary nodepool with this name, and then roll the original nodepool.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing
```
default_node_pool = {
       name                  = "sharedsvc"
       vm_size               = "Standard_F4s_v2"
       subnet_key            = "aks_nodepool_system"
       enabled_auto_scaling  = false
       enable_node_public_ip = false
       max_pods              = 30
       node_count            = 1
       os_disk_size_gb       = 512
+     os_disk_type          = "Ephemeral"
       temporary_name_for_rotation = "tempsvcpool"
       tags = {
         "project" = "system services"
       }
```

First deploy the default node pool without the "os_disk_type" setting, after build, then add the option and run terraform apply again. Now it will "modify" the node pool without throwing the error.