### PR TITLE
Adding dependabot configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,19 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/.github/workflows" # Location of package manifests
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "devcontainers" # See documentation for possible values
+    directory: "/.devcontainer" # Location of package manifests
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "terraform" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This pull request includes the addition of a `dependabot.yaml` configuration file in the `.github` directory. This file specifies that Dependabot should check for updates to the GitHub Actions, devcontainers, and Terraform package ecosystems on a weekly basis. 

* [`.github/dependabot.yaml`](diffhunk://#diff-ee0c08340ace9ac3ce3c78e2377968bca2376b8bfd9a7a48d96515f5490a902cR1-R19): Added a new configuration file for Dependabot. This file instructs Dependabot to check for updates in the "github-actions", "devcontainers", and "terraform" package ecosystems weekly.