### PR TITLE
Feature/#1879 dynamic secret outputs

### DIFF
--- a/dynamic_secrets.tf
+++ b/dynamic_secrets.tf
@@ -9,7 +9,7 @@ module "dynamic_keyvault_secrets" {
   for_each = {
     for keyvault_key, secrets in try(var.security.dynamic_keyvault_secrets, {}) : keyvault_key => {
       for key, value in secrets : key => value
-      if try(value.value, null) != null && try(value.value, null) != ""
+      if try(value.value, null) != null # && try(value.value, null) != ""  We want to allow empty values to support our Azdo-PAT usecease in level2
     }
   }
 

--- a/dynamic_secrets.tf
+++ b/dynamic_secrets.tf
@@ -17,6 +17,29 @@ module "dynamic_keyvault_secrets" {
   keyvault = local.combined_objects_keyvaults[local.client_config.landingzone_key][each.key]
 }
 
+
 output "dynamic_keyvault_secrets" {
-  value = module.dynamic_keyvault_secrets
+  value = { for key, value in try(var.security.dynamic_keyvault_secrets, {}):
+    key =>  module.dynamic_keyvault_secrets[key].secrets
+  }
 }
+# Output looks different then probably expected, its resource_type --> keyvault_key --> secret_key
+# dynamic_keyvault_secrets    = { <-- resource_type
+#   keyvault_key = {                <-- keyvault_key
+#     secret_key = {                <-- secret_key
+#       content_type            = ""
+#       expiration_date         = null
+#       id                      = "https://vault_xy.vault.azure.net/secrets/secret-name/xxx"
+#       key_vault_id            = "/subscriptions/1234/resourceGroups/rg-fo/providers/Microsoft.KeyVault/vaults/vault_xy"
+#       name                    = "secret-name"
+#       not_before_date         = null
+#       resource_id             = "/subscriptions/1234/resourceGroups/rg-fo/providers/Microsoft.KeyVault/vaults/vault_xy/secrets/secret-name/versions/xxx"
+#       resource_versionless_id = "/subscriptions/1234/resourceGroups/rg-fo/providers/Microsoft.KeyVault/vaults/vault_xy/secrets/secret-name"
+#       tags                    = {}
+#       timeouts                = null
+#       value                   = ""
+#       version                 = "xxxxx"
+#       versionless_id          = "https://vault_xy.vault.azure.net/secrets/secret-name"
+#     }
+#   }
+# }

--- a/modules/security/dynamic_keyvault_secrets/keyvault.tf
+++ b/modules/security/dynamic_keyvault_secrets/keyvault.tf
@@ -48,3 +48,4 @@ module "secret_dynamic" {
   keyvault_id = var.keyvault.id
   config      = each.value.config
 }
+

--- a/modules/security/dynamic_keyvault_secrets/outputs.tf
+++ b/modules/security/dynamic_keyvault_secrets/outputs.tf
@@ -1,0 +1,14 @@
+locals {
+  secret_output = {for key, value in var.settings : 
+    key => merge(
+      try(module.secret[key].secret, {}),
+      try(module.secret_value[key].secret, {}),
+      try(module.secret_immutable[key].secret, {}),
+      try(module.secret_dynamic[key].secret, {}),
+    )
+  }
+
+}
+output "secrets" {
+  value = local.secret_output
+}

--- a/modules/security/dynamic_keyvault_secrets/secret/outputs.tf
+++ b/modules/security/dynamic_keyvault_secrets/secret/outputs.tf
@@ -1,0 +1,18 @@
+output "secret" {
+  value = azurerm_key_vault_secret.secret
+}
+output "id" {
+  value = azurerm_key_vault_secret.secret.id
+}
+output "resource_id" {
+  value = azurerm_key_vault_secret.secret.resource_id
+}
+output "resource_versionless_id" {
+  value = azurerm_key_vault_secret.secret.resource_versionless_id
+}
+output "version" {
+  value = azurerm_key_vault_secret.secret.version
+}
+output "versionless_id" {
+  value = azurerm_key_vault_secret.secret.versionless_id
+}

--- a/modules/security/dynamic_keyvault_secrets/secret_dynamic/outputs.tf
+++ b/modules/security/dynamic_keyvault_secrets/secret_dynamic/outputs.tf
@@ -1,0 +1,19 @@
+output "secret" {
+  value = azurerm_key_vault_secret.secret
+}
+
+output "id" {
+  value = azurerm_key_vault_secret.secret.id
+}
+output "resource_id" {
+  value = azurerm_key_vault_secret.secret.resource_id
+}
+output "resource_versionless_id" {
+  value = azurerm_key_vault_secret.secret.resource_versionless_id
+}
+output "version" {
+  value = azurerm_key_vault_secret.secret.version
+}
+output "versionless_id" {
+  value = azurerm_key_vault_secret.secret.versionless_id
+}

--- a/modules/security/dynamic_keyvault_secrets/secret_immutable/outputs.tf
+++ b/modules/security/dynamic_keyvault_secrets/secret_immutable/outputs.tf
@@ -1,0 +1,18 @@
+output "secret" {
+  value = azurerm_key_vault_secret.secret.0
+}
+output "id" {
+  value = azurerm_key_vault_secret.secret.0.id
+}
+output "resource_id" {
+  value = azurerm_key_vault_secret.secret.0.resource_id
+}
+output "resource_versionless_id" {
+  value = azurerm_key_vault_secret.secret.0.resource_versionless_id
+}
+output "version" {
+  value = azurerm_key_vault_secret.secret.0.version
+}
+output "versionless_id" {
+  value = azurerm_key_vault_secret.secret.0.versionless_id
+}


### PR DESCRIPTION
# [#1879](https://github.com/aztfmod/terraform-azurerm-caf/issues/1879)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description
Allows secrets with empty values and adds outputs to dynamic_secrets.
```
# Adding a secret with an empty value is needed if there are secrets we can not populate using CAF. An example is the Azure devops PAT needed for the devops integration.
dynamic_keyvault_secrets = {
  level0 = {   
    admin = {
      secret_name = "azdo-pat-admin"
      value       = ""
    }
  }
}
```

Adds output structure to dynamic_secrets:
Output looks different then probably expected, its resource_type --> keyvault_key --> secret_key
```
 dynamic_keyvault_secrets    = { <-- resource_type
   keyvault_key = {                <-- keyvault_key
   secret_key = {                <-- secret_key
       content_type            = ""
       expiration_date         = null
       id                      = "https://vault_xy.vault.azure.net/secrets/secret-name/xxx"
       key_vault_id            = "/subscriptions/1234/resourceGroups/rg-fo/providers/Microsoft.KeyVault/vaults/vault_xy"
       name                    = "secret-name"
       not_before_date         = null
       resource_id             = "/subscriptions/1234/resourceGroups/rg-fo/providers/Microsoft.KeyVault/vaults/vault_xy/secrets/secret-name/versions/xxx"
       resource_versionless_id = "/subscriptions/1234/resourceGroups/rg-fo/providers/Microsoft.KeyVault/vaults/vault_xy/secrets/secret-name"
       tags                    = {}
       timeouts                = null
       value                   = ""
       version                 = "xxxxx"
       versionless_id          = "https://vault_xy.vault.azure.net/secrets/secret-name"
     }
   }
 }
```
## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
