### PR TITLE
fix: inconsistent types in conditional

### DIFF
--- a/modules/messaging/web_pubsub/private_endpoint.tf
+++ b/modules/messaging/web_pubsub/private_endpoint.tf
@@ -8,7 +8,7 @@ module "private_endpoint" {
   global_settings = var.global_settings
   location        = local.location
   name            = each.value.name
-  private_dns     = can(each.value.private_dns) ? var.remote_objects.private_dns : {}
+  private_dns     = var.remote_objects.private_dns
   resource_groups = var.remote_objects.resource_groups
   resource_id     = azurerm_web_pubsub.wps.id
   settings        = each.value


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

We are getting following error message when using private endpoints with webpubsub:

2024/07/29 06:57:53 Error: Inconsistent conditional result types 2024/07/29 06:57:53
2024/07/29 06:57:53   on /home/AzDevOps_azpcontainer/.terraform/modules/stage2/modules/messaging/web_pubsub/private_endpoint.tf line 11, in module "private_endpoint":
2024/07/29 06:57:53   11:   private_dns     = can(each.value.private_dns) ? var.remote_objects.private_dns : {}
2024/07/29 06:57:53     ├────────────────
2024/07/29 06:57:53     │ each.value.private_dns is object with 2 attributes
2024/07/29 06:57:53     │ var.remote_objects.private_dns is object with 5 attributes
2024/07/29 06:57:53
2024/07/29 06:57:53 The true and false result expressions must have consistent types. The 'true'
2024/07/29 06:57:53 value includes object attribute "devops", which is absent in the 'false'

We don't need the condition here, as the private_dns variable will only act as a resource reference and the decision making will be done by the var.settings.private_dns parameter

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
