### PR TITLE
Add servicebus_queues scope for role assignment

### DIFF
--- a/roles.tf
+++ b/roles.tf
@@ -157,6 +157,7 @@ locals {
     route_tables                               = local.combined_objects_route_tables
     servicebus_namespaces                      = local.combined_objects_servicebus_namespaces
     servicebus_topics                          = local.combined_objects_servicebus_topics
+    servicebus_queues                          = local.combined_objects_servicebus_queues
     storage_accounts                           = local.combined_objects_storage_accounts
     subscriptions                              = local.combined_objects_subscriptions
     synapse_workspaces                         = local.combined_objects_synapse_workspaces

--- a/roles.tf
+++ b/roles.tf
@@ -156,8 +156,8 @@ locals {
     resource_groups                            = local.combined_objects_resource_groups
     route_tables                               = local.combined_objects_route_tables
     servicebus_namespaces                      = local.combined_objects_servicebus_namespaces
-    servicebus_topics                          = local.combined_objects_servicebus_topics
     servicebus_queues                          = local.combined_objects_servicebus_queues
+    servicebus_topics                          = local.combined_objects_servicebus_topics
     storage_accounts                           = local.combined_objects_storage_accounts
     subscriptions                              = local.combined_objects_subscriptions
     synapse_workspaces                         = local.combined_objects_synapse_workspaces


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description
Adding servicebus queues to the role mappings, to complete the yesterday approved commit:
https://github.com/aztfmod/terraform-azurerm-caf/pull/1860

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [ ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
```role_mapping = {
  built_in_role_mapping = {
    servicebus_queues = {
      "queue" = {
        "Azure Service Bus Data Receiver" = {
          azuread_groups = {
            keys = ["group"]
          }
        }
      }
    } 
  }
}
