### PR TITLE
Feature/add ddos protection plan id var non global to ddos

### DIFF
--- a/examples/networking/examples/networking/ddos_reusing_existing_plan_id/configuration.tfvars
+++ b/examples/networking/examples/networking/ddos_reusing_existing_plan_id/configuration.tfvars
@@ -1,0 +1,36 @@
+#Please don't include this example in CI due to DDOS Cost consumption
+
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "australiaeast"
+  }
+}
+
+resource_groups = {
+  ddosrg = {
+    name   = "ddos"
+    region = "region1"
+  }
+}
+
+ddos_services = {
+  ddos = {
+    name               = "ddos-testplan"
+    resource_group_key = "ddosrg"
+  }
+}
+
+vnets = {
+  vnet1 = {
+    ddos_services_lz_key = "" #If the reference of Remote DDOS subscription plan is being inferred
+    ddos_services_key  = "ddos"
+    # ddos_protection_plan_id = "/subscriptions/00000000-0000-0000-0000-0000000/resourceGroups/rgname/providers/Microsoft.Network/ddosProtectionPlans/planname" # uncomment and complete for use
+    resource_group_key = "ddosrg"
+    vnet = {
+      name          = "test-vnet"
+      address_space = ["10.0.0.0/16"]
+    }
+    specialsubnets = {}
+  }
+}

--- a/networking.tf
+++ b/networking.tf
@@ -32,8 +32,8 @@ module "networking" {
   for_each   = local.networking.vnets
 
   application_security_groups       = local.combined_objects_application_security_groups
-  client_config                     = local.client_config
-  ddos_id                           = try(local.combined_objects_ddos_services[try(each.value.ddos_services_lz_key, local.client_config.landingzone_key)][try(each.value.ddos_services_key, each.value.ddos_services_key)].id, "")
+  client_config                     = local.client_config  
+  ddos_id                           = can(each.value.ddos_protection_plan_id) || can(each.value.ddos_services_key) == false ? try(each.value.ddos_protection_plan_id, null) : try(local.combined_objects_ddos_services[try(each.value.ddos_services_lz_key, local.client_config.landingzone_key)][try(each.value.ddos_services_key, each.value.ddos_services_key)].id, "")
   diagnostics                       = local.combined_diagnostics
   global_settings                   = local.global_settings
   network_security_groups           = module.network_security_groups


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have added example(s) inside the [./examples/] folder
- [x] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

DDOS protection plan id variable non global added

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

#You need to create DDOS Plan before
#I have commented the example to avoid errors in tests

global_settings = {
default_region = "region1"
regions = {
region1 = "australiaeast"
}
}

resource_groups = {
ddosrg = {
name = "ddos"
region = "region1"
}
}

ddos_services = {
ddos = {
name = "ddos-testplan"
resource_group_key = "ddosrg"
}
}

vnets = {
vnet1 = {
ddos_services_lz_key = "" #If the reference of Remote DDOS subscription plan is being inferred
ddos_services_key = "ddos"
# ddos_protection_plan_id = "/subscriptions/00000000-0000-0000-0000-0000000/resourceGroups/rgname/providers/Microsoft.Network/ddosProtectionPlans/planname" # uncomment and complete for use
resource_group_key = "ddosrg"
vnet = {
name = "test-vnet"
address_space = ["10.0.0.0/16"]
}
specialsubnets = {}
}
}
