### PR TITLE
Container Groups - network_profile_id is deprecated. Managed Identity Support for Container Registry

### DIFF
--- a/compute_container_groups.tf
+++ b/compute_container_groups.tf
@@ -18,6 +18,7 @@ module "container_groups" {
     keyvaults          = local.combined_objects_keyvaults
     managed_identities = local.combined_objects_managed_identities
     network_profiles   = local.combined_objects_network_profiles
+    networking         = local.combined_objects_networking
   }
 }
 


### PR DESCRIPTION
- network_profile_id is [deprecated](https://docs.microsoft.com/en-us/azure/container-instances/container-instances-vnet) by Azure. For users who want to continue to manage existing azurerm_container_group that rely on network_profile_id, please stay on provider versions prior to v3.16.0 (2 Years old). Otherwise, use subnet_ids instead.

- Azure Container Registry support for Managed Identity

# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/1946)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [X] I have added example(s) inside the [./examples/] folder
- [X] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [X] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [X] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

network_profile_id is [deprecated](https://docs.microsoft.com/en-us/azure/container-instances/container-instances-vnet) by Azure. For users who want to continue to manage existing azurerm_container_group that rely on network_profile_id, please stay on provider versions prior to v3.16.0. Otherwise, use subnet_ids instead.

[More Info - AzureRM SubnetIds](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_group#subnet_ids)

Azure Container Registry supports Managed Identity

## Does this introduce a breaking change

- [X] YES
- [ ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
Uses need to upgrade AzureRM version later than v3.16.0. Its been 2 years since this was deprecated. Its valid for users to upgrade the AzureRM provider.

## Testing

I have deployed these changes in my production environment using Rover and CAF Super Module / Landing Zone
`Running Terraform apply with plan /home/vscode/.terraform.cache/Test/rover_jobs/20240326231818809384800/tfstates/level0/tfstate/level0_azure_devops_agents.tfplan
Terraform apply (azurerm) with version v1.5.6
module.caf.module.container_groups["rover_level0"].azurerm_container_group.acg: Destroying... [id=/subscriptions/XYZ/resourceGroups/rg-devops-agents/providers/Microsoft.ContainerInstance/containerGroups/ci-rover-level0-test-001]
module.caf.module.container_groups["rover_level0"].azurerm_container_group.acg: Destruction complete after 3s
module.caf.module.resource_groups["integration"].azurerm_resource_group.rg: Modifying... [id=/subscriptions/XYZ/resourceGroups/rg-integration-devops-agents]
module.caf.module.resource_groups["rg1"].azurerm_resource_group.rg: Modifying... [id=/subscriptions/XYZ/resourceGroups/rg-devops-agents]
module.caf.module.resource_groups["integration"].azurerm_resource_group.rg: Modifications complete after 3s [id=/subscriptions/XYZ/resourceGroups/rg-integration-devops-agents]
module.caf.module.resource_groups["rg1"].azurerm_resource_group.rg: Modifications complete after 4s [id=/subscriptions/XYZ/resourceGroups/rg-devops-agents]
module.caf.module.container_groups["rover_level0"].azurerm_container_group.acg: Creating...
module.caf.module.container_groups["rover_level1"].azurerm_container_group.acg: Modifying... [id=/subscriptions/XYZ/resourceGroups/rg-devops-agents/providers/Microsoft.ContainerInstance/containerGroups/ci-rover-level1-test-001]
module.caf.module.container_groups["rover_level1"].azurerm_container_group.acg: Modifications complete after 3s [id=/subscriptions/XYZ/resourceGroups/rg-devops-agents/providers/Microsoft.ContainerInstance/containerGroups/ci-rover-level1-test-001]
module.caf.module.container_groups["rover_level0"].azurerm_container_group.acg: Still creating... [10s elapsed]
module.caf.module.container_groups["rover_level0"].azurerm_container_group.acg: Still creating... [20s elapsed]
module.caf.module.container_groups["rover_level0"].azurerm_container_group.acg: Still creating... [30s elapsed]
module.caf.module.container_groups["rover_level0"].azurerm_container_group.acg: Still creating... [40s elapsed]
module.caf.module.container_groups["rover_level0"].azurerm_container_group.acg: Still creating... [50s elapsed]
module.caf.module.container_groups["rover_level0"].azurerm_container_group.acg: Still creating... [1m0s elapsed]
module.caf.module.container_groups["rover_level0"].azurerm_container_group.acg: Still creating... [1m10s elapsed]
module.caf.module.container_groups["rover_level0"].azurerm_container_group.acg: Still creating... [1m20s elapsed]
module.caf.module.container_groups["rover_level0"].azurerm_container_group.acg: Still creating... [1m30s elapsed]
module.caf.module.container_groups["rover_level0"].azurerm_container_group.acg: Still creating... [1m40s elapsed]
module.caf.module.container_groups["rover_level0"].azurerm_container_group.acg: Still creating... [1m50s elapsed]
module.caf.module.container_groups["rover_level0"].azurerm_container_group.acg: Still creating... [2m0s elapsed]
module.caf.module.container_groups["rover_level0"].azurerm_container_group.acg: Still creating... [2m10s elapsed]
module.caf.module.container_groups["rover_level0"].azurerm_container_group.acg: Creation complete after 2m12s [id=/subscriptions/XYZ/resourceGroups/rg-devops-agents/providers/Microsoft.ContainerInstance/containerGroups/ci-rover-level0-test-001]`


`container_groups = {
  rover_level0 = {
    name               = "ci-rover-level0-001"
    region             = "region1"
    resource_group_key = "rg1"
    ip_address_type    = "Private"
    network = {
      subnets = {
        subnet1 = {
          vnet_key   = "devops_region1"
          subnet_key = "release_agent_level0"
        }
      }
    }

    os_type        = "Linux"
    restart_policy = "Always" // Possible values are 'Always'(default) 'Never' 'OnFailure'

    containers = {
      rover = {
        name   = "aztfmod-rover"
        image  = "rangerrom1.azurecr.io/rover-agent:1.5.6-2309.0507-azdo"
        cpu    = "1"
        memory = "1"

        ports = {
          22 = {
            port     = 22
            protocol = "TCP"
          }
        }

        environment_variables = {
          ARM_USE_MSI               = true
          AGENT_KEYVAULT_SECRET     = "azdo-pat-agent" #secret name for the pat
          VSTS_AGENT_INPUT_AGENT    = "rover-agent"    #non random agent name
          VSTS_AGENT_INPUT_POOL     = "caf-level0"
          VSTS_AGENT_INPUT_URL      = "https://rangerrom.visualstudio.com/"
          VSTS_AGENT_INPUT_AUTH     = "pat"
          VSTS_AGENT_INPUT_RUN_ARGS = "--once"
        }

        environment_variables_from_resources = {
          AGENT_KEYVAULT_NAME = {
            output_key    = "keyvaults"
            resource_key  = "level0"
            attribute_key = "name"
          }
          MSI_ID = {
            output_key    = "managed_identities"
            resource_key  = "level0"
            attribute_key = "id"
          }
        }
      }

    } //containers


    identity = {
      type = "UserAssigned"

      remote = {
        launchpad = {
          managed_identity_keys = [
            "level0",
          ]
        }
      }
    }

    image_registry_credentials = {
      acr1 = { # To be able to pull container from private repo
        user_assigned_identity_key = "level0"
        server                     = "rangerrom.azurecr.io"
      }

    }
  }
  }`
