### PR TITLE
Add support for base_tags and module_tag to firewall policies module

### DIFF
--- a/modules/networking/firewall_policies/main.tf
+++ b/modules/networking/firewall_policies/main.tf
@@ -11,6 +11,5 @@ locals {
   module_tag = {
     "module" = basename(abspath(path.module))
   }
-  # tags = merge(var.base_tags, local.module_tag, var.tags)
-  tags = var.tags # temporal use until tag uppercase fixed
+  tags = merge(local.base_tags, local.module_tag, var.tags)
 }


### PR DESCRIPTION
## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Add support for base_tags and module_tag to firewall policies module

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
