### PR TITLE
APIM - use existing pip

### DIFF
--- a/.github/workflows/standalone-scenarios-longrunners.json
+++ b/.github/workflows/standalone-scenarios-longrunners.json
@@ -17,6 +17,7 @@
     "apim/115-api_management_private_virtual_network",
     "apim/116-api_management_subscription",
     "apim/117-api_management_product",
+    "apim/118-api_management_platform_stv2",
     "app_gateway/301-agw-v1",
     "compute/vmware_cluster/101-vmware_cluster",
     "networking/virtual_network_gateway/100-expressroute-gateway",

--- a/api_management.tf
+++ b/api_management.tf
@@ -7,6 +7,7 @@ module "api_management" {
   settings        = each.value
 
   vnets               = local.combined_objects_networking
+  public_ip_addresses = local.combined_objects_public_ip_addresses
   base_tags           = local.global_settings.inherit_tags
   resource_group      = local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group_key, each.value.resource_group.key)]
   resource_group_name = can(each.value.resource_group.name) || can(each.value.resource_group_name) ? try(each.value.resource_group.name, each.value.resource_group_name) : null

--- a/examples/apim/118-api_management_platform_stv2/configuration.tfvars
+++ b/examples/apim/118-api_management_platform_stv2/configuration.tfvars
@@ -1,0 +1,200 @@
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "uksouth"
+  }
+  inherit_tags = true
+  tags = {
+    example = "apim/118-stv2.*"
+  }
+}
+
+resource_groups = {
+  rg_example_apim_uks = {
+    name   = "example-apim-uks" # prefix-rg-example-apim-uks
+    region = "region1"
+    tags = {
+      level = "level3"
+    }
+  }
+}
+
+vnets = {
+  # Example vNet 
+  vnet_example_uks = {
+    resource_group_key = "rg_example_apim_uks"
+    region             = "region1"
+    vnet = {
+      name          = "example-uks" # prefix-vnet-example-uks
+      address_space = [""] 
+    }
+    subnets = {
+      
+      # Example subnet for APIM private endpoint
+      
+      snet_example_apim_uks = {
+        name            = "example-apim-uks" #prefix-snet-example-apim-uks
+        cidr            = [""]
+        nsg_key         = "nsg_example_apim_uks"
+      # route_table_key = ""
+        service_endpoints = ["Microsoft.KeyVault", "Microsoft.Storage", "Microsoft.Sql", "Microsoft.EventHub", "Microsoft.ServiceBus"] # service endpoints required for APIM
+      }
+    }  
+  }
+}
+
+network_security_group_definition = {
+  # This entry is applied to all subnets with no NSG defined
+  empty_nsg_no_log = {}
+
+  # Example NSG for APIM 
+  nsg_example_apim_uks = {
+    name               = "example-apim-uks" # prefix-nsg-example-apim-uks
+    version            = 1
+    flow_logs = {
+    resource_group_key = "rg_example_apim_uks" 
+      name    = "example-apim-uks" # example-apim-uks
+      version = 2
+      enabled = true
+      storage_account = {
+        storage_account_destination = "all_regions"
+        retention = {
+          enabled = true
+          days    = 30
+        }
+      }
+      traffic_analytics = {
+        enabled                             = true
+        log_analytics_workspace_destination = "central_logs"
+        workspace_region                    = "uksouth"
+        interval_in_minutes                 = "10"
+      }
+    }
+    # Baseline APIM rules come from Microsoft documentation - https://learn.microsoft.com/en-us/azure/api-management/api-management-using-with-internal-vnet?tabs=stv2#configure-nsg-rules
+    nsg = [
+      {
+        name                       = "Inbound-ApiManagement",
+        priority                   = "1000"
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "3443"
+        source_address_prefix      = "ApiManagement"
+        destination_address_prefix = "VirtualNetwork"
+      },
+      {
+        name                       = "Inbound-AzureLoadBalancer",
+        priority                   = "1010"
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "6390"
+        source_address_prefix      = "AzureLoadBalancer"
+        destination_address_prefix = "VirtualNetwork"
+      },
+      {
+        name                       = "Outbound-Storage",
+        priority                   = "1000"
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "443"
+        source_address_prefix      = "VirtualNetwork"
+        destination_address_prefix = "Storage"
+      },
+      {
+        name                       = "Outbound-SQL",
+        priority                   = "1010"
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "1443"
+        source_address_prefix      = "VirtualNetwork"
+        destination_address_prefix = "SQL"
+      },
+      {
+        name                       = "Outbound-AzureKeyVault",
+        priority                   = "1020"
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "443"
+        source_address_prefix      = "VirtualNetwork"
+        destination_address_prefix = "AzureKeyVault"
+      },
+      {
+        name                       = "Outbound-AzureMonitor",
+        priority                   = "1030"
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_ranges    = ["443", "1886"]
+        source_address_prefix      = "VirtualNetwork"
+        destination_address_prefix = "AzureMonitor"
+      },
+    ]
+  }
+}
+
+public_ip_addresses = {
+
+  # Public IP for the example APIM Instance
+  pip_apim_uks = {
+    name               = "example-apim-uks" # prefix-pip-example-apim-uks
+    region             = "region1"
+    resource_group_key = "rg_example_apim_uks"
+    sku                = "Standard" # must be 'Standard' SKU
+
+    # Standard SKU Public IP Addresses that do not specify a zone are zone redundant by default.
+    allocation_method       = "Static"
+    ip_version              = "IPv4"
+    idle_timeout_in_minutes = "4"
+    domain_name_label       = "example-apim-uks"
+  }
+}
+
+api_management = {
+  apim_uks = {
+    name                 = "example-uks" # prefix-apim-example-uks
+    resource_group_key   = "rg_example_apim_uks "
+    publisher_name       = "apim.example.sre.com"
+    publisher_email      = "example.apim@sre.com"
+    sku_name             = "Developer_1" # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management#sku_name
+    region               = "region1"
+
+    # Required to deploy APIM on platform verions stv2.*
+    public_ip = {       
+      key     = "pip_apim_uks"
+     # lz_key = ""
+    }  
+
+    virtual_network_type = "Internal" # The type of virtual network you want to use, valid values include: None, External, Internal. Defaults to None.
+    virtual_network_configuration = {
+      vnet_key   = "vnet_example_uks"
+      subnet_key = "snet_example_apim_uks"
+    # lz_key     = ""
+    }
+
+    identity = {
+      type                  = "UserAssigned"
+      managed_identity_keys = ["msi_apim_uks"]
+    }
+    
+    portal = {
+      host_name = "example.apim.com"
+    }
+  }
+}
+
+managed_identities = {
+  msi_apim_uks = {
+    name               = "example-apim-uks" # prefix-msi-example-apim-uks
+    resource_group_key = "rg_dev_apim_uks"
+  }
+}

--- a/modules/apim/api_management/module.tf
+++ b/modules/apim/api_management/module.tf
@@ -16,6 +16,12 @@ resource "azurerm_api_management" "apim" {
   publisher_name      = var.settings.publisher_name
   publisher_email     = var.settings.publisher_email
   sku_name            = var.settings.sku_name
+
+  public_ip_address_id  = try(coalesce(
+        try(var.public_ip_addresses[var.client_config.landingzone_key][var.settings.public_ip.key].id, var.public_ip_addresses[var.settings.public_ip.lz_key][var.settings.public_ip.key].id, null),
+        try(var.settings.public_ip_id, null)
+  ), null)
+  
   dynamic "additional_location" {
     for_each = try(var.settings.additional_location, null) != null ? [var.settings.additional_location] : []
 

--- a/modules/apim/api_management/variables.tf
+++ b/modules/apim/api_management/variables.tf
@@ -29,3 +29,6 @@ variable "base_tags" {
   description = "Base tags for the resource to be inherited from the resource group."
   type        = bool
 }
+variable "public_ip_addresses" {
+  default = {}
+}


### PR DESCRIPTION
## PR Checklist

- [x] I have added example(s) inside the [./examples/] folder
- [x] I have added the example(s) to the integration test list for [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change? PR [1788](https://github.com/aztfmod/terraform-azurerm-caf/pull/1788) is still open as requested changes (Oct 2nd 2023) haven't been completed.

## Description

APIM does not currently support using an existing Public IP, which is required for deployment/upgrade of the APIM Platform to version stv2.*.   stv1 is going EOL 2025.  This PR adds support for using a Public IP in the APIM module.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

## Testing

Run example  examples/apim/118-api_management_platform_stv2/configuration.tfvars
I was able to successfully deploy it in my testing.