### PR TITLE
VM backup protection

### DIFF
--- a/compute_virtual_machines.tf
+++ b/compute_virtual_machines.tf
@@ -29,7 +29,7 @@ module "virtual_machines" {
   network_security_groups     = local.combined_objects_network_security_groups
   proximity_placement_groups  = local.combined_objects_proximity_placement_groups
   public_ip_addresses         = local.combined_objects_public_ip_addresses
-  recovery_vaults             = local.combined_objects_recovery_vaults
+  recovery_vaults             = can(each.value.backup.vault_key) ? local.combined_objects_recovery_vaults[try(each.value.backup.lz_key, local.client_config.landingzone_key)][each.value.backup.vault_key] : null
   settings                    = each.value
   storage_accounts            = local.combined_objects_storage_accounts
   vnets                       = local.combined_objects_networking

--- a/modules/compute/virtual_machine/backup.tf
+++ b/modules/compute/virtual_machine/backup.tf
@@ -1,25 +1,22 @@
-
 resource "azurerm_backup_protected_vm" "backup" {
   count = try(var.settings.backup, null) == null ? 0 : 1
 
   resource_group_name = coalesce(
-    try(var.settings.backup.backup_vault_rg, null),
-    try(split("/", var.settings.backup.backup_vault_id)[4], null),
-    try(var.recovery_vaults[var.client_config.landingzone_key][var.settings.backup.vault_key].resource_group_name, null),
-    try(var.recovery_vaults[var.settings.backup.lz_key][var.settings.backup.vault_key].resource_group_name, null)
+    try(var.recovery_vaults.resource_group_name, null),
+    try(var.settings.backup.backup_vault_rg , null),
+    try(split("/", var.settings.backup.backup_vault_id)[4], null)
   )
   recovery_vault_name = coalesce(
+    try(var.recovery_vaults.name , null),
     try(var.settings.backup.backup_vault_name, null),
-    try(split("/", var.settings.backup.backup_vault_id)[8], null),
-    try(var.recovery_vaults[var.client_config.landingzone_key][var.settings.backup.vault_key].name, null),
-    try(var.recovery_vaults[var.settings.backup.lz_key][var.settings.backup.vault_key].name, null)
-  )
+    try(split("/", var.settings.backup.backup_vault_id)[8], null)
+  ) 
   source_vm_id = local.os_type == "linux" ? try(azurerm_linux_virtual_machine.vm["linux"].id, null) : try(azurerm_windows_virtual_machine.vm["windows"].id, null)
-  backup_policy_id = coalesce(
-    try(var.settings.backup.backup_policy_id, null),
-    try(var.recovery_vaults[var.client_config.landingzone_key][var.settings.backup.vault_key].backup_policies.virtual_machines[var.settings.backup.policy_key].id, null),
-    try(var.recovery_vaults[var.settings.backup.lz_key][var.settings.backup.vault_key].backup_policies.virtual_machines[var.settings.backup.policy_key].id, null)
+  backup_policy_id  = coalesce(
+    try(var.recovery_vaults.backup_policies.virtual_machines[var.settings.backup.policy_key].id , null),
+    try(var.settings.backup.backup_policy_id, null)
   )
-
-  # tags                = local.tags      # Commented - forcing a plan to create some diff as the tag is not handled properly in 2.37.0
+  exclude_disk_luns = try(var.settings.backup.exclude_disk_luns , null)
+  include_disk_luns = try(var.settings.backup.include_disk_luns , null)
+  protection_state  = try(var.settings.backup.protection_state  , null)
 }


### PR DESCRIPTION
# [1828](https://github.com/aztfmod/terraform-azurerm-caf/issues/1828)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [ ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

version: aztfmod/rover:1.5.6-2309.0507

in my case, the vm module stopped re-creating the resource
please take a look.
maybe it will help solve the problem
at the same time added new features(exclude_disk_luns, include_disk_luns , protection_state )