### PR TITLE
FIX: Missing Parameters in Function App result in failed execution

### DIFF
--- a/modules/webapps/function_app/module.tf
+++ b/modules/webapps/function_app/module.tf
@@ -150,7 +150,11 @@ resource "azurerm_function_app" "function_app" {
 
         content {
           ip_address                = lookup(ip_restriction.value, "ip_address", null)
+          service_tag               = lookup(scm_ip_restriction.value, "service_tag", null)
           virtual_network_subnet_id = lookup(ip_restriction.value, "virtual_network_subnet_id", null)
+          name                      = lookup(scm_ip_restriction.value, "name", null)
+          priority                  = lookup(scm_ip_restriction.value, "priority", null)
+          action                    = lookup(scm_ip_restriction.value, "action", null)
         }
       }
       dynamic "scm_ip_restriction" {


### PR DESCRIPTION
## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->
There is currently configurations missing for IP Restriction rules that exist for the SCM IP Restriction Rules, as a result we see an error that gets thrown via Terraform and an apply cannot be done.

```
2025-02-14T15:45:13.5562971Z Error: expanding `site_config` for Function App "APP" (Resource Group "rg"): one of `ip_address`, `service_tag` or `virtual_network_subnet_id` must be set for an IP restriction
2025-02-14T15:45:13.5563279Z 
2025-02-14T15:45:13.5563615Z   with module.caf.module.function_apps["APP"].azurerm_function_app.function_app,
2025-02-14T15:45:13.5564133Z   on .terraform/modules/caf/modules/webapps/function_app/module.tf line 12, in resource "azurerm_function_app" "function_app":
2025-02-14T15:45:13.5564754Z   12: resource "azurerm_function_app" "function_app" {
```

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
