### PR TITLE
feat: Add support for carriage return when loading file as secret

### DIFF
--- a/modules/security/keyvault/secrets.tf
+++ b/modules/security/keyvault/secrets.tf
@@ -7,7 +7,7 @@ resource "azurerm_key_vault_secret" "secret" {
   }
 
   name            = each.value.name
-  value           = try(each.value.is_value_filepath, false) ? base64encode(file(each.value.value)) : each.value.value
+  value           = try(each.value.is_value_filepath, false) ? (try(each.value.base64encode, true) ? base64encode(file(each.value.value)) : replace(file(each.value.value), "/\n/", "\n")) : each.value.value
   key_vault_id    = azurerm_key_vault.keyvault.id
   content_type    = try(each.value.content_type, null)
   not_before_date = try(each.value.not_before_date, null)
@@ -24,7 +24,7 @@ resource "azurerm_key_vault_secret" "secret_ignore_changes" {
   }
 
   name            = each.value.name
-  value           = try(each.value.is_value_filepath, false) ? base64encode(file(each.value.value)) : each.value.value
+  value           = try(each.value.is_value_filepath, false) ? (try(each.value.base64encode, true) ? base64encode(file(each.value.value)) : replace(file(each.value.value), "/\n/", "\n")) : each.value.value
   key_vault_id    = azurerm_key_vault.keyvault.id
   content_type    = try(each.value.content_type, null)
   not_before_date = try(each.value.not_before_date, null)


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [X] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [X] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Currently, when you add a secret on a keyvault with `is_value_filepath = true`, the content of the file is encoded in base64. This PR introduce a new variable `base64encode` with true as default to avoid breaking changes. If the value is set to false, the carriage return will be replaced as per documentation: [azurerm_key_vault_secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret#value)

> Key Vault strips newlines. To preserve newlines in multi-line secrets try replacing them with \n or by base 64 encoding them with replace(file("my_secret_file"), "/\n/", "\n") or base64encode(file("my_secret_file")), respectively.

```hcl
keyvaults = {
  example = {
    name = "example"
    secrets = {
      name              = "example-with-file"
      value             = "./multiline.txt"
      is_value_filepath = true
      base64encode      = false
    }
  }
}
```

## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
