### PR TITLE
Fixed typo on set_resource.sh

### DIFF
--- a/modules/networking/application_gateway_application/scripts/set_resource.sh
+++ b/modules/networking/application_gateway_application/scripts/set_resource.sh
@@ -235,7 +235,7 @@ case "${RESOURCE}" in
         ignorecase=$([ -z "${IGNORE_CASE}" ] && echo "" || echo "--ignore-case ${IGNORE_CASE} ")
         negate=$([ -z "${NEGATE}" ] && echo "" || echo "--negate ${NEGATE} ")
         pattern=$([ -z "${PATTERN}" ] && echo "" || echo "--pattern ${PATTERN} ")
-2
+        
         execute_with_backoff az network application-gateway rewrite-rule condition create -g ${RG_NAME} \
             --gateway-name ${APPLICATION_GATEWAY_NAME} --variable ${VARIABLE} --rule-set-name ${RULE_SET_NAME} --rule-name ${RULE_NAME}\
             ${ignorecase} ${negate} ${pattern}


### PR DESCRIPTION
Fixed typo on set_resource.sh - line 238

# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->
release 5.7.8 has a typo on line 238 of set_resource.sh

## Does this introduce a breaking change

- [ ] YES
- [x ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
