### PR TITLE
Container App Env: added support for workload profile.Container App: made ingress/traffic_weight  parameters optional

### DIFF
--- a/examples/compute/container_app/102-simple-private-container-app-env/configuration.tfvars
+++ b/examples/compute/container_app/102-simple-private-container-app-env/configuration.tfvars
@@ -60,6 +60,12 @@ container_app_environments = {
     tags = {
       environment = "testing"
     }
+    workload_profile = {
+      name                  = "Consumption"
+      workload_profile_type = "Consumption" # Possible values include Consumption, D4, D8, D16, D32, E4, E8, E16 and E32
+      maximum_count = "3"
+      minimum_count = "1"
+    }  
   }
 }
 
@@ -68,6 +74,7 @@ container_apps = {
     name                          = "nginx-app"
     container_app_environment_key = "cae1"
     resource_group_key            = "rg1"
+    workload_profile_name = "Consumption" # Name of container_app_environments workload_profile
 
     revision_mode = "Single"
     template = {

--- a/modules/compute/container_app/container_app.tf
+++ b/modules/compute/container_app/container_app.tf
@@ -14,7 +14,8 @@ resource "azurerm_container_app" "ca" {
   container_app_environment_id = var.container_app_environment_id
   revision_mode                = var.settings.revision_mode
   tags                         = merge(local.tags, try(var.settings.tags, null))
-
+  workload_profile_name        = try(var.settings.workload_profile_name, null)
+  
   template {
     dynamic "container" {
       for_each = var.settings.template.container
@@ -214,7 +215,8 @@ resource "azurerm_container_app" "ca" {
       external_enabled           = try(ingress.value.external_enabled, null)
       fqdn                       = try(ingress.value.fqdn, null)
       target_port                = ingress.value.target_port
-      transport                  = ingress.value.transport
+      transport                  = try(ingress.value.transport, null)
+      exposed_port               = try(ingress.value.exposed_port, null)
 
       dynamic "custom_domain" {
         for_each = try(ingress.value.custom_domain, {})
@@ -230,9 +232,9 @@ resource "azurerm_container_app" "ca" {
         for_each = try(ingress.value.traffic_weight, {})
 
         content {
-          label           = traffic_weight.value.label
-          latest_revision = traffic_weight.value.latest_revision
-          revision_suffix = traffic_weight.value.revision_suffix
+          label           = try(traffic_weight.value.label, null)
+          latest_revision = try(traffic_weight.value.latest_revision, null)
+          revision_suffix = try(traffic_weight.value.revision_suffix, null)
           percentage      = traffic_weight.value.percentage
         }
       }

--- a/modules/compute/container_app_environment/container_app_environment.tf
+++ b/modules/compute/container_app_environment/container_app_environment.tf
@@ -18,4 +18,15 @@ resource "azurerm_container_app_environment" "cae" {
   internal_load_balancer_enabled              = try(var.settings.internal_load_balancer_enabled, null)
   zone_redundancy_enabled                     = try(var.settings.zone_redundancy_enabled, null)
   tags                                        = merge(local.tags, try(var.settings.tags, null))
+
+  dynamic "workload_profile" {
+    for_each = can(var.settings.workload_profile) ? [var.settings.workload_profile] : []
+
+    content {
+      name                  = var.settings.workload_profile.name
+      workload_profile_type = var.settings.workload_profile.workload_profile_type
+      maximum_count         = var.settings.workload_profile.maximum_count
+      minimum_count         = var.settings.workload_profile.minimum_count
+    }
+  }
 }


### PR DESCRIPTION
Container App Env: added support for workload profile.Container App: made ingress/traffic_weight parameters optional

# [2103](https://github.com/aztfmod/terraform-azurerm-caf/issues/2103)
# [2099](https://github.com/aztfmod/terraform-azurerm-caf/issues/2099)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing
aztfmod/rover:1.8.5-2409.0402
5.7.14
<!-- Instructions for testing and validation of your code -->
