### PR TITLE
Simon/load balance multiple frontend ip

### DIFF
--- a/examples/networking/lb/100-lb/configurations.tfvars
+++ b/examples/networking/lb/100-lb/configurations.tfvars
@@ -52,9 +52,11 @@ lb = {
       key = "rg1"
     }
     frontend_ip_configuration = {
-      name = "PublicIPAddress"
-      public_ip_address = {
-        key = "lb_pip"
+      fipc_001 = {
+        name = "PublicIPAddress"
+        public_ip_address = {
+          key = "lb_pip"
+        }
       }
     }
     sku = "Standard"

--- a/examples/networking/lb/101-vm_lb/configurations.tfvars
+++ b/examples/networking/lb/101-vm_lb/configurations.tfvars
@@ -111,12 +111,14 @@ lb = {
       key = "lb"
     }
     frontend_ip_configuration = {
-      name = "config1"
-      subnet = {
-        vnet_key = "vnet_test"
-        key      = "subnet1"
+      fipc_001 = {
+        name = "config1"
+        subnet = {
+          vnet_key = "vnet_test"
+          key      = "subnet1"
+        }
+        private_ip_address_allocation = "Dynamic"
       }
-      private_ip_address_allocation = "Dynamic"
     }
     sku = "Basic" #SKU must match with the SKU of the PIP
   }

--- a/examples/networking/lb/102-vm_lb_dns_servers/configurations.tfvars
+++ b/examples/networking/lb/102-vm_lb_dns_servers/configurations.tfvars
@@ -138,12 +138,14 @@ lb = {
       key = "lb"
     }
     frontend_ip_configuration = {
-      name = "config1"
-      subnet = {
-        vnet_key = "vnet_test"
-        key      = "subnet1"
+      fipc_001 = {
+        name = "config1"
+        subnet = {
+          vnet_key = "vnet_test"
+          key      = "subnet1"
+        }
+        private_ip_address_allocation = "Dynamic"
       }
-      private_ip_address_allocation = "Dynamic"
     }
     sku = "Basic" #SKU must match with the SKU of the PIP
   }

--- a/examples/networking/lb/103-lb-multi-frontend-ip/configurations.tfvars
+++ b/examples/networking/lb/103-lb-multi-frontend-ip/configurations.tfvars
@@ -1,27 +1,27 @@
 global_settings = {
-  default_region = "region1"
+  default_region                        = "region1"
   regions = {
-    region1 = "australiaeast"
+    region1                             = "australiaeast"
   }
 }
 
 resource_groups = {
   rg_lb_001 = {
-    name = "loadbalancer-example"
+    name                                = "loadbalancer-example"
   }
 }
 
 vnets = {
   vnet_lb_001 = {
-    resource_group_key = "rg_lb_001"
+    resource_group_key                  = "rg_lb_001"
     vnet = {
-      name = "loadbalancer-example"
-      address_space = ["192.168.1.0/24"]
+      name                              = "loadbalancer-example"
+      address_space                     = ["192.168.1.0/24"]
     }
     subnets = {
       snet_lb_001 = {
-        name = "loadbalancer-example"
-        cidr = ["192.168.1.0/24"]
+        name                            = "loadbalancer-example"
+        cidr                            = ["192.168.1.0/24"]
       }
     }
   }
@@ -29,150 +29,150 @@ vnets = {
 
 lb = {
   lb_lb_001 = {
-    name = "loadbalancer-example"
-    resource_group_key = "rg_lb_001"
+    name                                = "loadbalancer-example"
+    resource_group_key                  = "rg_lb_001"
     frontend_ip_configuration = {
       fipc_001 = {
-        name = "loadbalancer-example-001"
+        name                            = "loadbalancer-example-001"
         subnet = {
-          vnet_key = "vnet_lb_001"
-          key = "snet_lb_001"
+          vnet_key                      = "vnet_lb_001"
+          key                           = "snet_lb_001"
         }
         private_ip_address_allocation = "Static"
-        private_ip_address = "192.168.1.10"
+        private_ip_address              = "192.168.1.10"
       }
       fipc_002 = {
-        name = "loadbalancer-example-002"
+        name                            = "loadbalancer-example-002"
         subnet = {
-          vnet_key = "vnet_lb_001"
-          key = "snet_lb_001"
+          vnet_key                      = "vnet_lb_001"
+          key                           = "snet_lb_001"
         }
-        private_ip_address_allocation = "Static"
-        private_ip_address = "192.168.1.15"
+        private_ip_address_allocation   = "Static"
+        private_ip_address              = "192.168.1.15"
       }
     }
-    sku = "Standard"
+    sku                                 = "Standard"
   }
 }
 
 lb_backend_address_pool = {
   lbap_lb_001 = {
     loadbalancer = {
-      key = "lb_lb_001"
+      key                               = "lb_lb_001"
     }
-    name = "loadbalancer-example"
+    name                                = "loadbalancer-example"
   }
 }
 
 network_interface_backend_address_pool_association = {
   bap_lb_001 = {
     backend_address_pool = {
-      key = "lbap_lb_001"
+      key                               = "lbap_lb_001"
     }
     network_interface = {
-      vm_key = "vm_lb_001"
-      nic_key = "nic_lb_001"
-      # id = ""
+      vm_key                            = "vm_lb_001"
+      nic_key                           = "nic_lb_001"
+      # id                              = ""
     }
   }
   bap_lb_002 = {
     backend_address_pool = {
-      key = "lbap_lb_001"
+      key                               = "lbap_lb_001"
     }
     network_interface = {
-      vm_key = "vm_lb_002"
-      nic_key = "nic_lb_002"
-      # id = ""
+      vm_key                            = "vm_lb_002"
+      nic_key                           = "nic_lb_002"
+      # id                              = ""
     }
   }
 }
 
 lb_probe = {
   tcp_80_probe = {
-    resource_group_key = "rg_lb_001"
+    resource_group_key                  = "rg_lb_001"
     loadbalancer = {
-      key = "lb_lb_001"
+      key                               = "lb_lb_001"
     }
-    name = "tcp-80-probe"
-    port = 80
-    protocol = "Tcp"
-    interval_in_seconds = 5
-    number_of_probes = 3
+    name                                = "tcp-80-probe"
+    port                                = 80
+    protocol                            = "Tcp"
+    interval_in_seconds                 = 5
+    number_of_probes                    = 3
   }
 
   tcp_443_probe = {
-    resource_group_key = "rg_lb_001"
+    resource_group_key                  = "rg_lb_001"
     loadbalancer = {
-      key = "lb_lb_001"
+      key                               = "lb_lb_001"
     }
-    name = "tcp-443-probe"
-    port = 443
-    protocol = "Tcp"
-    interval_in_seconds = 5
-    number_of_probes = 3
+    name                                = "tcp-443-probe"
+    port                                = 443
+    protocol                            = "Tcp"
+    interval_in_seconds                 = 5
+    number_of_probes                    = 3
   }
 }
 
 lb_rule = {
   lbr_lb_001 = {
     resource_group = {
-      key = "rg_lb_001"
+      key                               = "rg_lb_001"
     }
     loadbalancer = {
-      key = "lb_lb_001"
+      key                               = "lb_lb_001"
     }
     backend_address_pool = {
       lbap_lb_001 = {
-        key = "lbap_lb_001"
+        key                             = "lbap_lb_001"
       }
     }
     probe = {
-      key = "tcp_80_probe"
+      key                               = "tcp_80_probe"
     }
-    name = "lbrule-01"
-    frontend_port = "80"
-    backend_port = "80"
-    protocol = "Tcp"
-    disable_outbound_snat = true
-    enable_floating_ip = true
-    idle_timeout_in_minutes = 30
-    frontend_ip_configuration_name = "loadbalancer-example-001"
+    name                                = "lbrule-01"
+    frontend_port                       = "80"
+    backend_port                        = "80"
+    protocol                            = "Tcp"
+    disable_outbound_snat               = true
+    enable_floating_ip                  = true
+    idle_timeout_in_minutes             = 30
+    frontend_ip_configuration_name      = "loadbalancer-example-001"
   }
   lbr_lb_002 = {
     resource_group = {
-      key = "rg_lb_001"
+      key                               = "rg_lb_001"
     }
     loadbalancer = {
-      key = "lb_lb_001"
+      key                               = "lb_lb_001"
     }
     backend_address_pool = {
       lbap_lb_001 = {
-        key = "lbap_lb_001"
+        key                             = "lbap_lb_001"
       }
     }
     probe = {
-      key = "tcp_443_probe"
+      key                               = "tcp_443_probe"
     }
-    name = "lbrule-02"
-    frontend_port = "443"
-    backend_port = "443"
-    protocol = "Tcp"
-    disable_outbound_snat = true
-    enable_floating_ip = true
-    idle_timeout_in_minutes = 30
-    frontend_ip_configuration_name = "loadbalancer-test-002"
+    name                                = "lbrule-02"
+    frontend_port                       = "443"
+    backend_port                        = "443"
+    protocol                            = "Tcp"
+    disable_outbound_snat               = true
+    enable_floating_ip                  = true
+    idle_timeout_in_minutes             = 30
+    frontend_ip_configuration_name      = "loadbalancer-test-002"
   }
 }
 
 keyvaults = {
   kv_lb_001 = {
-    name = "loadbalancer-example"
-    resource_group_key = "rg_lb_001"
-    sku_name = "standard"
+    name                                = "loadbalancer-example"
+    resource_group_key                  = "rg_lb_001"
+    sku_name                            = "standard"
     creation_policies = {
       logged_in_user = {
-        secret_permissions = ["Set", "Get", "List", "Delete", "Purge", "Recover"]
-        key_permissions = ["Get", "List", "Update", "Create", "Import", "Delete", "Recover", "Backup", "Restore", "Decrypt", "Encrypt", "UnwrapKey", "WrapKey", "Verify", "Sign", "Purge"]
+        secret_permissions              = ["Set", "Get", "List", "Delete", "Purge", "Recover"]
+        key_permissions                 = ["Get", "List", "Update", "Create", "Import", "Delete", "Recover", "Backup", "Restore", "Decrypt", "Encrypt", "UnwrapKey", "WrapKey", "Verify", "Sign", "Purge"]
       }
     }
   }
@@ -180,75 +180,75 @@ keyvaults = {
 
 virtual_machines = {
   vm_lb_001 = {
-    resource_group_key = "rg_lb_001"
-    os_type = "linux"
-    keyvault_key = "kv_lb_001"
+    resource_group_key                  = "rg_lb_001"
+    os_type                             = "linux"
+    keyvault_key                        = "kv_lb_001"
 
     networking_interfaces = {
       nic_lb_001 = {
-        vnet_key = "vnet_lb_001"
-        subnet_key = "snet_lb_001"
-        name = "loadbalancer-example-001"
-        enable_ip_forwarding = false
+        vnet_key                        = "vnet_lb_001"
+        subnet_key                      = "snet_lb_001"
+        name                            = "loadbalancer-example-001"
+        enable_ip_forwarding            = false
       }
     }
 
     virtual_machine_settings = {
       linux = {
-        name = "loadbalancer-example-001"
-        size = "Standard_F2"
-        admin_username = "adminuser"
+        name                            = "loadbalancer-example-001"
+        size                            = "Standard_F2"
+        admin_username                  = "adminuser"
         disable_password_authentication = true
-        network_interface_keys = ["nic_lb_001"]
+        network_interface_keys          = ["nic_lb_001"]
 
         os_disk = {
-          name = "loadbalancer-example-001"
-          caching = "ReadWrite"
-          storage_account_type = "Standard_LRS"
+          name                          = "loadbalancer-example-001"
+          caching                       = "ReadWrite"
+          storage_account_type          = "Standard_LRS"
         }
 
         source_image_reference = {
-          publisher = "Canonical"
-          offer = "UbuntuServer"
-          sku = "18.04-LTS"
-          version = "latest"
+          publisher                     = "Canonical"
+          offer                         = "UbuntuServer"
+          sku                           = "18.04-LTS"
+          version                       = "latest"
         }
       }
     }
   }
   vm_lb_002 = {
-    resource_group_key = "rg_lb_001"
-    os_type = "linux"
-    keyvault_key = "kv_lb_001"
+    resource_group_key                  = "rg_lb_001"
+    os_type                             = "linux"
+    keyvault_key                        = "kv_lb_001"
 
     networking_interfaces = {
       nic_lb_002 = {
-        vnet_key = "vnet_lb_001"
-        subnet_key = "snet_lb_001"
-        name = "loadbalancer-example-002"
-        enable_ip_forwarding = false
+        vnet_key                        = "vnet_lb_001"
+        subnet_key                      = "snet_lb_001"
+        name                            = "loadbalancer-example-002"
+        enable_ip_forwarding            = false
       }
     }
 
     virtual_machine_settings = {
       linux = {
-        name = "loadbalancer-example-002"
-        size = "Standard_F2"
-        admin_username = "adminuser"
+        name                            = "loadbalancer-example-002"
+        size                            = "Standard_F2"
+        admin_username                  = "adminuser"
         disable_password_authentication = true
-        network_interface_keys = ["nic_lb_002"]
+        network_interface_keys          = ["nic_lb_002"]
 
         os_disk = {
-          name = "loadbalancer-example-002"
-          caching = "ReadWrite"
-          storage_account_type = "Standard_LRS"
+          name                          = "loadbalancer-example-002"
+          caching                       = "ReadWrite"
+          storage_account_type          = "Standard_LRS"
         }
 
         source_image_reference = {
-          publisher = "Canonical"
-          offer = "UbuntuServer"
-          sku = "18.04-LTS"
-          version = "latest"
+          publisher                     = "Canonical"
+          offer                         = "UbuntuServer"
+          sku                           = "18.04-LTS"
+          version                       = "latest"
         }
       }
     }

--- a/examples/networking/lb/103-lb-multi-frontend-ip/configurations.tfvars
+++ b/examples/networking/lb/103-lb-multi-frontend-ip/configurations.tfvars
@@ -1,0 +1,256 @@
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "australiaeast"
+  }
+}
+
+resource_groups = {
+  rg_lb_001 = {
+    name = "loadbalancer-example"
+  }
+}
+
+vnets = {
+  vnet_lb_001 = {
+    resource_group_key = "rg_lb_001"
+    vnet = {
+      name = "loadbalancer-example"
+      address_space = ["192.168.1.0/24"]
+    }
+    subnets = {
+      snet_lb_001 = {
+        name = "loadbalancer-example"
+        cidr = ["192.168.1.0/24"]
+      }
+    }
+  }
+}
+
+lb = {
+  lb_lb_001 = {
+    name = "loadbalancer-example"
+    resource_group_key = "rg_lb_001"
+    frontend_ip_configuration = {
+      fipc_001 = {
+        name = "loadbalancer-example-001"
+        subnet = {
+          vnet_key = "vnet_lb_001"
+          key = "snet_lb_001"
+        }
+        private_ip_address_allocation = "Static"
+        private_ip_address = "192.168.1.10"
+      }
+      fipc_002 = {
+        name = "loadbalancer-example-002"
+        subnet = {
+          vnet_key = "vnet_lb_001"
+          key = "snet_lb_001"
+        }
+        private_ip_address_allocation = "Static"
+        private_ip_address = "192.168.1.15"
+      }
+    }
+    sku = "Standard"
+  }
+}
+
+lb_backend_address_pool = {
+  lbap_lb_001 = {
+    loadbalancer = {
+      key = "lb_lb_001"
+    }
+    name = "loadbalancer-example"
+  }
+}
+
+network_interface_backend_address_pool_association = {
+  bap_lb_001 = {
+    backend_address_pool = {
+      key = "lbap_lb_001"
+    }
+    network_interface = {
+      vm_key = "vm_lb_001"
+      nic_key = "nic_lb_001"
+      # id = ""
+    }
+  }
+  bap_lb_002 = {
+    backend_address_pool = {
+      key = "lbap_lb_001"
+    }
+    network_interface = {
+      vm_key = "vm_lb_002"
+      nic_key = "nic_lb_002"
+      # id = ""
+    }
+  }
+}
+
+lb_probe = {
+  tcp_80_probe = {
+    resource_group_key = "rg_lb_001"
+    loadbalancer = {
+      key = "lb_lb_001"
+    }
+    name = "tcp-80-probe"
+    port = 80
+    protocol = "Tcp"
+    interval_in_seconds = 5
+    number_of_probes = 3
+  }
+
+  tcp_443_probe = {
+    resource_group_key = "rg_lb_001"
+    loadbalancer = {
+      key = "lb_lb_001"
+    }
+    name = "tcp-443-probe"
+    port = 443
+    protocol = "Tcp"
+    interval_in_seconds = 5
+    number_of_probes = 3
+  }
+}
+
+lb_rule = {
+  lbr_lb_001 = {
+    resource_group = {
+      key = "rg_lb_001"
+    }
+    loadbalancer = {
+      key = "lb_lb_001"
+    }
+    backend_address_pool = {
+      lbap_lb_001 = {
+        key = "lbap_lb_001"
+      }
+    }
+    probe = {
+      key = "tcp_80_probe"
+    }
+    name = "lbrule-01"
+    frontend_port = "80"
+    backend_port = "80"
+    protocol = "Tcp"
+    disable_outbound_snat = true
+    enable_floating_ip = true
+    idle_timeout_in_minutes = 30
+    frontend_ip_configuration_name = "loadbalancer-example-001"
+  }
+  lbr_lb_002 = {
+    resource_group = {
+      key = "rg_lb_001"
+    }
+    loadbalancer = {
+      key = "lb_lb_001"
+    }
+    backend_address_pool = {
+      lbap_lb_001 = {
+        key = "lbap_lb_001"
+      }
+    }
+    probe = {
+      key = "tcp_443_probe"
+    }
+    name = "lbrule-02"
+    frontend_port = "443"
+    backend_port = "443"
+    protocol = "Tcp"
+    disable_outbound_snat = true
+    enable_floating_ip = true
+    idle_timeout_in_minutes = 30
+    frontend_ip_configuration_name = "loadbalancer-test-002"
+  }
+}
+
+keyvaults = {
+  kv_lb_001 = {
+    name = "loadbalancer-example"
+    resource_group_key = "rg_lb_001"
+    sku_name = "standard"
+    creation_policies = {
+      logged_in_user = {
+        secret_permissions = ["Set", "Get", "List", "Delete", "Purge", "Recover"]
+        key_permissions = ["Get", "List", "Update", "Create", "Import", "Delete", "Recover", "Backup", "Restore", "Decrypt", "Encrypt", "UnwrapKey", "WrapKey", "Verify", "Sign", "Purge"]
+      }
+    }
+  }
+}
+
+virtual_machines = {
+  vm_lb_001 = {
+    resource_group_key = "rg_lb_001"
+    os_type = "linux"
+    keyvault_key = "kv_lb_001"
+
+    networking_interfaces = {
+      nic_lb_001 = {
+        vnet_key = "vnet_lb_001"
+        subnet_key = "snet_lb_001"
+        name = "loadbalancer-example-001"
+        enable_ip_forwarding = false
+      }
+    }
+
+    virtual_machine_settings = {
+      linux = {
+        name = "loadbalancer-example-001"
+        size = "Standard_F2"
+        admin_username = "adminuser"
+        disable_password_authentication = true
+        network_interface_keys = ["nic_lb_001"]
+
+        os_disk = {
+          name = "loadbalancer-example-001"
+          caching = "ReadWrite"
+          storage_account_type = "Standard_LRS"
+        }
+
+        source_image_reference = {
+          publisher = "Canonical"
+          offer = "UbuntuServer"
+          sku = "18.04-LTS"
+          version = "latest"
+        }
+      }
+    }
+  }
+  vm_lb_002 = {
+    resource_group_key = "rg_lb_001"
+    os_type = "linux"
+    keyvault_key = "kv_lb_001"
+
+    networking_interfaces = {
+      nic_lb_002 = {
+        vnet_key = "vnet_lb_001"
+        subnet_key = "snet_lb_001"
+        name = "loadbalancer-example-002"
+        enable_ip_forwarding = false
+      }
+    }
+
+    virtual_machine_settings = {
+      linux = {
+        name = "loadbalancer-example-002"
+        size = "Standard_F2"
+        admin_username = "adminuser"
+        disable_password_authentication = true
+        network_interface_keys = ["nic_lb_002"]
+
+        os_disk = {
+          name = "loadbalancer-example-002"
+          caching = "ReadWrite"
+          storage_account_type = "Standard_LRS"
+        }
+
+        source_image_reference = {
+          publisher = "Canonical"
+          offer = "UbuntuServer"
+          sku = "18.04-LTS"
+          version = "latest"
+        }
+      }
+    }
+  }
+}

--- a/examples/networking/lb/103-lb-multi-frontend-ip/configurations.tfvars
+++ b/examples/networking/lb/103-lb-multi-frontend-ip/configurations.tfvars
@@ -160,7 +160,7 @@ lb_rule = {
     disable_outbound_snat               = true
     enable_floating_ip                  = true
     idle_timeout_in_minutes             = 30
-    frontend_ip_configuration_name      = "loadbalancer-test-002"
+    frontend_ip_configuration_name      = "loadbalancer-example-002"
   }
 }
 

--- a/modules/networking/lb/module.tf
+++ b/modules/networking/lb/module.tf
@@ -15,7 +15,7 @@ resource "azurerm_lb" "lb" {
   location            = var.location
 
   dynamic "frontend_ip_configuration" {
-    for_each = try(var.settings.frontend_ip_configuration, null) != null ? [var.settings.frontend_ip_configuration] : []
+    for_each = try(var.settings.frontend_ip_configuration, null)
     content {
       name                                               = try(frontend_ip_configuration.value.name, null)
       gateway_load_balancer_frontend_ip_configuration_id = try(frontend_ip_configuration.value.gateway_load_balancer_frontend_ip_configuration_id, null)

--- a/modules/networking/lb/module.tf
+++ b/modules/networking/lb/module.tf
@@ -26,7 +26,7 @@ resource "azurerm_lb" "lb" {
       zones                                              = can(frontend_ip_configuration.value.zones) ? frontend_ip_configuration.value.zones : try(frontend_ip_configuration.value.availability_zone, null)
       # TODO: availability_zone kept for smooth migration to 3.0
 
-      public_ip_address_id = can(frontend_ip_configuration.value.public_ip_address.id) || can(frontend_ip_configuration.value.public_ip_address.key) ? try(frontend_ip_configuration.value.public_ip_address.id, var.remote_objects.public_ip_addresses[try(frontend_ip_configuration.value.public_ip_address.lz_key, var.client_config.landingzone_key)][frontend_ip_configuration.value.public_ip_address.key].id) : null
+      public_ip_address_id = can(frontend_ip_configuration.value.public_ip_address.id) || can(frontend_ip_configuration.value.public_ip_address.key) ? can(frontend_ip_configuration.value.public_ip_address.id) ? frontend_ip_configuration.value.public_ip_address.id : var.remote_objects.public_ip_addresses[try(frontend_ip_configuration.value.public_ip_address.lz_key, var.client_config.landingzone_key)][frontend_ip_configuration.value.public_ip_address.key].id : null
       subnet_id            = can(frontend_ip_configuration.value.subnet.id) || can(frontend_ip_configuration.value.subnet.key) ? try(frontend_ip_configuration.value.subnet.id, var.remote_objects.virtual_network[try(frontend_ip_configuration.value.subnet.lz_key, var.client_config.landingzone_key)][frontend_ip_configuration.value.subnet.vnet_key].subnets[frontend_ip_configuration.value.subnet.key].id) : null
 
     }

--- a/modules/networking/lb_backend_address_pool/module.tf
+++ b/modules/networking/lb_backend_address_pool/module.tf
@@ -10,7 +10,7 @@ resource "azurecaf_name" "lb" {
   use_slug      = var.global_settings.use_slug
 }
 resource "azurerm_lb_backend_address_pool" "lb" {
-  loadbalancer_id = can(var.settings.loadbalancer.id) || can(var.settings.loadbalancer.key) ? try(var.settings.loadbalancer.id, var.remote_objects.lb[try(var.settings.loadbalancer.lz_key, var.client_config.landingzone_key)][var.settings.loadbalancer.key].id) : null
+  loadbalancer_id = can(var.settings.loadbalancer.id) ? var.settings.loadbalancer.id : can(var.settings.loadbalancer.key) ? var.remote_objects.lb[try(var.settings.loadbalancer.lz_key, var.client_config.landingzone_key)][var.settings.loadbalancer.key].id : null
   name            = azurecaf_name.lb.result
 
   dynamic "tunnel_interface" {

--- a/modules/networking/lb_nat_pool/module.tf
+++ b/modules/networking/lb_nat_pool/module.tf
@@ -16,7 +16,7 @@ resource "azurerm_lb_nat_pool" "lb" {
   frontend_port_end              = var.settings.frontend_port_end
   frontend_port_start            = var.settings.frontend_port_start
   idle_timeout_in_minutes        = try(var.settings.idle_timeout_in_minutes, null)
-  loadbalancer_id                = can(var.settings.loadbalancer.id) || can(var.settings.loadbalancer.key) ? try(var.settings.loadbalancer.id, var.remote_objects.lb[try(var.settings.loadbalancer.lz_key, var.client_config.landingzone_key)][var.settings.loadbalancer.key].id) : null
+  loadbalancer_id                = can(var.settings.loadbalancer.id) ? var.settings.loadbalancer.id : can(var.settings.loadbalancer.key) ? var.remote_objects.lb[try(var.settings.loadbalancer.lz_key, var.client_config.landingzone_key)][var.settings.loadbalancer.key].id : null
   name                           = azurecaf_name.lb.result
   protocol                       = var.settings.protocol
   resource_group_name            = var.resource_group_name

--- a/modules/networking/lb_nat_rule/module.tf
+++ b/modules/networking/lb_nat_rule/module.tf
@@ -16,7 +16,7 @@ resource "azurerm_lb_nat_rule" "lb" {
   frontend_ip_configuration_name = var.settings.frontend_ip_configuration_name
   frontend_port                  = var.settings.frontend_port
   idle_timeout_in_minutes        = try(var.settings.idle_timeout_in_minutes, null)
-  loadbalancer_id                = can(var.settings.loadbalancer.id) || can(var.settings.loadbalancer.key) ? try(var.settings.loadbalancer.id, var.remote_objects.lb[try(var.settings.loadbalancer.lz_key, var.client_config.landingzone_key)][var.settings.loadbalancer.key].id) : null
+  loadbalancer_id                = can(var.settings.loadbalancer.id) ? var.settings.loadbalancer.id : can(var.settings.loadbalancer.key) ? var.remote_objects.lb[try(var.settings.loadbalancer.lz_key, var.client_config.landingzone_key)][var.settings.loadbalancer.key].id : null
   name                           = azurecaf_name.lb.result
   protocol                       = var.settings.protocol
   resource_group_name            = var.resource_group_name

--- a/modules/networking/lb_outbound_rule/module.tf
+++ b/modules/networking/lb_outbound_rule/module.tf
@@ -14,7 +14,7 @@ resource "azurerm_lb_outbound_rule" "lb" {
   backend_address_pool_id  = can(var.settings.backend_address_pool.id) || can(var.settings.backend_address_pool.key) ? try(var.settings.backend_address_pool.id, var.remote_objects.lb_backend_address_pool[try(var.settings.backend_address_pool.lz_key, var.client_config.landingzone_key)][var.settings.backend_address_pool.key].id) : null
   enable_tcp_reset         = try(var.settings.enable_tcp_reset, null)
   idle_timeout_in_minutes  = try(var.settings.idle_timeout_in_minutes, null)
-  loadbalancer_id          = can(var.settings.loadbalancer.id) || can(var.settings.loadbalancer.key) ? try(var.settings.loadbalancer.id, var.remote_objects.lb[try(var.settings.loadbalancer.lz_key, var.client_config.landingzone_key)][var.settings.loadbalancer.key].id) : null
+  loadbalancer_id          = can(var.settings.loadbalancer.id) ? var.settings.loadbalancer.id : can(var.settings.loadbalancer.key) ? var.remote_objects.lb[try(var.settings.loadbalancer.lz_key, var.client_config.landingzone_key)][var.settings.loadbalancer.key].id : null
   name                     = azurecaf_name.lb.result
   protocol                 = var.settings.protocol
 

--- a/modules/networking/lb_probe/module.tf
+++ b/modules/networking/lb_probe/module.tf
@@ -11,7 +11,7 @@ resource "azurecaf_name" "lb" {
 }
 resource "azurerm_lb_probe" "lb" {
   name                = azurecaf_name.lb.result
-  loadbalancer_id     = can(var.settings.loadbalancer.id) || can(var.settings.loadbalancer.key) ? try(var.settings.loadbalancer.id, var.remote_objects.lb[try(var.settings.loadbalancer.lz_key, var.client_config.landingzone_key)][var.settings.loadbalancer.key].id) : null
+  loadbalancer_id     = can(var.settings.loadbalancer.id) ? var.settings.loadbalancer.id : can(var.settings.loadbalancer.key) ? var.remote_objects.lb[try(var.settings.loadbalancer.lz_key, var.client_config.landingzone_key)][var.settings.loadbalancer.key].id : null
   protocol            = try(var.settings.protocol, null)
   port                = var.settings.port
   request_path        = try(var.settings.request_path, null)

--- a/modules/networking/lb_rule/module.tf
+++ b/modules/networking/lb_rule/module.tf
@@ -11,7 +11,7 @@ resource "azurecaf_name" "lb" {
 }
 resource "azurerm_lb_rule" "lb" {
   name                           = azurecaf_name.lb.result
-  loadbalancer_id                = can(var.settings.loadbalancer.id) || can(var.settings.loadbalancer.key) ? try(var.settings.loadbalancer.id, var.remote_objects.lb[try(var.settings.loadbalancer.lz_key, var.client_config.landingzone_key)][var.settings.loadbalancer.key].id) : null
+  loadbalancer_id                = can(var.settings.loadbalancer.id) ? var.settings.loadbalancer.id : can(var.settings.loadbalancer.key) ? var.remote_objects.lb[try(var.settings.loadbalancer.lz_key, var.client_config.landingzone_key)][var.settings.loadbalancer.key].id : null
   frontend_ip_configuration_name = var.settings.frontend_ip_configuration_name
   protocol                       = var.settings.protocol
   frontend_port                  = var.settings.frontend_port


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/1848)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

This is based on https://github.com/aztfmod/terraform-azurerm-caf/pull/1849 and adds fixes to resource recreation problems when adding/changing loadbalancer configuration.

```
➜  examples git:(main) ✗ terraform plan -var-file networking/lb/100-lb/configurations.tfvars
module.example.random_string.prefix[0]: Refreshing state... [id=vvws]
module.example.module.lb_probe["lbp1"].azurecaf_name.lb: Refreshing state... [id=fjabrfeqpnfrqvlm]
module.example.module.lb_nat_pool["lbnp1"].azurecaf_name.lb: Refreshing state... [id=ivpaxbylfpcfsbhw]
module.example.module.lb_outbound_rule["lbor1"].azurecaf_name.lb: Refreshing state... [id=hhhnbkkubwobtskv]
module.example.module.lb["lb1"].azurecaf_name.lb: Refreshing state... [id=hwkpiiyaanhlhulh]
module.example.module.lb_backend_address_pool_address["lbbapa1"].azurecaf_name.lb: Refreshing state... [id=etbtddubtfdphycr]
module.example.azurecaf_name.public_ip_addresses["lb_pip"]: Refreshing state... [id=kkoanxkoeilvjkxn]
module.example.module.lb_nat_rule["lbnr1"].azurecaf_name.lb: Refreshing state... [id=mxjkssagsvgpiyig]
module.example.module.lb_backend_address_pool["lbap1"].azurecaf_name.lb: Refreshing state... [id=kolhfnxsdskpiefk]
module.example.module.lb_rule["lbr2"].azurecaf_name.lb: Refreshing state... [id=yadxitlkntvvnhfh]
module.example.module.lb_rule["lbr1"].azurecaf_name.lb: Refreshing state... [id=eywakhodqhuvrkag]
module.example.data.azuread_client_config.current: Reading...
module.example.data.azuread_client_config.current: Read complete after 0s [id=3fd2cab1-f540-48f1-b76d-55f4d472c837-04b07795-8ddb-461a-bbee-02f9e1bf7b46-39f09920-9e89-441d-b217-d7ec228041a5]
module.example.data.azurerm_client_config.current: Reading...
module.example.module.resource_group_reused["rg1"].data.azurerm_resource_group.rg: Reading...
module.example.data.azurerm_subscription.primary: Reading...
data.azurerm_client_config.default: Reading...
module.example.data.azurerm_client_config.current: Read complete after 0s [id=Y2xpZW50Q29uZmlncy9jbGllbnRJZD0wNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDY7b2JqZWN0SWQ9MzlmMDk5MjAtOWU4OS00NDFkLWIyMTctZDdlYzIyODA0MWE1O3N1YnNjcmlwdGlvbklkPTk1MjY2N2ZmLTFkM2EtNDFjZS1iMjVmLWEzNmI3MTc1YzQzNjt0ZW5hbnRJZD0zZmQyY2FiMS1mNTQwLTQ4ZjEtYjc2ZC01NWY0ZDQ3MmM4Mzc=]
data.azurerm_client_config.default: Read complete after 0s [id=Y2xpZW50Q29uZmlncy9jbGllbnRJZD0wNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDY7b2JqZWN0SWQ9MzlmMDk5MjAtOWU4OS00NDFkLWIyMTctZDdlYzIyODA0MWE1O3N1YnNjcmlwdGlvbklkPTk1MjY2N2ZmLTFkM2EtNDFjZS1iMjVmLWEzNmI3MTc1YzQzNjt0ZW5hbnRJZD0zZmQyY2FiMS1mNTQwLTQ4ZjEtYjc2ZC01NWY0ZDQ3MmM4Mzc=]
module.example.data.azurerm_subscription.primary: Read complete after 1s [id=/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436]
module.example.module.resource_group_reused["rg1"].data.azurerm_resource_group.rg: Read complete after 1s [id=/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2]
module.example.module.networking["vnet1"].azurecaf_name.caf_name_vnet: Refreshing state... [id=dmwqojmtivarwlbl]
module.example.module.networking["vnet1"].module.subnets["subnet1"].azurecaf_name.subnet: Refreshing state... [id=vspfovtbflrfhkfy]
module.example.module.public_ip_addresses["lb_pip"].azurerm_public_ip.pip: Refreshing state... [id=/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/publicIPAddresses/vvws-pip-lb_pip1]
module.example.module.networking["vnet1"].azurerm_virtual_network.vnet: Refreshing state... [id=/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/virtualNetworks/vvws-vnet-vnet1]
module.example.module.networking["vnet1"].module.subnets["subnet1"].azurerm_subnet.subnet: Refreshing state... [id=/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/virtualNetworks/vvws-vnet-vnet1/subnets/vvws-snet-subnet1]
module.example.module.lb["lb1"].azurerm_lb.lb: Refreshing state... [id=/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer]
module.example.module.lb_nat_rule["lbnr1"].azurerm_lb_nat_rule.lb: Refreshing state... [id=/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/inboundNatRules/vvws-lbnatrl-HttpAccess]
module.example.module.lb_backend_address_pool["lbap1"].azurerm_lb_backend_address_pool.lb: Refreshing state... [id=/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/backendAddressPools/vvws-adf-BackEndAddressPool]
module.example.module.lb_nat_pool["lbnp1"].azurerm_lb_nat_pool.lb: Refreshing state... [id=/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/inboundNatPools/vvws-adf-SampleApplicationPool]
module.example.module.lb_probe["lbp1"].azurerm_lb_probe.lb: Refreshing state... [id=/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/probes/vvws-adf-ssh-running-probe]
module.example.module.lb_backend_address_pool_address["lbbapa1"].azurerm_lb_backend_address_pool_address.lb: Refreshing state... [id=/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/backendAddressPools/vvws-adf-BackEndAddressPool/addresses/vvws-adf-example]
module.example.module.lb_outbound_rule["lbor1"].azurerm_lb_outbound_rule.lb: Refreshing state... [id=/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/outboundRules/vvws-adf-OutboundRule]
module.example.module.lb_rule["lbr2"].azurerm_lb_rule.lb: Refreshing state... [id=/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/loadBalancingRules/vvws-adf-LBRule1]
module.example.module.lb_rule["lbr1"].azurerm_lb_rule.lb: Refreshing state... [id=/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/loadBalancingRules/vvws-adf-LBRule]

Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform apply" which may have affected this plan:

  # module.example.module.lb["lb1"].azurerm_lb.lb has changed
  ~ resource "azurerm_lb" "lb" {
        id                   = "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer"
        name                 = "vvws-lb-TestLoadBalancer"
        tags                 = {
            "module" = "lb"
        }
        # (5 unchanged attributes hidden)

      ~ frontend_ip_configuration {
            id                            = "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/frontendIPConfigurations/PublicIPAddress"
          ~ inbound_nat_rules             = [
              + "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/inboundNatRules/vvws-lbnatrl-HttpAccess",
            ]
          ~ load_balancer_rules           = [
              + "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/loadBalancingRules/vvws-adf-LBRule",
              + "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/loadBalancingRules/vvws-adf-LBRule1",
            ]
            name                          = "PublicIPAddress"
          ~ outbound_rules                = [
              + "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/outboundRules/vvws-adf-OutboundRule",
            ]
          + zones                         = []
            # (2 unchanged attributes hidden)
        }
    }

  # module.example.module.lb_backend_address_pool["lbap1"].azurerm_lb_backend_address_pool.lb has changed
  ~ resource "azurerm_lb_backend_address_pool" "lb" {
        id                        = "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/backendAddressPools/vvws-adf-BackEndAddressPool"
      ~ load_balancing_rules      = [
          + "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/loadBalancingRules/vvws-adf-LBRule1",
        ]
        name                      = "vvws-adf-BackEndAddressPool"
      ~ outbound_rules            = [
          + "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/outboundRules/vvws-adf-OutboundRule",
        ]
        # (3 unchanged attributes hidden)
    }


Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes, the following plan may include actions to undo or respond to these changes.

─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # module.example.azurecaf_name.public_ip_addresses["lb_pip2"] will be created
  + resource "azurecaf_name" "public_ip_addresses" {
      + clean_input   = true
      + id            = (known after apply)
      + name          = "lb_pip2"
      + passthrough   = false
      + prefixes      = [
          + "vvws",
        ]
      + random_length = 0
      + resource_type = "azurerm_public_ip"
      + result        = (known after apply)
      + results       = (known after apply)
      + separator     = "-"
      + use_slug      = true
    }

  # module.example.module.lb["lb1"].azurerm_lb.lb will be updated in-place
  ~ resource "azurerm_lb" "lb" {
        id                   = "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer"
        name                 = "vvws-lb-TestLoadBalancer"
        tags                 = {
            "module" = "lb"
        }
        # (5 unchanged attributes hidden)

      ~ frontend_ip_configuration {
            id                            = "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/frontendIPConfigurations/PublicIPAddress"
            name                          = "PublicIPAddress"
          ~ public_ip_address_id          = "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/publicIPAddresses/vvws-pip-lb_pip1" -> (known after apply)
            # (5 unchanged attributes hidden)
        }
    }

  # module.example.module.lb_backend_address_pool["lbap1"].azurerm_lb_backend_address_pool.lb must be replaced
-/+ resource "azurerm_lb_backend_address_pool" "lb" {
      ~ backend_ip_configurations = [] -> (known after apply)
      ~ id                        = "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/backendAddressPools/vvws-adf-BackEndAddressPool" -> (known after apply)
      ~ inbound_nat_rules         = [] -> (known after apply)
      ~ load_balancing_rules      = [
          - "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/loadBalancingRules/vvws-adf-LBRule1",
        ] -> (known after apply)
      ~ loadbalancer_id           = "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer" # forces replacement -> (known after apply) # forces replacement
        name                      = "vvws-adf-BackEndAddressPool"
      ~ outbound_rules            = [
          - "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/outboundRules/vvws-adf-OutboundRule",
        ] -> (known after apply)
    }

  # module.example.module.lb_backend_address_pool_address["lbbapa1"].azurerm_lb_backend_address_pool_address.lb must be replaced
-/+ resource "azurerm_lb_backend_address_pool_address" "lb" {
      ~ backend_address_pool_id       = "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/backendAddressPools/vvws-adf-BackEndAddressPool" # forces replacement -> (known after apply) # forces replacement
      ~ id                            = "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/backendAddressPools/vvws-adf-BackEndAddressPool/addresses/vvws-adf-example" -> (known after apply)
      ~ inbound_nat_rule_port_mapping = [] -> (known after apply)
        name                          = "vvws-adf-example"
        # (2 unchanged attributes hidden)
    }

  # module.example.module.lb_nat_pool["lbnp1"].azurerm_lb_nat_pool.lb must be replaced
-/+ resource "azurerm_lb_nat_pool" "lb" {
      - floating_ip_enabled            = false -> null
      ~ frontend_ip_configuration_id   = "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/frontendIPConfigurations/PublicIPAddress" -> (known after apply)
      ~ id                             = "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/inboundNatPools/vvws-adf-SampleApplicationPool" -> (known after apply)
      ~ loadbalancer_id                = "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer" # forces replacement -> (known after apply) # forces replacement
        name                           = "vvws-adf-SampleApplicationPool"
      - tcp_reset_enabled              = false -> null
        # (7 unchanged attributes hidden)
    }

  # module.example.module.lb_nat_rule["lbnr1"].azurerm_lb_nat_rule.lb must be replaced
-/+ resource "azurerm_lb_nat_rule" "lb" {
      + backend_ip_configuration_id    = (known after apply)
      ~ enable_floating_ip             = false -> (known after apply)
      - enable_tcp_reset               = false -> null
      ~ frontend_ip_configuration_id   = "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/frontendIPConfigurations/PublicIPAddress" -> (known after apply)
      ~ id                             = "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/inboundNatRules/vvws-lbnatrl-HttpAccess" -> (known after apply)
      ~ idle_timeout_in_minutes        = 4 -> (known after apply)
      ~ loadbalancer_id                = "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer" # forces replacement -> (known after apply) # forces replacement
        name                           = "vvws-lbnatrl-HttpAccess"
        # (5 unchanged attributes hidden)
    }

  # module.example.module.lb_outbound_rule["lbor1"].azurerm_lb_outbound_rule.lb must be replaced
-/+ resource "azurerm_lb_outbound_rule" "lb" {
      ~ backend_address_pool_id  = "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/backendAddressPools/vvws-adf-BackEndAddressPool" -> (known after apply)
      ~ id                       = "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/outboundRules/vvws-adf-OutboundRule" -> (known after apply)
      ~ loadbalancer_id          = "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer" # forces replacement -> (known after apply) # forces replacement
        name                     = "vvws-adf-OutboundRule"
        # (4 unchanged attributes hidden)

      ~ frontend_ip_configuration {
          ~ id   = "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/frontendIPConfigurations/PublicIPAddress" -> (known after apply)
            name = "PublicIPAddress"
        }
    }

  # module.example.module.lb_probe["lbp1"].azurerm_lb_probe.lb must be replaced
-/+ resource "azurerm_lb_probe" "lb" {
      ~ id                  = "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/probes/vvws-adf-ssh-running-probe" -> (known after apply)
      ~ load_balancer_rules = [
          - "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/loadBalancingRules/vvws-adf-LBRule1",
        ] -> (known after apply)
      ~ loadbalancer_id     = "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer" # forces replacement -> (known after apply) # forces replacement
        name                = "vvws-adf-ssh-running-probe"
      ~ protocol            = "Tcp" -> (known after apply)
        # (4 unchanged attributes hidden)
    }

  # module.example.module.lb_rule["lbr1"].azurerm_lb_rule.lb must be replaced
-/+ resource "azurerm_lb_rule" "lb" {
      - backend_address_pool_ids       = [] -> null
      - enable_tcp_reset               = false -> null
      ~ frontend_ip_configuration_id   = "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/frontendIPConfigurations/PublicIPAddress" -> (known after apply)
      ~ id                             = "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/loadBalancingRules/vvws-adf-LBRule" -> (known after apply)
      ~ idle_timeout_in_minutes        = 4 -> (known after apply)
      ~ load_distribution              = "Default" -> (known after apply)
      ~ loadbalancer_id                = "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer" # forces replacement -> (known after apply) # forces replacement
        name                           = "vvws-adf-LBRule"
      + probe_id                       = (known after apply)
        # (6 unchanged attributes hidden)
    }

  # module.example.module.lb_rule["lbr2"].azurerm_lb_rule.lb must be replaced
-/+ resource "azurerm_lb_rule" "lb" {
      ~ backend_address_pool_ids       = [
          - "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/backendAddressPools/vvws-adf-BackEndAddressPool",
        ] -> (known after apply)
      - enable_tcp_reset               = false -> null
      ~ frontend_ip_configuration_id   = "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/frontendIPConfigurations/PublicIPAddress" -> (known after apply)
      ~ id                             = "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/loadBalancingRules/vvws-adf-LBRule1" -> (known after apply)
      ~ idle_timeout_in_minutes        = 4 -> (known after apply)
      ~ load_distribution              = "Default" -> (known after apply)
      ~ loadbalancer_id                = "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer" # forces replacement -> (known after apply) # forces replacement
        name                           = "vvws-adf-LBRule1"
      ~ probe_id                       = "/subscriptions/952667ff-1d3a-41ce-b25f-a36b7175c436/resourceGroups/sisch-test2/providers/Microsoft.Network/loadBalancers/vvws-lb-TestLoadBalancer/probes/vvws-adf-ssh-running-probe" -> (known after apply)
        # (6 unchanged attributes hidden)
    }

  # module.example.module.public_ip_addresses["lb_pip2"].azurerm_public_ip.pip will be created
  + resource "azurerm_public_ip" "pip" {
      + allocation_method       = "Static"
      + ddos_protection_mode    = "VirtualNetworkInherited"
      + fqdn                    = (known after apply)
      + id                      = (known after apply)
      + idle_timeout_in_minutes = 4
      + ip_address              = (known after apply)
      + ip_version              = "IPv4"
      + location                = "westeurope"
      + name                    = (known after apply)
      + resource_group_name     = "sisch-test2"
      + sku                     = "Standard"
      + sku_tier                = "Regional"
      + zones                   = [
          + "1",
          + "2",
          + "3",
        ]
    }

Plan: 10 to add, 1 to change, 8 to destroy.

Changes to Outputs:
  ~ objects = (sensitive value)
╷
│ Warning: Deprecated Resource
│ 
│   with module.example.module.integration_service_environment.azurerm_integration_service_environment.ise,
│   on ../modules/logic_app/integration_service_environment/module.tf line 12, in resource "azurerm_integration_service_environment" "ise":
│   12: resource "azurerm_integration_service_environment" "ise" {
│ 
│ The "azurerm_integrated_service_environment" resource is deprecated and will be removed in v4.0 of the Azure Provider. The underlying Azure Service is being retired on 2024-08-31 and new instances cannot be
│ provisioned by default after 2022-11-01. More information on the retirement and how to migrate to Logic Apps Standard ("azurerm_logic_app_standard") can be found here: https://aka.ms/isedeprecation.
│ 
│ (and 5 more similar warnings elsewhere)
╵

─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
```

## Does this introduce a breaking change

- [x] YES
- [ ] NO

- frontend_ip_configuration in lb need to change from list to named referenced map

## Testing

<!-- Instructions for testing and validation of your code -->
