### PR TITLE
blob: Ignore local filename

### DIFF
--- a/modules/storage_account/blob/module.tf
+++ b/modules/storage_account/blob/module.tf
@@ -21,6 +21,10 @@ resource "azurerm_storage_blob" "blob" {
     replace_triggered_by = [
       random_id.md5
     ]
+
+    ignore_changes = [
+      source
+    ]
   }
 }
 


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

For my understanding the path and name of a local file should not matter. The checksum calculation logic should trigger if there is a change in the content of the file:
https://github.com/pho-enix/terraform-azurerm-caf/blob/15e0ba74053ffeade2fa729af8f1680951ad5f8e/modules/storage_account/blob/module.tf#L31

So my proposal is to ignore the `source` field. However I am not sure if there might by any corner- or special cases where this might be a problem.

## Does this introduce a breaking change

- [ ] YES
- [ ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
