### PR TITLE
[Bugfix] Create Recovery Vault Private Endpoints in another resource group

### DIFF
--- a/examples/recovery_vault/103-asr-with-private-endpoint/private_endpoints.tfvars
+++ b/examples/recovery_vault/103-asr-with-private-endpoint/private_endpoints.tfvars
@@ -10,6 +10,11 @@ private_endpoints = {
         # name = ""                        # Name of the private endpoint
         # lz_key = ""                      # Key of the landingzone where the storage account has been deployed.
         # resource_group_key = ""          # Key of the resource group where the private endpoint will be created. Default to the vnet's resource group
+        # resource_group = { # Or using a resource group from another LZ
+        #   key    = ""
+        #   lz_key = ""
+        # }
+
         # tags
         private_service_connection = {
           name = "psc-asr"

--- a/examples/recovery_vault/104-backupvault-with-private-endpoint/private_endpoints.tfvars
+++ b/examples/recovery_vault/104-backupvault-with-private-endpoint/private_endpoints.tfvars
@@ -10,6 +10,10 @@ private_endpoints = {
 
         # name = ""                        # Name of the private endpoint
         # resource_group_key = ""          # Key of the resource group where the private endpoint will be created. Defaults to the vnet's resource group
+        # resource_group = { # Or using a resource group from another LZ
+        #   key    = ""
+        #   lz_key = ""
+        # }
         private_service_connection = {
           name              = "psc-backup"
           subresource_names = ["AzureBackup"]

--- a/modules/networking/private_links/endpoints/subnet/recovery_vaults.tf
+++ b/modules/networking/private_links/endpoints/subnet/recovery_vaults.tf
@@ -10,7 +10,7 @@ module "recovery_vault" {
   location            = var.vnet_location # The private endpoint must be deployed in the same region as the virtual network.
   name                = try(each.value.name, each.key)
   private_dns         = var.private_dns
-  resource_group_name = try(var.resource_groups[each.value.resource_group_key].name, var.vnet_resource_group_name)
+  resource_group_name = try(var.resource_groups[try(each.value.resource_group.lz_key, var.client_config.landingzone_key)][try(each.value.resource_group_key, each.value.resource_group.key)].name, var.vnet_resource_group_name)
   resource_id         = can(each.value.resource_id) ? each.value.resource_id : var.remote_objects.recovery_vaults[var.client_config.landingzone_key][each.key].id
   settings            = each.value
   subnet_id           = var.subnet_id
@@ -28,7 +28,7 @@ module "recovery_vault_remote" {
   location            = var.vnet_location # The private endpoint must be deployed in the same region as the virtual network.
   name                = try(each.value.name, each.key)
   private_dns         = var.private_dns
-  resource_group_name = try(var.resource_groups[each.value.resource_group_key].name, var.vnet_resource_group_name)
+  resource_group_name = try(var.resource_groups[try(each.value.resource_group.lz_key, var.client_config.landingzone_key)][try(each.value.resource_group_key, each.value.resource_group.key)].name, var.vnet_resource_group_name)
   resource_id         = var.remote_objects.recovery_vaults[var.client_config.landingzone_key][each.key].id
   settings            = each.value
   subnet_id           = var.subnet_id

--- a/modules/recovery_vault/private_endpoints.tf
+++ b/modules/recovery_vault/private_endpoints.tf
@@ -14,7 +14,6 @@ module "private_endpoint" {
   resource_group_name = local.resource_group_name
   subnet_id           = can(each.value.subnet_id) ? each.value.subnet_id : var.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
   settings            = each.value
-  subresource_names   = ["AzureSiteRecovery"]
   global_settings     = var.global_settings
   tags                = local.tags
   base_tags           = var.base_tags


### PR DESCRIPTION
- [X] I have added example(s) inside the [./examples/] folder

## Description

[BUG] It was not possible to create a recovery vault private endpoint in a resource group other than the vnet's resource group

- fix for deploy private endpoint in a resource group other than vnet's resource group
- fix for deploy  private endpoint  using resource group from another LZ

## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing
- Run the examples with the private endpoint and use this to create the endpoint in another resource group than the vnet's resource group:

```terraform
         resource_group_key = "your_rg_key"
```

- Run the examples with the private endpoint and use this to create the endpoint in a Resource group from another LZ:

```terraform
         resource_group = { 
           key   = "your_rg_key"
           lz_key = "your_lz_key"
         }
```

