### PR TITLE
Upgrade to TF 1.8.4

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,7 +6,7 @@
   version: '3.7'
   services:
     rover:
-      image: aztfmod/rover:1.7.5-2405.0203
+      image: aztfmod/rover:1.8.4-2405.2306
       user: vscode
 
       labels:

--- a/.github/workflows/landingzone-scenarios.yaml
+++ b/.github/workflows/landingzone-scenarios.yaml
@@ -86,7 +86,7 @@ jobs:
     needs: [job]
 
     container:
-      image: aztfmod/rover:1.7.5-2405.0203
+      image: aztfmod/rover:1.8.4-2405.2306
       options: --user 0
 
     steps:

--- a/.github/workflows/rover.yaml
+++ b/.github/workflows/rover.yaml
@@ -46,7 +46,7 @@ jobs:
     needs: rover_setup
 
     container:
-      image: aztfmod/rover:1.7.5-2405.0203
+      image: aztfmod/rover:1.8.4-2405.2306
       options: --user 0
 
     env:

--- a/.github/workflows/standalone-compute.yaml
+++ b/.github/workflows/standalone-compute.yaml
@@ -46,7 +46,7 @@ jobs:
       matrix: ${{fromJSON(needs.load_scenarios.outputs.matrix)}}
 
     container:
-      image: aztfmod/rover:1.7.5-2405.0203
+      image: aztfmod/rover:1.8.4-2405.2306
       options: --user 0
 
     steps:
@@ -131,7 +131,7 @@ jobs:
     needs: [testcases]
 
     container:
-      image: aztfmod/rover:1.7.5-2405.0203
+      image: aztfmod/rover:1.8.4-2405.2306
       options: --user 0
 
     steps:

--- a/.github/workflows/standalone-networking.yaml
+++ b/.github/workflows/standalone-networking.yaml
@@ -46,7 +46,7 @@ jobs:
       matrix: ${{fromJSON(needs.load_scenarios.outputs.matrix)}}
 
     container:
-      image: aztfmod/rover:1.7.5-2405.0203
+      image: aztfmod/rover:1.8.4-2405.2306
       options: --user 0
 
     steps:

--- a/.github/workflows/standalone-regressor-tf100.yaml
+++ b/.github/workflows/standalone-regressor-tf100.yaml
@@ -58,7 +58,7 @@ jobs:
       matrix: ${{fromJSON(needs.load_scenarios.outputs.matrix)}}
 
     container:
-      image: aztfmod/rover:1.7.5-2405.0203
+      image: aztfmod/rover:1.8.4-2405.2306
       options: --user 0
 
     steps:
@@ -178,7 +178,7 @@ jobs:
     needs: [testcases]
 
     container:
-      image: aztfmod/rover:1.7.5-2405.0203
+      image: aztfmod/rover:1.8.4-2405.2306
       options: --user 0
 
     steps:

--- a/.github/workflows/standalone-tf100.yaml
+++ b/.github/workflows/standalone-tf100.yaml
@@ -55,7 +55,7 @@ jobs:
       matrix: ${{fromJSON(needs.load_scenarios.outputs.matrix)}}
 
     container:
-      image: aztfmod/rover:1.7.5-2405.0203
+      image: aztfmod/rover:1.8.4-2405.2306
       options: --user 0
 
     steps:
@@ -140,7 +140,7 @@ jobs:
     needs: [testcases]
 
     container:
-      image: aztfmod/rover:1.7.5-2405.0203
+      image: aztfmod/rover:1.8.4-2405.2306
       options: --user 0
 
     steps:


### PR DESCRIPTION
This pull request primarily updates the version of the `aztfmod/rover` Docker image used across multiple files in the project. The version is updated from `1.7.5-2405.0203` to `1.8.4-2405.2306`. This change affects the project's development environment setup and the execution environment for various GitHub workflows.

Expected improvement: Terraform 1.8.4 performance improvement at ```plan``` time. 