### PR TITLE
Add wait time/delay  feature after private endpoint creation for private DNS zone policy

### DIFF
--- a/modules/networking/private_endpoint/private_endpoint.tf
+++ b/modules/networking/private_endpoint/private_endpoint.tf
@@ -54,3 +54,12 @@ resource "azurerm_private_endpoint" "pep" {
   }
 
 }
+
+resource "time_sleep" "delay" {
+  count = can(lookup(var.settings,var.settings.delay_time_after_creation,false)) ? 1: 0
+  depends_on = [azurerm_private_endpoint.pep]
+  create_duration = var.settings.delay_time_after_creation
+  lifecycle {
+    replace_triggered_by = [ azurerm_private_endpoint.pep ]
+  }
+}


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## Description

This feature will allow to create a delay or wait time after Private Endpoint creation if needed. This delay will help azure policy related to private dns zone to take effect (linking Azure private dns zone to private endpoint). This feature will work only if the variable **var.settings.delay_time_after_creation** is used in the private endpoint deployment.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

## Testing

To test this feature, use the parameter **delay_time_after_creation** in private_endpoints variable for a particular resource. 
