### PR TITLE
Blinq global settings override custom role

### DIFF
--- a/modules/roles/custom_roles/module.tf
+++ b/modules/roles/custom_roles/module.tf
@@ -14,7 +14,6 @@ resource "azurecaf_name" "custom_role" {
   use_slug      = local.global_settings.use_slug
 }
 
-
 resource "azurerm_role_definition" "custom_role" {
   name = azurecaf_name.custom_role.result
 

--- a/modules/roles/custom_roles/module.tf
+++ b/modules/roles/custom_roles/module.tf
@@ -14,16 +14,6 @@ resource "azurecaf_name" "custom_role" {
   use_slug      = local.global_settings.use_slug
 }
 
-# resource "azurecaf_name" "custom_role" {
-#   name          = var.custom_role.name
-#   resource_type = "azurerm_resource_group"
-#   #TODO: need to be changed to appropriate resource (no caf reference for now)
-#   prefixes      = var.global_settings.prefixes
-#   random_length = var.global_settings.random_length
-#   clean_input   = true
-#   passthrough   = var.global_settings.passthrough
-#   use_slug      = var.global_settings.use_slug
-# }
 
 resource "azurerm_role_definition" "custom_role" {
   name = azurecaf_name.custom_role.result

--- a/modules/roles/custom_roles/module.tf
+++ b/modules/roles/custom_roles/module.tf
@@ -6,9 +6,20 @@ resource "azurecaf_name" "custom_role" {
   prefixes      = var.global_settings.prefixes
   random_length = var.global_settings.random_length
   clean_input   = true
-  passthrough   = var.global_settings.passthrough
-  use_slug      = var.global_settings.use_slug
+  passthrough   = local.global_settings.passthrough
+  use_slug      = local.global_settings.use_slug
 }
+
+# resource "azurecaf_name" "custom_role" {
+#   name          = var.custom_role.name
+#   resource_type = "azurerm_resource_group"
+#   #TODO: need to be changed to appropriate resource (no caf reference for now)
+#   prefixes      = var.global_settings.prefixes
+#   random_length = var.global_settings.random_length
+#   clean_input   = true
+#   passthrough   = var.global_settings.passthrough
+#   use_slug      = var.global_settings.use_slug
+# }
 
 resource "azurerm_role_definition" "custom_role" {
   name = azurecaf_name.custom_role.result

--- a/modules/roles/custom_roles/module.tf
+++ b/modules/roles/custom_roles/module.tf
@@ -1,10 +1,14 @@
 
+locals {
+  global_settings = merge(var.global_settings, var.custom_role.global_settings)
+}
+
 resource "azurecaf_name" "custom_role" {
   name          = var.custom_role.name
   resource_type = "azurerm_resource_group"
   #TODO: need to be changed to appropriate resource (no caf reference for now)
-  prefixes      = var.global_settings.prefixes
-  random_length = var.global_settings.random_length
+  prefixes      = local.global_settings.prefixes
+  random_length = local.global_settings.random_length
   clean_input   = true
   passthrough   = local.global_settings.passthrough
   use_slug      = local.global_settings.use_slug


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

We have a customer requirement to be able to create custom roles with specific names, not following the solution naming convention. Magnus Implemented standardized solution for global settings override.

custom_role don't have the settings var, but existing custom_role var represent the same (each.value).

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [X] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [X] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
