### PR TITLE
AKS: Fix default nodepool upgrade settings

### DIFF
--- a/modules/compute/aks/aks.tf
+++ b/modules/compute/aks/aks.tf
@@ -77,7 +77,9 @@ resource "azurerm_kubernetes_cluster" "aks" {
     dynamic "upgrade_settings" {
       for_each = try(var.settings.default_node_pool.upgrade_settings, null) == null ? [] : [1]
       content {
-        max_surge = upgrade_settings.value.max_surge
+        drain_timeout_in_minutes      = try(var.settings.default_node_pool.upgrade_settings.drain_timeout_in_minutes, null)
+        node_soak_duration_in_minutes = try(var.settings.default_node_pool.upgrade_settings.node_soak_duration_in_minutes, null)
+        max_surge                     = var.settings.default_node_pool.upgrade_settings.max_surge
       }
     }
 


### PR DESCRIPTION
# [2068](https://github.com/aztfmod/terraform-azurerm-caf/issues/2068)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

The current module has a bug if values for `upgrade_settings` are set

```
│ Error: Unsupported attribute
│ 
│   on .terraform/modules/caf/modules/compute/aks/aks.tf line 80, in resource "azurerm_kubernetes_cluster" "aks":
│   80:         max_surge = upgrade_settings.value.max_surge
│     ├────────────────
│     │ upgrade_settings.value is 1
│ 
│ Can't access attributes on a primitive-typed value (number).
```

I'm also adding the optional settings in the [upgrade_settings](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster#max_surge) block


## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
