### PR TITLE
Add private link access to storage account network rules

### DIFF
--- a/modules/storage_account/storage_account.tf
+++ b/modules/storage_account/storage_account.tf
@@ -176,6 +176,14 @@ resource "azurerm_storage_account" "stg" {
       virtual_network_subnet_ids = try(var.storage_account.network.subnets, null) == null ? null : [
         for key, value in var.storage_account.network.subnets : can(value.remote_subnet_id) ? value.remote_subnet_id : var.vnets[try(value.lz_key, var.client_config.landingzone_key)][value.vnet_key].subnets[value.subnet_key].id
       ]
+      dynamic "private_link_access" {
+        for_each = lookup(var.storage_account.network, "private_link_access", false) == false ? [] : [1]
+
+        content {
+          endpoint_resource_id = var.storage_account.network.private_link_access.endpoint_resource_id
+          endpoint_tenant_id   = try(var.storage_account.network.private_link_access.endpoint_tenant_id, null)
+        }
+      }
     }
   }
 

--- a/modules/storage_account/storage_account.tf
+++ b/modules/storage_account/storage_account.tf
@@ -177,11 +177,12 @@ resource "azurerm_storage_account" "stg" {
         for key, value in var.storage_account.network.subnets : can(value.remote_subnet_id) ? value.remote_subnet_id : var.vnets[try(value.lz_key, var.client_config.landingzone_key)][value.vnet_key].subnets[value.subnet_key].id
       ]
       dynamic "private_link_access" {
-        for_each = lookup(var.storage_account.network, "private_link_access", false) == false ? [] : [1]
+        iterator = private_link_access
+        for_each = lookup(var.storage_account.network, "private_link_access", null) == null ? {} : var.storage_account.network.private_link_access
 
         content {
-          endpoint_resource_id = each.value.endpoint_resource_id
-          endpoint_tenant_id   = try(each.value.endpoint_tenant_id, null)
+          endpoint_resource_id = private_link_access.value.endpoint_resource_id
+          endpoint_tenant_id   = try(private_link_access.value.endpoint_tenant_id, null)
         }
       }
     }

--- a/modules/storage_account/storage_account.tf
+++ b/modules/storage_account/storage_account.tf
@@ -180,8 +180,8 @@ resource "azurerm_storage_account" "stg" {
         for_each = lookup(var.storage_account.network, "private_link_access", false) == false ? [] : [1]
 
         content {
-          endpoint_resource_id = var.storage_account.network.private_link_access.endpoint_resource_id
-          endpoint_tenant_id   = try(var.storage_account.network.private_link_access.endpoint_tenant_id, null)
+          endpoint_resource_id = each.value.endpoint_resource_id
+          endpoint_tenant_id   = try(each.value.endpoint_tenant_id, null)
         }
       }
     }


### PR DESCRIPTION
# [2101](https://github.com/aztfmod/terraform-azurerm-caf/issues/2101)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Add missing option [private link access](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account#private_link_access-1) to Storage Account module

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Create a Storage Account with `private_link_access`