### PR TITLE
fix: cosmos db role definition reference

### DIFF
--- a/cosmos_db_roles.tf
+++ b/cosmos_db_roles.tf
@@ -57,7 +57,7 @@ resource "azurerm_cosmosdb_sql_role_assignment" "cosmos_account" {
         try(each.value.resource_group.name, each.value.resource_group_name) :
         local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group_key, each.value.resource_group.key)].name
       ),
-      local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group_key, each.value.resource_group.key)].name,
+      local.combined_objects_cosmos_dbs[try(each.value.account.lz_key, local.client_config.landingzone_key)][try(each.value.account_key, each.value.account.key)].name,
       local.cosmosdb_built_in_roles[lower(each.value.role_definition_name)]
     )
   )
@@ -93,7 +93,7 @@ resource "azurerm_cosmosdb_sql_role_assignment" "cosmos_sql_database" {
         try(each.value.resource_group.name, each.value.resource_group_name) :
         local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group_key, each.value.resource_group.key)].name
       ),
-      local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group_key, each.value.resource_group.key)].name,
+      local.combined_objects_cosmos_dbs[try(each.value.account.lz_key, local.client_config.landingzone_key)][try(each.value.account_key, each.value.account.key)].name,
       local.cosmosdb_built_in_roles[lower(each.value.role_definition_name)]
     )
   )
@@ -129,7 +129,7 @@ resource "azurerm_cosmosdb_sql_role_assignment" "cosmos_sql_container" {
         try(each.value.resource_group.name, each.value.resource_group_name) :
         local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group_key, each.value.resource_group.key)].name
       ),
-      local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group_key, each.value.resource_group.key)].name,
+      local.combined_objects_cosmos_dbs[try(each.value.account.lz_key, local.client_config.landingzone_key)][try(each.value.account_key, each.value.account.key)].name,
       local.cosmosdb_built_in_roles[lower(each.value.role_definition_name)]
     )
   )


### PR DESCRIPTION
## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

cosmos db role definition is incorrectly referring to resource group id instead of cosmos db id

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
