### PR TITLE
Fix: Add time-sleep 30s to kv access policy

### DIFF
--- a/modules/security/keyvault/initial_policy.tf
+++ b/modules/security/keyvault/initial_policy.tf
@@ -11,3 +11,9 @@ module "initial_policy" {
     managed_identities = var.managed_identities
   }
 }
+
+resource "time_sleep" "initial_policy" {
+  depends_on = [module.initial_policy]
+
+  create_duration = "30s"
+}

--- a/modules/security/keyvault_access_policies/policies.tf
+++ b/modules/security/keyvault_access_policies/policies.tf
@@ -83,6 +83,12 @@ module "logged_in_user" {
   object_id     = var.client_config.object_id
 }
 
+resource "time_sleep" "logged_in_user" {
+  depends_on = [module.logged_in_user]
+
+  create_duration = "30s"
+}
+
 module "logged_in_aad_app" {
   source = "./access_policy"
   for_each = {
@@ -100,6 +106,12 @@ module "logged_in_aad_app" {
   access_policy = each.value
   tenant_id     = var.client_config.tenant_id
   object_id     = var.client_config.object_id
+}
+
+resource "time_sleep" "logged_in_aad_app" {
+  depends_on = [module.logged_in_aad_app]
+
+  create_duration = "30s"
 }
 
 module "object_id" {


### PR DESCRIPTION
# Add time-sleep 30s to kv access policy for:
- intial_policy
- logged_in_<user|app> policy

# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [- ] I have added example(s) inside the [./examples/] folder
- [- ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [X] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [X] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
