### PR TITLE
feat(management-locks): adding prototype for management locks module

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -470,4 +470,6 @@ locals {
 
 
   load_test = try(var.load_test, {})
+
+  azurerm_management_locks = try(var.azurerm_management_locks, {})
 }

--- a/management_locks.tf
+++ b/management_locks.tf
@@ -1,0 +1,32 @@
+locals {
+  lockable_resource_types = distinct([ for lock, config in local.azurerm_management_locks:
+    config.resource_type
+  ])
+  lockable_resources = merge( # T
+    contains(local.lockable_resource_types, "storage_accounts") ? { "storage_accounts" = local.combined_objects_storage_accounts} : {},
+    contains(local.lockable_resource_types, "resource_groups") ? { "resource_groups" = local.combined_objects_resource_groups} : {}
+  )
+  lock_info = { for lock, config in local.azurerm_management_locks:
+    lock => {
+      scope = try(config.resource_id, local.lockable_resources[config.resource_type][try(config.resource_lz_key, local.client_config.landingzone_key)][config.resource_key].id)
+    }
+  }
+}
+
+resource "azurerm_management_lock" "lock" {
+  for_each = local.azurerm_management_locks
+  name       = each.value.name
+  scope      = local.lock_info[each.key].scope
+  lock_level = each.value.lock_level
+  notes      = each.value.notes
+}
+
+output "lockable_resource_types" {
+  value = local.lockable_resource_types
+}
+output "lockable_resources" {
+  value = local.lockable_resources
+}
+output "lock_info" {
+  value = local.lock_info
+}

--- a/variables.tf
+++ b/variables.tf
@@ -450,3 +450,8 @@ variable "load_test" {
   default     = {}
 }
 
+
+
+variable "azurerm_management_locks" {
+  default = {}
+}


### PR DESCRIPTION
# [1995](https://github.com/aztfmod/terraform-azurerm-caf/issues/1995)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description
This is a prototype for the resource lock module. I struggled to find a way to implement it as an independent resource, as it could apply to any kind of resource.
I would love to hear your feedback on this approach.

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
```
azurerm_management_locks = {

  lock_2 = {
    name = "lock2"
    resource_type = "storage_accounts"
    resource_key = "testing_sa"
    #resource_lz_key = ""
    #resource_id = ""
    lock_level = "CanNotDelete" #ReadOnly
    notes = "room for notes"
  }
}
```