### PR TITLE
fix: duplicate lz key reference

### DIFF
--- a/modules/monitoring/monitor_activity_log_alert/module.tf
+++ b/modules/monitoring/monitor_activity_log_alert/module.tf
@@ -13,7 +13,7 @@ resource "azurerm_monitor_activity_log_alert" "mala" {
   resource_group_name = var.resource_group_name
   scopes = try(flatten([
     for key, value in var.settings.scopes : coalesce(
-      try(var.remote_objects[value.resource_type][value.lz_key][value.lz_key][value.key].id, null),
+      try(var.remote_objects[value.resource_type][value.lz_key][value.key].id, null),
       try(var.remote_objects[value.resource_type][var.client_config.landingzone_key][value.key].id, null),
       try(value.id, null),
       []
@@ -28,7 +28,7 @@ resource "azurerm_monitor_activity_log_alert" "mala" {
       resource_type     = try(criteria.value.resource_type, null)
       resource_group    = try(criteria.value.resource_group, null)
       resource_id = try(
-        var.remote_objects[criteria.value.resource.resource_type][criteria.value.resource.lz_key][criteria.value.resource.lz_key][criteria.value.resource.key].id,
+        var.remote_objects[criteria.value.resource.resource_type][criteria.value.resource.lz_key][criteria.value.resource.key].id,
         var.remote_objects[criteria.value.resource.resource_type][var.client_config.landingzone_key][criteria.value.resource.key].id,
         criteria.value.resource.id,
         null


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

monitor_activity_log_alert resource definition has duplicate lz_key in the resource references.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
