### PR TITLE
fix(public_ip_addresses): reverse_fqdn type

### DIFF
--- a/modules/networking/public_ip_addresses/variables.tf
+++ b/modules/networking/public_ip_addresses/variables.tf
@@ -70,7 +70,7 @@ variable "generate_domain_name_label" {
 
 variable "reverse_fqdn" {
   description = "(Optional) A fully qualified domain name that resolves to this public IP address. If the reverseFqdn is specified, then a PTR DNS record is created pointing from the IP address in the in-addr.arpa domain to the reverse FQDN."
-  type        = bool
+  type        = string
   default     = null
 }
 


### PR DESCRIPTION
## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

reverse_fqdn requires a string to be defined for public_ip_address, but was bool, which made it unusable

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
