### PR TITLE
Added support for dynamic_keyvault_secrets to role_mapping

### DIFF
--- a/examples/role_mapping/102-dynamic-secret-role-mapping/configuration.tfvars
+++ b/examples/role_mapping/102-dynamic-secret-role-mapping/configuration.tfvars
@@ -1,0 +1,97 @@
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "westeurope"
+  }
+}
+
+resource_groups = {
+  rg1 = {
+    name = "example-msi-kv-rg1"
+  }
+}
+
+keyvaults = {
+  kv1 = {
+    name                      = "kv1examplemsi"
+    resource_group_key        = "rg1"
+    sku_name                  = "premium"
+    soft_delete_enabled       = true
+    enable_rbac_authorization = true
+
+    # creation_policies = {}
+    # }
+
+  }
+}
+
+dynamic_keyvault_secrets = {
+  kv1 = {
+    domain_join_username = {
+      secret_name = "domain-join-username"
+      value       = "domainjoinuser@contoso.com"
+    }
+    domain_join_password = {
+      secret_name = "domain-join-password"
+      value       = "MyDoma1nVery@Str5ngP!44w0rdToChaNge#"
+    }
+  }
+}
+
+managed_identities = {
+  msi1 = { # managed identity key
+    name               = "msi1"
+    resource_group_key = "rg1"
+  }
+}
+
+azuread_groups = {
+  my_group = { # azuread group key
+    name = "my_group"
+  }
+}
+
+azuread_groups_membership = {
+  my_group = { # azuread group key
+    managed_identities = {
+      members = {
+        keys = ["msi1"]
+      }
+    }
+  }
+}
+
+role_mapping = {
+  built_in_role_mapping = {
+    # keyvaults = { 
+    #   kv1 = {
+    #     "Key Vault Administrator" = {
+    #       logged_in = {
+    #         keys = ["user"]
+    #       }
+    #     }
+    #   }
+    # }
+    # To be able to run this example the user/service principal should already have 
+    # "Key Vault Administrator" to be able to create dynamic_keyvault_secrets in the newly created keyvault.
+    # And set the rights on the secrets
+    dynamic_keyvault_secrets = {
+      domain_join_username = { # dynamic keyvault secret key to apply role mapping to
+        keyvault_key = "kv1" # keyvault key in wich the secret is stored.
+        "Key Vault Secrets User" = {
+          azuread_groups = {
+            keys = ["my_group"]
+          }
+        }
+      }
+      domain_join_password = {
+        keyvault_key = "kv1"
+        "Key Vault Secrets User" = {
+          azuread_groups = {
+            keys = ["my_group"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/roles.tf
+++ b/roles.tf
@@ -72,6 +72,18 @@ data "azurerm_management_group" "level" {
   name = lower(each.key) == "root" ? data.azurerm_client_config.current.tenant_id : each.key
 }
 
+data "azurerm_key_vault_secret" "key_vault_secret" {
+  depends_on = [
+    module.dynamic_keyvault_secrets,
+    time_sleep.azurerm_role_assignment_for
+  ]
+  for_each = {
+    for key, value in try(var.role_mapping.built_in_role_mapping.dynamic_keyvault_secrets, {}) : key => value
+  }
+  key_vault_id = try(local.combined_objects_keyvaults[var.current_landingzone_key][each.value.keyvault_key].id, null)
+  name         = try(local.security.dynamic_keyvault_secrets[each.value.keyvault_key][each.key].secret_name, null)
+}
+
 locals {
 
   aks_ingress_application_gateway_identities = tomap(
@@ -96,10 +108,21 @@ locals {
     }
   )
 
+  dynamic_keyvault_secrets = tomap({
+      (var.current_landingzone_key) = {
+        for key, value in try(var.role_mapping.built_in_role_mapping.dynamic_keyvault_secrets, {}) :
+        key => {
+          id =  data.azurerm_key_vault_secret.key_vault_secret[key].resource_versionless_id
+        }
+      }
+    }
+  )
+
   # Nested objects that must be processed after the services_roles
   services_roles_deferred = {
     storage_containers          = local.combined_objects_storage_containers
     storage_account_file_shares = local.combined_objects_storage_account_file_shares
+    dynamic_keyvault_secrets    = local.dynamic_keyvault_secrets
   }
 
 
@@ -224,7 +247,7 @@ locals {
                     object_id_lz_key        = try(object_resources.lz_key, null)
                   }
                 ]
-              ] if role_definition_name != "lz_key"
+              ] if !contains(["lz_key", "keyvault_key"], role_definition_name)
             ]
           ]
         ]
@@ -248,44 +271,54 @@ locals {
 #       }
 #     }
 #   }
-
-#  built_in_role_mapping = {
-#       aks_clusters = {
-#         seacluster = {
-#           "Azure Kubernetes Service Cluster Admin Role" = {
-#             azuread_group_keys = {
-#               keys = [ "aks_admins" ]
-#             }
-#             managed_identity_keys = {
-#               keys = [ "jumpbox" ]
-#             }
+#
+#   built_in_role_mapping = {
+#     aks_clusters = {
+#       seacluster = {
+#         "Azure Kubernetes Service Cluster Admin Role" = {
+#           azuread_group_keys = {
+#             keys = [ "aks_admins" ]
 #           }
-#         }
-#       }
-#       azure_container_registries = {
-#         acr1 = {
-#           "AcrPull" = {
-#             aks_cluster_keys = {
-#               keys = [ "seacluster" ]
-#             }
-#           }
-#         }
-#       }
-#       storage_accounts = {
-#         scripts_region1 = {
-#           "Storage Blob Data Contributor" = {
-#             logged_in = {
-#               keys = [ "user" ]
-#             }
-#             managed_identities = {
-#               lz_key = "launchpad"
-#               keys = [ "level0", "level1" ]
-#             }
+#           managed_identity_keys = {
+#             keys = [ "jumpbox" ]
 #           }
 #         }
 #       }
 #     }
-# ......
+#     azure_container_registries = {
+#       acr1 = {
+#         "AcrPull" = {
+#           aks_cluster_keys = {
+#             keys = [ "seacluster" ]
+#           }
+#         }
+#       }
+#     }
+#     storage_accounts = {
+#       scripts_region1 = {
+#         "Storage Blob Data Contributor" = {
+#           logged_in = {
+#             keys = [ "user" ]
+#           }
+#           managed_identities = {
+#             lz_key = "launchpad"
+#             keys = [ "level0", "level1" ]
+#           }
+#         }
+#       }
+#     }
+#     dynamic_keyvault_secrets = {
+#       my_secret_key = {
+#         keyvault_key = "kv1"
+#         "Key Vault Secrets User" = {
+#           azuread_groups = {
+#             keys = ["my_group"]
+#           }
+#         }
+#       }
+#     }
+#   }
+#......
 
 ## Generates a transformed structure for azurerm_role_assignment to process
 # built_in_roles = {


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [X] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [X] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [X] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->

Run the provided example (examples/role_mapping/102-dynamic-secret-role-mapping/configuration.tfvars). 
Make sure the user/service principal already has "Key Vault Administrator" rights on the subscription/management group otherwise a RBAC chicken/egg issue occurs when creating the keyvault and tying to add secrets. 