### PR TITLE
Add Support of domain_configuration_type parameter

### DIFF
--- a/examples/identity/active_directory_domain_service/100-active_directory_domain_service-replica/configuration.tfvars
+++ b/examples/identity/active_directory_domain_service/100-active_directory_domain_service-replica/configuration.tfvars
@@ -37,9 +37,10 @@ active_directory_domain_service = {
     resource_group = {
       key = "rg"
     }
-    domain_name           = "widgetslogin.net"
-    sku                   = "Enterprise"
-    filtered_sync_enabled = false
+    domain_name               = "widgetslogin.net"
+    sku                       = "Enterprise"
+    filtered_sync_enabled     = false
+    domain_configuration_type = "FullySynced"
 
     initial_replica_set = {
       region = "region1"

--- a/modules/identity/active_directory_domain_service/module.tf
+++ b/modules/identity/active_directory_domain_service/module.tf
@@ -19,13 +19,14 @@ resource "azurecaf_name" "aadds" {
 #   use_slug      = var.global_settings.use_slug
 # }
 resource "azurerm_active_directory_domain_service" "aadds" {
-  name                  = azurecaf_name.aadds.result
-  resource_group_name   = local.resource_group_name
-  location              = local.location
-  domain_name           = var.settings.domain_name
-  filtered_sync_enabled = try(var.settings.filtered_sync_enabled, null)
-  sku                   = var.settings.sku
-  tags                  = merge(local.tags, try(var.settings.tags, {}))
+  name                      = azurecaf_name.aadds.result
+  resource_group_name       = local.resource_group_name
+  location                  = local.location
+  domain_name               = var.settings.domain_name
+  filtered_sync_enabled     = try(var.settings.filtered_sync_enabled, null)
+  domain_configuration_type = try(var.settings.domain_configuration_type, null)
+  sku                       = var.settings.sku
+  tags                      = merge(local.tags, try(var.settings.tags, {}))
 
   dynamic "secure_ldap" {
     for_each = can(var.settings.secure_ldap) ? [var.settings.secure_ldap] : []


### PR DESCRIPTION
## PR Checklist

---


- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [X] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Add support of [domain_configuration_type] (https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/active_directory_domain_service#domain_configuration_type) in the AADDS module.

Edit example configuration by adding the [domain_configuration_type] with "FullySynced"

## Does this introduce a breaking change

- [ ] YES
- [X] NO


## Testing


