### PR TITLE
Fix: SCM IP Restrictions being used on IP Restrictions

### DIFF
--- a/modules/webapps/function_app/module.tf
+++ b/modules/webapps/function_app/module.tf
@@ -150,11 +150,11 @@ resource "azurerm_function_app" "function_app" {
 
         content {
           ip_address                = lookup(ip_restriction.value, "ip_address", null)
-          service_tag               = lookup(scm_ip_restriction.value, "service_tag", null)
+          service_tag               = lookup(ip_restriction.value, "service_tag", null)
           virtual_network_subnet_id = lookup(ip_restriction.value, "virtual_network_subnet_id", null)
-          name                      = lookup(scm_ip_restriction.value, "name", null)
-          priority                  = lookup(scm_ip_restriction.value, "priority", null)
-          action                    = lookup(scm_ip_restriction.value, "action", null)
+          name                      = lookup(ip_restriction.value, "name", null)
+          priority                  = lookup(ip_restriction.value, "priority", null)
+          action                    = lookup(ip_restriction.value, "action", null)
         }
       }
       dynamic "scm_ip_restriction" {


### PR DESCRIPTION
This modifies the Function App Module to ensure that the lookup is using the `ip_restriction` block as opposed to the `scm_ip_restriction` block.

## PR Checklist

---

- [X] I have added example(s) inside the [./examples/] folder
- [X] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ X I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [X] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->
Ensures that IP Restrictions can be handled via TF modules

## Does this introduce a breaking change

- [ ] YES
- [X] NO