### PR TITLE
Add storage defender support

### DIFF
--- a/.github/workflows/standalone-scenarios.json
+++ b/.github/workflows/standalone-scenarios.json
@@ -119,6 +119,7 @@
     "storage_accounts/107-storage-account-management-policy",
     "storage_accounts/109-storage-account-advanced-options-cmk",
     "storage_accounts/110-file-share-with-acl",
+    "storage_accounts/112-storage-account-with-defender",
     "storage_container/101-storage_container",
     "synapse_analytics/100-synapse",
     "synapse_analytics/101-synapse-sparkpool",

--- a/examples/storage_accounts/112-storage-account-with-defender/configuration.tfvars
+++ b/examples/storage_accounts/112-storage-account-with-defender/configuration.tfvars
@@ -1,0 +1,49 @@
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "australiaeast"
+  }
+}
+
+resource_groups = {
+  test = {
+    name = "storage-account-defender"
+  }
+}
+
+# https://docs.microsoft.com/en-us/azure/storage/
+storage_accounts = {
+  sa1 = {
+    name = "sa1dev"
+    # This option is to enable remote RG reference
+    # resource_group = {
+    #   lz_key = ""
+    #   key    = ""
+    # }
+
+    resource_group_key = "test"
+    # Account types are BlobStorage, BlockBlobStorage, FileStorage, Storage and StorageV2. Defaults to StorageV2
+    account_kind = "BlobStorage"
+    # Account Tier options are Standard and Premium. For BlockBlobStorage and FileStorage accounts only Premium is valid.
+    account_tier = "Standard"
+    #  Valid options are LRS, GRS, RAGRS, ZRS, GZRS and RAGZRS
+    account_replication_type = "LRS" # https://docs.microsoft.com/en-us/azure/storage/common/storage-redundancy
+    tags = {
+      environment = "dev"
+      team        = "IT"
+      ##
+    }
+    containers = {
+      dev = {
+        name = "random"
+      }
+    }
+
+    defender = {
+      override_subscription_settings              = true
+      malware_scanning_on_upload                  = true
+      malware_scanning_on_upload_cap_gb_per_month = 10
+      sensitive_data_discovery_enabled            = false
+    }
+  }
+}

--- a/modules/storage_account/storage_defender.tf
+++ b/modules/storage_account/storage_defender.tf
@@ -3,7 +3,7 @@ resource "azurerm_security_center_storage_defender" "defender" {
 
   storage_account_id                          = azurerm_storage_account.stg.id
   override_subscription_settings_enabled      = try(var.storage_account.defender.override_subscription_settings, null)
-  malware_scanning_on_upload_enabled          = try(var.storage_account.defender.malware_scanning_on_upload, false)
+  malware_scanning_on_upload_enabled          = try(var.storage_account.defender.malware_scanning_on_upload, null)
   malware_scanning_on_upload_cap_gb_per_month = try(var.storage_account.defender.malware_scanning_on_upload_cap_gb_per_month, -1)
   sensitive_data_discovery_enabled            = try(var.storage_account.defender.sensitive_data_discovery_enabled, false)
 }

--- a/modules/storage_account/storage_defender.tf
+++ b/modules/storage_account/storage_defender.tf
@@ -4,6 +4,6 @@ resource "azurerm_security_center_storage_defender" "defender" {
   storage_account_id                          = azurerm_storage_account.stg.id
   override_subscription_settings_enabled      = try(var.storage_account.defender.override_subscription_settings, null)
   malware_scanning_on_upload_enabled          = try(var.storage_account.defender.malware_scanning_on_upload, null)
-  malware_scanning_on_upload_cap_gb_per_month = try(var.storage_account.defender.malware_scanning_on_upload_cap_gb_per_month, -1)
+  malware_scanning_on_upload_cap_gb_per_month = try(var.storage_account.defender.malware_scanning_on_upload_cap_gb_per_month, null)
   sensitive_data_discovery_enabled            = try(var.storage_account.defender.sensitive_data_discovery_enabled, false)
 }

--- a/modules/storage_account/storage_defender.tf
+++ b/modules/storage_account/storage_defender.tf
@@ -5,5 +5,5 @@ resource "azurerm_security_center_storage_defender" "defender" {
   override_subscription_settings_enabled      = try(var.storage_account.defender.override_subscription_settings, null)
   malware_scanning_on_upload_enabled          = try(var.storage_account.defender.malware_scanning_on_upload, null)
   malware_scanning_on_upload_cap_gb_per_month = try(var.storage_account.defender.malware_scanning_on_upload_cap_gb_per_month, null)
-  sensitive_data_discovery_enabled            = try(var.storage_account.defender.sensitive_data_discovery_enabled, false)
+  sensitive_data_discovery_enabled            = try(var.storage_account.defender.sensitive_data_discovery_enabled, null)
 }

--- a/modules/storage_account/storage_defender.tf
+++ b/modules/storage_account/storage_defender.tf
@@ -2,7 +2,7 @@ resource "azurerm_security_center_storage_defender" "defender" {
   count = can(var.storage_account.defender) ? 1 : 0
 
   storage_account_id                          = azurerm_storage_account.stg.id
-  override_subscription_settings_enabled      = try(var.storage_account.defender.override_subscription_settings, false)
+  override_subscription_settings_enabled      = try(var.storage_account.defender.override_subscription_settings, null)
   malware_scanning_on_upload_enabled          = try(var.storage_account.defender.malware_scanning_on_upload, false)
   malware_scanning_on_upload_cap_gb_per_month = try(var.storage_account.defender.malware_scanning_on_upload_cap_gb_per_month, -1)
   sensitive_data_discovery_enabled            = try(var.storage_account.defender.sensitive_data_discovery_enabled, false)

--- a/modules/storage_account/storage_defender.tf
+++ b/modules/storage_account/storage_defender.tf
@@ -1,0 +1,9 @@
+resource "azurerm_security_center_storage_defender" "defender" {
+  count = can(var.storage_account.defender) ? 1 : 0
+
+  storage_account_id                          = azurerm_storage_account.stg.id
+  override_subscription_settings_enabled      = try(var.storage_account.defender.override_subscription_settings, false)
+  malware_scanning_on_upload_enabled          = try(var.storage_account.defender.malware_scanning_on_upload, false)
+  malware_scanning_on_upload_cap_gb_per_month = try(var.storage_account.defender.malware_scanning_on_upload_cap_gb_per_month, -1)
+  sensitive_data_discovery_enabled            = try(var.storage_account.defender.sensitive_data_discovery_enabled, false)
+}


### PR DESCRIPTION
## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Add support for enabling Defender for Storage on a storage account.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
