### PR TITLE
Add secure_boot_enabled and vtpm_enabled options

### DIFF
--- a/modules/compute/virtual_machine/vm_linux.tf
+++ b/modules/compute/virtual_machine/vm_linux.tf
@@ -76,13 +76,16 @@ resource "azurerm_linux_virtual_machine" "vm" {
   size                            = each.value.size
   tags                            = merge(local.tags, try(each.value.tags, null))
   zone                            = try(each.value.zone, null)
+  secure_boot_enabled             = try(each.value.secure_boot_enabled, null)
+  vtpm_enabled                    = try(each.value.vtpm_enabled, null)
+
 
   custom_data = try(
     try(
       try(local_sensitive_file.custom_data[each.key].content_base64, local.dynamic_custom_data[each.value.custom_data][each.value.name]),
-      try(filebase64(format("%s/%s", path.cwd, each.value.custom_data)), base64encode(each.value.custom_data))), 
+      try(filebase64(format("%s/%s", path.cwd, each.value.custom_data)), base64encode(each.value.custom_data))),
   null)
-  
+
 
   dedicated_host_id = can(each.value.dedicated_host.key) ? var.dedicated_hosts[try(each.value.dedicated_host.lz_key, var.client_config.landingzone_key)][each.value.dedicated_host.key].id : try(each.value.dedicated_host.id, null)
 

--- a/modules/compute/virtual_machine/vm_windows.tf
+++ b/modules/compute/virtual_machine/vm_windows.tf
@@ -63,6 +63,9 @@ resource "azurerm_windows_virtual_machine" "vm" {
   tags                         = merge(local.tags, try(each.value.tags, null))
   timezone                     = try(each.value.timezone, null)
   zone                         = try(each.value.zone, null)
+  secure_boot_enabled          = try(each.value.secure_boot_enabled, null)
+  vtpm_enabled                 = try(each.value.vtpm_enabled, null)
+
 
   custom_data = try(
     try(filebase64(format("%s/%s", path.cwd, each.value.custom_data)), base64encode(each.value.custom_data)),


### PR DESCRIPTION
## Description

Add secure_boot_enabled and vtpm_enabled options in Windows and Linux VMs

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->

Create a VM with the options enabled like:

```terraform
global_settings = {
  default_region = "region1"
  regions = {
    region1 = "westeurope"
  }
}

resource_groups = {
  vm_region1 = {
    name = "example-virtual-machine-olandese"
  }
}

virtual_machines = {

  domain_controller_1_vm = {

    resource_group = {
      key = "vm_region1"
    }

    provision_vm_agent                   = true
    boot_diagnostics_storage_account_key = ""
    os_type                              = "windows"

    keyvault_key = "example_vm_rg1"

    networking_interfaces = {
      nic0 = {
        # Value of the keys from networking.tfvars
        vnet_key                = "vnet_region1"
        subnet_key              = "example"
        name                    = "0"
        enable_ip_forwarding    = false
        internal_dns_name_label = "nic0"
      }
    }

    data_disks = {
      vm-wl-addc-datadisk = {
        name                 = "data01-vm-wl-addc-p1"
        storage_account_type = "Premium_LRS"
        create_option        = "Empty"
        disk_size_gb         = "32"
        lun                  = 0
        caching              = "ReadWrite"
        # Choose the zone in which this first vm resides
        zone = 2
      }
    }

    virtual_machine_settings = {
      windows = {
        name                            = "wl-addc-p1"
        size                            = "Standard_B2ms"
        admin_username                  = "adminuser"
        disable_password_authentication = true
        zone                            = 2

        patch_mode          = "AutomaticByPlatform"
        hotpatching_enabled = false

        # MUST BE TRUE!
        encryption_at_host_enabled = false

        # Value of the nic keys to attach the VM. The first one in the list is the default nic
        network_interface_keys = ["nic0"]

        identity = {
          type = "SystemAssigned"
        }

        os_disk = {
          name                 = "os-vm-wl-addc-p1"
          disk_size_gb         = "64"
          caching              = "ReadWrite"
          storage_account_type = "Premium_LRS"
          zone                 = 2
        }

        source_image_reference = {
          publisher = "MicrosoftWindowsServer"
          offer     = "WindowsServer"
          sku       = "2022-datacenter-azure-edition-hotpatch-smalldisk"
          version   = "latest"
        }

        secure_boot_enabled = true
        vtpm_enabled = true
      }
    }
  }
}
```
