### PR TITLE
added backup in azurerm_cosmosdb_account

### DIFF
--- a/modules/databases/cosmos_dbs/cosmosdb_account.tf
+++ b/modules/databases/cosmos_dbs/cosmosdb_account.tf
@@ -56,6 +56,19 @@ resource "azurerm_cosmosdb_account" "cosmos_account" {
       name = capabilities.value
     }
   }
+
+  dynamic "backup" {
+    for_each = try(var.settings.backup, null) != null ? [var.settings.backup] : []
+
+    content {
+      type                = backup.value.type
+      tier                = try(backup.value.tier, null)
+      interval_in_minutes = try(backup.value.interval_in_minutes, null)
+      retention_in_hours  = try(backup.value.retention_in_hours, null)
+      storage_redundancy  = try(backup.value.storage_redundancy, null)
+    }
+  }
+
   dynamic "restore" {
     for_each = try(var.settings.restore, null) != null ? [var.settings.restore] : []
     content {
@@ -71,5 +84,3 @@ resource "azurerm_cosmosdb_account" "cosmos_account" {
     }
   }
 }
-
-


### PR DESCRIPTION
# [2074](https://github.com/aztfmod/terraform-azurerm-caf/issues/2074)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description
This pull request includes changes to the `modules/databases/cosmos_dbs/cosmosdb_account.tf` file to add dynamic backup configurations for Cosmos DB accounts.

Key changes:

* Added a dynamic block for `backup` configurations in the `azurerm_cosmosdb_account` resource. This block includes parameters such as `type`, `tier`, `interval_in_minutes`, `retention_in_hours`, and `storage_redundancy`, which are conditionally set based on the `var.settings.backup` variable.
* Removed unnecessary blank lines at the end of the `azurerm_cosmosdb_account` resource definition.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
