### PR TITLE
Fix error with missing global settings in variable

### DIFF
--- a/modules/roles/custom_roles/module.tf
+++ b/modules/roles/custom_roles/module.tf
@@ -1,6 +1,6 @@
 
 locals {
-  global_settings = merge(var.global_settings, var.custom_role.global_settings)
+  global_settings = merge(var.global_settings, try(var.custom_role.global_settings,{}))
 }
 
 resource "azurecaf_name" "custom_role" {


### PR DESCRIPTION
## Description

If you try to create a custom role definition (following the examples) you get the following error: 
![image](https://github.com/aztfmod/terraform-azurerm-caf/assets/1708128/f25b1e81-f836-423b-b2a2-f8334da77bc1)

This fixes the need to add an empty custom_role.global_settings variable to make it work.

## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

To see the error: 
Run the example in the folder azuread/101-custom-role-assignable-scopes


