### PR TITLE
Adding FMT on push

### DIFF
--- a/.github/workflows/on_push_fmt.yaml
+++ b/.github/workflows/on_push_fmt.yaml
@@ -12,12 +12,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Important: This is needed to push changes back to the repository
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v3
 
       - name: Terraform Format
         run: terraform fmt -recursive
@@ -29,6 +29,6 @@ jobs:
           git diff --quiet && git diff --staged --quiet || (git add -A && git commit -m "Apply terraform fmt")
       
       - name: Push changes
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@v0.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on_push_fmt.yaml
+++ b/.github/workflows/on_push_fmt.yaml
@@ -1,0 +1,34 @@
+name: Terraform Format
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  terraform:
+    name: 'Terraform Format'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Important: This is needed to push changes back to the repository
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+
+      - name: Terraform Format
+        run: terraform fmt -recursive
+
+      - name: Commit changes
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git diff --quiet && git diff --staged --quiet || (git add -A && git commit -m "Apply terraform fmt")
+      
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary 

This pull request introduces a new GitHub workflow in the `.github/workflows/on_push_fmt.yaml` file. The workflow, named `Terraform Format`, is triggered on push events to the `main` branch. It sets up a job that checks out the code, sets up Terraform, applies the `terraform fmt -recursive` command to format the Terraform code, commits any changes resulting from the formatting, and finally pushes these changes back to the repository.