### PR TITLE
Fix: Data factory iteration for global_parameter

### DIFF
--- a/modules/data_factory/data_factory/module.tf
+++ b/modules/data_factory/data_factory/module.tf
@@ -25,7 +25,7 @@ resource "azurerm_data_factory" "df" {
     }
   }
   dynamic "global_parameter" {
-    for_each = try(var.settings.global_parameter, null) != null ? [var.settings.global_parameter] : []
+    for_each = try(var.settings.global_parameter, null) != null ? var.settings.global_parameter : {}
 
     content {
       name  = global_parameter.value.name


### PR DESCRIPTION
global_parameter should be processed as list of objects

# [#990 Data factory dynamic iteration not working for global_parameter](https://github.com/aztfmod/terraform-azurerm-caf/issues/990)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [X ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

global_parameter is not treated correctly in the current code, resulting in an incorrect code generation and even errors.
The proposed fix solves this issue.

## Does this introduce a breaking change

- [ ] YES
- [X ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Created a data factory with 2 global parameters as follows which tested OK:

  data_factory = {
    data_factory = {
      df_adf = {
        name = "adf"
        resource_group = {
          key = "rg_adf"
          #name = ""
        }
        global_parameter = {
          gp_p1 = {
            name  = "P1"
            type  = "String"
            value = "p1"
          } 
          gp_p2 = {
            name  = "P2"
            type  = "String"
            value = "p2"
          } 
}
        identity = {
          type = "SystemAssigned"
        }
        managed_virtual_network_enabled = false
      }
